### PR TITLE
SCRIPTS: removed image extensions from shaders

### DIFF
--- a/code/tools/shadertool/shadertool.c
+++ b/code/tools/shadertool/shadertool.c
@@ -161,14 +161,14 @@ static int validateShader(const char *filename, const char *pk3dir, const char *
 
 		const char *token = COM_ParseExt(&buf);
 		if (!token[0]) {
-			return 1;
+			return 0;
 		}
 
 		Q_strncpyz(shaderName, token, sizeof(shaderName));
 
 		token = COM_ParseExt(&buf);
 		if (token[0] != '{' || token[1] != '\0') {
-			printf("WARNING: missing opening brace\n");
+			printf("%s: error missing opening brace\n", filename);
 			return 1;
 		}
 
@@ -186,6 +186,7 @@ static int validateShader(const char *filename, const char *pk3dir, const char *
 					   !strcmp(token, "q3map_lightimage") || !strcmp(token, "skyparms")) {
 				token = COM_ParseExt(&buf);
 				if (!token[0]) {
+					printf("%s: error unexpected end of shader found\n", filename);
 					return 1;
 				}
 				if (validateTexture(filename, pk3dir, token) != 0) {

--- a/code/tools/shadertool/shadertool.c
+++ b/code/tools/shadertool/shadertool.c
@@ -193,6 +193,7 @@ static int validateShader(const char *filename, const char *pk3dir, const char *
 				}
 			}
 			// TODO animMap
+			// TODO skyparms _ft _bk _rt _lf _up _dn
 
 			if (depth == 0) {
 				break;

--- a/wop/scripts.pk3dir/scripts/common.shader
+++ b/wop/scripts.pk3dir/scripts/common.shader
@@ -276,7 +276,7 @@ textures/common/woodclip		// causes footstep sounds like walking on wood
 // DONOT & NO
 // =================
 
-textures/common/donotenter		// bots are not blocked, but they avoid and try to leave those areas 
+textures/common/donotenter		// bots are not blocked, but they avoid and try to leave those areas
 {
 	qer_trans 0.50
 	surfaceparm nodraw
@@ -418,7 +418,7 @@ textures/common/hintskip		// same as skip, but name changed to allow Radiant to 
 
 textures/common/invisible		// solid and transparent polygons, which casts shadows
 {
-	surfaceparm nolightmap			
+	surfaceparm nolightmap
 	{
 		map textures/common/invisible
 		alphaFunc GE128
@@ -433,7 +433,7 @@ textures/common/mirror1			// clear mirror surface, use with misc_portal_surface 
 	surfaceparm nolightmap
 	portal
 	{
-		map textures/common/mirror1.tga
+		map textures/common/mirror1
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_ALPHA
 		depthWrite
 	}
@@ -461,7 +461,7 @@ textures/common/portal			// same as mirror1
 	surfaceparm nolightmap
 	portal
 	{
-		map textures/common/mirror1.tga
+		map textures/common/mirror1
 		tcMod turb 0 0.25 0 0.05
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_ALPHA
 		depthWrite

--- a/wop/scripts.pk3dir/scripts/pad_airplane.shader
+++ b/wop/scripts.pk3dir/scripts/pad_airplane.shader
@@ -4,10 +4,10 @@
 
 textures/pad_o4texs/ueberdenwolken
 {
-qer_editorimage textures/pad_o4texs/ueberdenwolken.jpg
+qer_editorimage textures/pad_o4texs/ueberdenwolken
 surfaceparm noimpact
 surfaceparm nolightmap
-q3map_lightimage textures/pad_o4texs/124.tga
+q3map_lightimage textures/pad_o4texs/124
 q3map_sun	0.925 0.949 1 120 60 20
 q3map_surfacelight 200
 skyparms env/ueberdenwolken - -
@@ -25,7 +25,7 @@ surfaceparm alphashadow
 cull none
 nopicmip
 	{
-	map textures/pad_o4texs/danke_erklaert_de.tga
+	map textures/pad_o4texs/danke_erklaert_de
 	blendFunc GL_ONE GL_ZERO
 	alphaFunc GE128
 	depthWrite
@@ -46,7 +46,7 @@ surfaceparm alphashadow
 cull none
 nopicmip
 	{
-	map textures/pad_o4texs/danke_noctuagraphics.tga
+	map textures/pad_o4texs/danke_noctuagraphics
 	blendFunc GL_ONE GL_ZERO
 	alphaFunc GE128
 	depthWrite
@@ -67,7 +67,7 @@ surfaceparm alphashadow
 cull none
 nopicmip
 	{
-	map textures/pad_o4texs/danke_maxmustermann.tga
+	map textures/pad_o4texs/danke_maxmustermann
 	blendFunc GL_ONE GL_ZERO
 	alphaFunc GE128
 	depthWrite
@@ -87,7 +87,7 @@ surfaceparm trans
 surfaceparm alphashadow
 nopicmip
 	{
-	map textures/pad_o4texs/gurtschlossa.tga
+	map textures/pad_o4texs/gurtschlossa
 	blendFunc GL_ONE GL_ZERO
 	alphaFunc GE128
 	depthWrite
@@ -108,7 +108,7 @@ surfaceparm alphashadow
 cull none
 nopicmip
 	{
-	map textures/pad_o4texs/gurtschlossc.tga
+	map textures/pad_o4texs/gurtschlossc
 	blendFunc GL_ONE GL_ZERO
 	alphaFunc GE128
 	depthWrite
@@ -129,7 +129,7 @@ surfaceparm alphashadow
 cull none
 nopicmip
 	{
-	map textures/pad_o4texs/sechseck.tga
+	map textures/pad_o4texs/sechseck
 	blendFunc GL_ONE GL_ZERO
 	alphaFunc GE128
 	depthWrite
@@ -151,7 +151,7 @@ surfaceparm alphashadow
 cull none
 nopicmip
 	{
-	map textures/pad_o4texs/serviette.tga
+	map textures/pad_o4texs/serviette
 	blendFunc GL_ONE GL_ZERO
 	alphaFunc GE128
 	depthWrite
@@ -171,7 +171,7 @@ nopicmip
 
 textures/pad_o4texs/neonwhite
 {
-	qer_editorimage textures/pad_o4texs/neonwhite.jpg
+	qer_editorimage textures/pad_o4texs/neonwhite
 	surfaceparm nomarks
 	surfaceparm nolightmap
 	q3map_surfacelight 3000
@@ -181,19 +181,19 @@ textures/pad_o4texs/neonwhite
 		rgbGen identity
 	}
 	{
-		map textures/pad_o4texs/neonwhite.jpg
+		map textures/pad_o4texs/neonwhite
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_o4texs/neonwhite.jpg
+		map textures/pad_o4texs/neonwhite
 		blendfunc GL_ONE GL_ONE
 	}
 }
 
 textures/pad_o4texs/warmwhite
 {
-	qer_editorimage textures/pad_o4texs/warmwhite.jpg
+	qer_editorimage textures/pad_o4texs/warmwhite
 	surfaceparm nomarks
 	surfaceparm nolightmap
 	q3map_surfacelight 2000
@@ -203,19 +203,19 @@ textures/pad_o4texs/warmwhite
 		rgbGen identity
 	}
 	{
-		map textures/pad_o4texs/warmwhite.jpg
+		map textures/pad_o4texs/warmwhite
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_o4texs/warmwhite.jpg
+		map textures/pad_o4texs/warmwhite
 		blendfunc GL_ONE GL_ONE
 	}
 }
 
 textures/pad_o4texs/redlight
 {
-	qer_editorimage textures/pad_o4texs/redlight.tga
+	qer_editorimage textures/pad_o4texs/redlight
 	surfaceparm nomarks
 	surfaceparm nolightmap
 	q3map_surfacelight 200
@@ -225,12 +225,12 @@ textures/pad_o4texs/redlight
 		rgbGen identity
 	}
 	{
-		map textures/pad_o4texs/redlight.tga
+		map textures/pad_o4texs/redlight
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_o4texs/redlight.tga
+		map textures/pad_o4texs/redlight
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -240,13 +240,13 @@ textures/pad_o4texs/redlight
 //-----------------------------------------------------------------
 textures/pad_o4texs/blinkgruen1
 {
-	qer_editorimage textures/pad_o4texs/blinkgruen.jpg
+	qer_editorimage textures/pad_o4texs/blinkgruen
 	surfaceparm trans
 	qer_trans .6
 	cull none
 	surfaceparm nomipmaps
 	{
-		map textures/pad_o4texs/blinkgruen.jpg
+		map textures/pad_o4texs/blinkgruen
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave Square 0 1 0 1.99
 	}
@@ -254,13 +254,13 @@ textures/pad_o4texs/blinkgruen1
 
 textures/pad_o4texs/blinkgruen2
 {
-	qer_editorimage textures/pad_o4texs/blinkgruen.jpg
+	qer_editorimage textures/pad_o4texs/blinkgruen
 	surfaceparm trans
 	qer_trans .6
 	cull none
 	surfaceparm nomipmaps
 	{
-		map textures/pad_o4texs/blinkgruen.jpg
+		map textures/pad_o4texs/blinkgruen
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave Square 0 1 0 2.51
 	}
@@ -268,13 +268,13 @@ textures/pad_o4texs/blinkgruen2
 
 textures/pad_o4texs/blinkgruen3
 {
-	qer_editorimage textures/pad_o4texs/blinkgruen.jpg
+	qer_editorimage textures/pad_o4texs/blinkgruen
 	surfaceparm trans
 	qer_trans .6
 	cull none
 	surfaceparm nomipmaps
 	{
-		map textures/pad_o4texs/blinkgruen.jpg
+		map textures/pad_o4texs/blinkgruen
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave Square 0 1 0 3.07
 	}
@@ -282,13 +282,13 @@ textures/pad_o4texs/blinkgruen3
 
 textures/pad_o4texs/blinkgruen4
 {
-	qer_editorimage textures/pad_o4texs/blinkgruen.jpg
+	qer_editorimage textures/pad_o4texs/blinkgruen
 	surfaceparm trans
 	qer_trans .6
 	cull none
 	surfaceparm nomipmaps
 	{
-		map textures/pad_o4texs/blinkgruen.jpg
+		map textures/pad_o4texs/blinkgruen
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave Square 0 1 0 3.53
 	}
@@ -296,13 +296,13 @@ textures/pad_o4texs/blinkgruen4
 
 textures/pad_o4texs/blinkgruen5
 {
-	qer_editorimage textures/pad_o4texs/blinkgruen.jpg
+	qer_editorimage textures/pad_o4texs/blinkgruen
 	surfaceparm trans
 	qer_trans .6
 	cull none
 	surfaceparm nomipmaps
 	{
-		map textures/pad_o4texs/blinkgruen.jpg
+		map textures/pad_o4texs/blinkgruen
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave Square 0 1 0 3.97
 	}
@@ -310,13 +310,13 @@ textures/pad_o4texs/blinkgruen5
 
 textures/pad_o4texs/blinkblauring
 {
-	qer_editorimage textures/pad_o4texs/blinkblauring.jpg
+	qer_editorimage textures/pad_o4texs/blinkblauring
 	surfaceparm trans
 	qer_trans .6
 	cull none
 	surfaceparm nomipmaps
 	{
-		map textures/pad_o4texs/blinkblauring.jpg
+		map textures/pad_o4texs/blinkblauring
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave Sin 0 1 0 0.25
 	}
@@ -330,7 +330,7 @@ textures/pad_o4texs/rubikrot
 	surfaceparm nolightmap
 	cull none
 	{
-		Map textures/pad_o4texs/rubikrot.tga
+		Map textures/pad_o4texs/rubikrot
 		blendFunc GL_ONE GL_ONE
 		rgbgen wave sin 0 1 0 1.01
 	}
@@ -345,7 +345,7 @@ textures/pad_o4texs/rubikgruen
 	surfaceparm nolightmap
 	cull none
 	{
-		Map textures/pad_o4texs/rubikgruen.tga
+		Map textures/pad_o4texs/rubikgruen
 		blendFunc GL_ONE GL_ONE
 		rgbgen wave sin 0 1 0 1.03
 	}
@@ -360,7 +360,7 @@ textures/pad_o4texs/rubikblau
 	surfaceparm nolightmap
 	cull none
 	{
-		Map textures/pad_o4texs/rubikblau.tga
+		Map textures/pad_o4texs/rubikblau
 		blendFunc GL_ONE GL_ONE
 		rgbgen wave sin 0 1 0 1.07
 	}
@@ -375,7 +375,7 @@ textures/pad_o4texs/rubikgelb
 	surfaceparm nolightmap
 	cull none
 	{
-		Map textures/pad_o4texs/rubikgelb.tga
+		Map textures/pad_o4texs/rubikgelb
 		blendFunc GL_ONE GL_ONE
 		rgbgen wave sin 0 1 0 1.09
 	}
@@ -390,7 +390,7 @@ textures/pad_o4texs/rubikorange
 	surfaceparm nolightmap
 	cull none
 	{
-		Map textures/pad_o4texs/rubikorange.tga
+		Map textures/pad_o4texs/rubikorange
 		blendFunc GL_ONE GL_ONE
 		rgbgen wave sin 0 1 0 1.13
 	}
@@ -405,7 +405,7 @@ textures/pad_o4texs/rubikweiss
 	surfaceparm nolightmap
 	cull none
 	{
-		Map textures/pad_o4texs/rubikweiss.tga
+		Map textures/pad_o4texs/rubikweiss
 		blendFunc GL_ONE GL_ONE
 		rgbgen wave sin 0 1 0 1.27
 	}
@@ -418,7 +418,7 @@ textures/pad_o4texs/rubikweiss
 
 textures/pad_o4texs/p032nonsolid
 {
-qer_editorimage textures/pad_o4texs/p032nonsolid.tga
+qer_editorimage textures/pad_o4texs/p032nonsolid
 surfaceparm nomarks
 surfaceparm nonsolid
 	{
@@ -435,190 +435,190 @@ surfaceparm nonsolid
 
 textures/pad_o4texs/Cabin-dispA
 {
-qer_editorimage textures/pad_o4texs/cabin-dispa.tga
+qer_editorimage textures/pad_o4texs/cabin-dispa
 q3map_surfacelight 10
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/cabin-dispa.tga
+	map textures/pad_o4texs/cabin-dispa
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/cabin-dispb.tga
+	map textures/pad_o4texs/cabin-dispb
 	blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit001
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit001.tga
+qer_editorimage textures/pad_o4texs/airplanecockpit001
 q3map_surfacelight 5
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit001.tga
+	map textures/pad_o4texs/airplanecockpit001
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit001b.tga
+	map textures/pad_o4texs/airplanecockpit001b
 	blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit002
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit002.tga
+qer_editorimage textures/pad_o4texs/airplanecockpit002
 q3map_surfacelight 10
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit002.tga
+	map textures/pad_o4texs/airplanecockpit002
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit002b.tga
+	map textures/pad_o4texs/airplanecockpit002b
 	blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit010
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit010.tga
+qer_editorimage textures/pad_o4texs/airplanecockpit010
 q3map_surfacelight 10
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit010.tga
+	map textures/pad_o4texs/airplanecockpit010
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit010b.tga
+	map textures/pad_o4texs/airplanecockpit010b
 	blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit011
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit011.tga
+qer_editorimage textures/pad_o4texs/airplanecockpit011
 q3map_surfacelight 10
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit011.tga
+	map textures/pad_o4texs/airplanecockpit011
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit011b.tga
+	map textures/pad_o4texs/airplanecockpit011b
 	blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit014
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit014.tga
+qer_editorimage textures/pad_o4texs/airplanecockpit014
 q3map_surfacelight 10
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit014.tga
+	map textures/pad_o4texs/airplanecockpit014
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit014b.tga
+	map textures/pad_o4texs/airplanecockpit014b
 	blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit015
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit015.tga
+qer_editorimage textures/pad_o4texs/airplanecockpit015
 q3map_surfacelight 10
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit015.tga
+	map textures/pad_o4texs/airplanecockpit015
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit015b.tga
+	map textures/pad_o4texs/airplanecockpit015b
 	blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit016
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit016.tga
+qer_editorimage textures/pad_o4texs/airplanecockpit016
 q3map_surfacelight 10
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit016.tga
+	map textures/pad_o4texs/airplanecockpit016
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit016b.tga
+	map textures/pad_o4texs/airplanecockpit016b
 	blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit020
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit020.tga
+qer_editorimage textures/pad_o4texs/airplanecockpit020
 q3map_surfacelight 10
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit020.tga
+	map textures/pad_o4texs/airplanecockpit020
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit020b.tga
+	map textures/pad_o4texs/airplanecockpit020b
 	blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit022
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit022.tga
+qer_editorimage textures/pad_o4texs/airplanecockpit022
 q3map_surfacelight 10
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit022.tga
+	map textures/pad_o4texs/airplanecockpit022
 	blendFunc filter
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit022b.tga
+	map textures/pad_o4texs/airplanecockpit022b
 	blendFunc add
 	}
 }
@@ -634,13 +634,13 @@ textures/pad_o4texs/patschefinger
 	map $lightmap
 	}
 	{
-	map textures/pad_o4texs/001.tga
+	map textures/pad_o4texs/001
 	blendFunc GL_DST_COLOR GL_SRC_ALPHA
 	rgbGen identity
 	alphaGen lightingSpecular
 	}
 	{
-	map textures/pad_o4texs/badspiegel.tga
+	map textures/pad_o4texs/badspiegel
 	tcgen environment
 	blendFunc GL_ONE GL_ONE
 	rgbGen identity
@@ -656,7 +656,7 @@ textures/pad_o4texs/glass-nonglare-001
 surfaceparm trans
 qer_trans 	0.5
 	{
-	map textures/pad_o4texs/glass-nonglare-001.tga
+	map textures/pad_o4texs/glass-nonglare-001
 	blendFunc GL_ONE GL_ONE
 	}
 }
@@ -666,7 +666,7 @@ textures/pad_o4texs/glass-nonglare-002
 surfaceparm trans
 qer_trans 	0.5
 	{
-	map textures/pad_o4texs/glass-nonglare-002.tga
+	map textures/pad_o4texs/glass-nonglare-002
 	blendFunc GL_ONE GL_ONE
 	}
 }
@@ -678,13 +678,13 @@ qer_trans 	0.5
 
 textures/pad_o4texs/AcmeTires
 {
-qer_editorimage textures/pad_o4texs/AcmeTires.tga
+qer_editorimage textures/pad_o4texs/AcmeTires
 surfaceparm trans
 qer_trans .6
 cull none
 surfaceparm nomipmaps
 	{
-	map textures/pad_o4texs/acmetires.tga
+	map textures/pad_o4texs/acmetires
 	blendFunc GL_DST_COLOR GL_ONE
 	}
 }
@@ -693,7 +693,7 @@ textures/pad_o4texs/lueftergitter
 {
 surfaceparm trans
 	{
-	map textures/pad_o4texs/lueftergitter.jpg
+	map textures/pad_o4texs/lueftergitter
 	blendfunc filter
 	}
 }
@@ -702,7 +702,7 @@ textures/pad_o4texs/lueftergitter2
 {
 surfaceparm trans
 	{
-	map textures/pad_o4texs/lueftergitter2.jpg
+	map textures/pad_o4texs/lueftergitter2
 	blendfunc filter
 	}
 }
@@ -711,7 +711,7 @@ textures/pad_o4texs/lueftergitter3
 {
 surfaceparm trans
 	{
-	map textures/pad_o4texs/lueftergitter3.jpg
+	map textures/pad_o4texs/lueftergitter3
 	blendfunc filter
 	}
 }
@@ -732,7 +732,7 @@ surfaceparm carpetsteps
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/teppich.tga
+	map textures/pad_o4texs/teppich
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}
@@ -746,7 +746,7 @@ surfaceparm carpetsteps
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p008leder.jpg
+	map textures/pad_o4texs/p008leder
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}
@@ -760,7 +760,7 @@ surfaceparm carpetsteps
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p002leder.jpg
+	map textures/pad_o4texs/p002leder
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}
@@ -777,7 +777,7 @@ surfaceparm metalsteps
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p888alugeb.jpg
+	map textures/pad_o4texs/p888alugeb
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}
@@ -791,7 +791,7 @@ surfaceparm metalsteps
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p001alugeb.jpg
+	map textures/pad_o4texs/p001alugeb
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}
@@ -813,14 +813,14 @@ surfaceparm metalsteps
 
 textures/pad_o4texs/metalstep063
 {
-qer_editorimage textures/pad_o4texs/metalstep063.tga
+qer_editorimage textures/pad_o4texs/metalstep063
 surfaceparm metalsteps
 	{
 	map $lightmap
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/063.tga
+	map textures/pad_o4texs/063
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}
@@ -837,7 +837,7 @@ textures/pad_o4texs/p002Holz
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p002holz.jpg
+	map textures/pad_o4texs/p002holz
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}
@@ -851,7 +851,7 @@ surfaceparm woodsteps
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p008holz.jpg
+	map textures/pad_o4texs/p008holz
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}
@@ -865,7 +865,7 @@ surfaceparm woodsteps
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p009holz.jpg
+	map textures/pad_o4texs/p009holz
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}
@@ -879,7 +879,7 @@ surfaceparm woodsteps
 	rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p039holz.jpg
+	map textures/pad_o4texs/p039holz
 	blendFunc GL_DST_COLOR GL_ZERO
 	rgbGen identity
 	}

--- a/wop/scripts.pk3dir/scripts/pad_airplane.shader
+++ b/wop/scripts.pk3dir/scripts/pad_airplane.shader
@@ -4,15 +4,14 @@
 
 textures/pad_o4texs/ueberdenwolken
 {
-qer_editorimage textures/pad_o4texs/ueberdenwolken
-surfaceparm noimpact
-surfaceparm nolightmap
-q3map_lightimage textures/pad_o4texs/124
-q3map_sun	0.925 0.949 1 120 60 20
-q3map_surfacelight 200
-skyparms env/ueberdenwolken - -
+	qer_editorimage textures/pad_o4texs/ueberdenwolken
+	surfaceparm noimpact
+	surfaceparm nolightmap
+	q3map_lightimage textures/pad_o4texs/124
+	q3map_sun	0.925 0.949 1 120 60 20
+	q3map_surfacelight 200
+	skyparms env/ueberdenwolken - -
 }
-
 
 //-----------------------------------------------------------------
 // einfache Texturen mit (ALPHA)Transparenz
@@ -20,148 +19,148 @@ skyparms env/ueberdenwolken - -
 
 textures/pad_o4texs/danke_erklaert_de
 {
-surfaceparm trans
-surfaceparm alphashadow
-cull none
-nopicmip
+	surfaceparm trans
+	surfaceparm alphashadow
+	cull none
+	nopicmip
 	{
-	map textures/pad_o4texs/danke_erklaert_de
-	blendFunc GL_ONE GL_ZERO
-	alphaFunc GE128
-	depthWrite
-	rgbGen identity
+		map textures/pad_o4texs/danke_erklaert_de
+		blendFunc GL_ONE GL_ZERO
+		alphaFunc GE128
+		depthWrite
+		rgbGen identity
 	}
 	{
-	map $lightmap
-	rgbGen identity
-	blendFunc GL_DST_COLOR GL_ZERO
-	depthFunc equal
+		map $lightmap
+		rgbGen identity
+		blendFunc GL_DST_COLOR GL_ZERO
+		depthFunc equal
 	}
 }
 
 textures/pad_o4texs/danke_noctuagraphics
 {
-surfaceparm trans
-surfaceparm alphashadow
-cull none
-nopicmip
+	surfaceparm trans
+	surfaceparm alphashadow
+	cull none
+	nopicmip
 	{
-	map textures/pad_o4texs/danke_noctuagraphics
-	blendFunc GL_ONE GL_ZERO
-	alphaFunc GE128
-	depthWrite
-	rgbGen identity
+		map textures/pad_o4texs/danke_noctuagraphics
+		blendFunc GL_ONE GL_ZERO
+		alphaFunc GE128
+		depthWrite
+		rgbGen identity
 	}
 	{
-	map $lightmap
-	rgbGen identity
-	blendFunc GL_DST_COLOR GL_ZERO
-	depthFunc equal
+		map $lightmap
+		rgbGen identity
+		blendFunc GL_DST_COLOR GL_ZERO
+		depthFunc equal
 	}
 }
 
 textures/pad_o4texs/danke_maxmustermann
 {
-surfaceparm trans
-surfaceparm alphashadow
-cull none
-nopicmip
+	surfaceparm trans
+	surfaceparm alphashadow
+	cull none
+	nopicmip
 	{
-	map textures/pad_o4texs/danke_maxmustermann
-	blendFunc GL_ONE GL_ZERO
-	alphaFunc GE128
-	depthWrite
-	rgbGen identity
+		map textures/pad_o4texs/danke_maxmustermann
+		blendFunc GL_ONE GL_ZERO
+		alphaFunc GE128
+		depthWrite
+		rgbGen identity
 	}
 	{
-	map $lightmap
-	rgbGen identity
-	blendFunc GL_DST_COLOR GL_ZERO
-	depthFunc equal
+		map $lightmap
+		rgbGen identity
+		blendFunc GL_DST_COLOR GL_ZERO
+		depthFunc equal
 	}
 }
 
 textures/pad_o4texs/gurtschlossA
 {
-surfaceparm trans
-surfaceparm alphashadow
-nopicmip
+	surfaceparm trans
+	surfaceparm alphashadow
+	nopicmip
 	{
-	map textures/pad_o4texs/gurtschlossa
-	blendFunc GL_ONE GL_ZERO
-	alphaFunc GE128
-	depthWrite
-	rgbGen identity
+		map textures/pad_o4texs/gurtschlossa
+		blendFunc GL_ONE GL_ZERO
+		alphaFunc GE128
+		depthWrite
+		rgbGen identity
 	}
 	{
-	map $lightmap
-	rgbGen identity
-	blendFunc GL_DST_COLOR GL_ZERO
-	depthFunc equal
+		map $lightmap
+		rgbGen identity
+		blendFunc GL_DST_COLOR GL_ZERO
+		depthFunc equal
 	}
 }
 
 textures/pad_o4texs/gurtschlossC
 {
-surfaceparm trans
-surfaceparm alphashadow
-cull none
-nopicmip
+	surfaceparm trans
+	surfaceparm alphashadow
+	cull none
+	nopicmip
 	{
-	map textures/pad_o4texs/gurtschlossc
-	blendFunc GL_ONE GL_ZERO
-	alphaFunc GE128
-	depthWrite
-	rgbGen identity
+		map textures/pad_o4texs/gurtschlossc
+		blendFunc GL_ONE GL_ZERO
+		alphaFunc GE128
+		depthWrite
+		rgbGen identity
 	}
 	{
-	map $lightmap
-	rgbGen identity
-	blendFunc GL_DST_COLOR GL_ZERO
-	depthFunc equal
+		map $lightmap
+		rgbGen identity
+		blendFunc GL_DST_COLOR GL_ZERO
+		depthFunc equal
 	}
 }
 
 textures/pad_o4texs/sechseck
 {
-surfaceparm trans
-surfaceparm alphashadow
-cull none
-nopicmip
+	surfaceparm trans
+	surfaceparm alphashadow
+	cull none
+	nopicmip
 	{
-	map textures/pad_o4texs/sechseck
-	blendFunc GL_ONE GL_ZERO
-	alphaFunc GE128
-	depthWrite
-	rgbGen identity
+		map textures/pad_o4texs/sechseck
+		blendFunc GL_ONE GL_ZERO
+		alphaFunc GE128
+		depthWrite
+		rgbGen identity
 	}
 	{
-	map $lightmap
-	rgbGen identity
-	blendFunc GL_DST_COLOR GL_ZERO
-	depthFunc equal
+		map $lightmap
+		rgbGen identity
+		blendFunc GL_DST_COLOR GL_ZERO
+		depthFunc equal
 	}
 }
 
 
 textures/pad_o4texs/serviette
 {
-surfaceparm trans
-surfaceparm alphashadow
-cull none
-nopicmip
+	surfaceparm trans
+	surfaceparm alphashadow
+	cull none
+	nopicmip
 	{
-	map textures/pad_o4texs/serviette
-	blendFunc GL_ONE GL_ZERO
-	alphaFunc GE128
-	depthWrite
-	rgbGen identity
+		map textures/pad_o4texs/serviette
+		blendFunc GL_ONE GL_ZERO
+		alphaFunc GE128
+		depthWrite
+		rgbGen identity
 	}
 	{
-	map $lightmap
-	rgbGen identity
-	blendFunc GL_DST_COLOR GL_ZERO
-	depthFunc equal
+		map $lightmap
+		rgbGen identity
+		blendFunc GL_DST_COLOR GL_ZERO
+		depthFunc equal
 	}
 }
 
@@ -418,9 +417,9 @@ textures/pad_o4texs/rubikweiss
 
 textures/pad_o4texs/p032nonsolid
 {
-qer_editorimage textures/pad_o4texs/p032nonsolid
-surfaceparm nomarks
-surfaceparm nonsolid
+	qer_editorimage textures/pad_o4texs/p032nonsolid
+	surfaceparm nomarks
+	surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
@@ -435,191 +434,191 @@ surfaceparm nonsolid
 
 textures/pad_o4texs/Cabin-dispA
 {
-qer_editorimage textures/pad_o4texs/cabin-dispa
-q3map_surfacelight 10
+	qer_editorimage textures/pad_o4texs/cabin-dispa
+	q3map_surfacelight 10
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/cabin-dispa
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/cabin-dispa
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/cabin-dispb
-	blendFunc add
+		map textures/pad_o4texs/cabin-dispb
+		blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit001
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit001
-q3map_surfacelight 5
+	qer_editorimage textures/pad_o4texs/airplanecockpit001
+	q3map_surfacelight 5
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit001
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/airplanecockpit001
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit001b
-	blendFunc add
+		map textures/pad_o4texs/airplanecockpit001b
+		blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit002
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit002
-q3map_surfacelight 10
+	qer_editorimage textures/pad_o4texs/airplanecockpit002
+	q3map_surfacelight 10
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit002
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/airplanecockpit002
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit002b
-	blendFunc add
+		map textures/pad_o4texs/airplanecockpit002b
+		blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit010
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit010
-q3map_surfacelight 10
+	qer_editorimage textures/pad_o4texs/airplanecockpit010
+	q3map_surfacelight 10
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit010
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/airplanecockpit010
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit010b
-	blendFunc add
+		map textures/pad_o4texs/airplanecockpit010b
+		blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit011
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit011
-q3map_surfacelight 10
+	qer_editorimage textures/pad_o4texs/airplanecockpit011
+	q3map_surfacelight 10
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit011
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/airplanecockpit011
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit011b
-	blendFunc add
+		map textures/pad_o4texs/airplanecockpit011b
+		blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit014
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit014
-q3map_surfacelight 10
+	qer_editorimage textures/pad_o4texs/airplanecockpit014
+	q3map_surfacelight 10
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit014
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/airplanecockpit014
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit014b
-	blendFunc add
+		map textures/pad_o4texs/airplanecockpit014b
+		blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit015
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit015
-q3map_surfacelight 10
+	qer_editorimage textures/pad_o4texs/airplanecockpit015
+	q3map_surfacelight 10
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit015
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/airplanecockpit015
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit015b
-	blendFunc add
+		map textures/pad_o4texs/airplanecockpit015b
+		blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit016
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit016
-q3map_surfacelight 10
+	qer_editorimage textures/pad_o4texs/airplanecockpit016
+	q3map_surfacelight 10
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit016
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/airplanecockpit016
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit016b
-	blendFunc add
+		map textures/pad_o4texs/airplanecockpit016b
+		blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit020
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit020
-q3map_surfacelight 10
+	qer_editorimage textures/pad_o4texs/airplanecockpit020
+	q3map_surfacelight 10
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit020
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/airplanecockpit020
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit020b
-	blendFunc add
+		map textures/pad_o4texs/airplanecockpit020b
+		blendFunc add
 	}
 }
 
 textures/pad_o4texs/airplanecockpit022
 {
-qer_editorimage textures/pad_o4texs/airplanecockpit022
-q3map_surfacelight 10
+	qer_editorimage textures/pad_o4texs/airplanecockpit022
+	q3map_surfacelight 10
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit022
-	blendFunc filter
-	rgbGen identity
+		map textures/pad_o4texs/airplanecockpit022
+		blendFunc filter
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/airplanecockpit022b
-	blendFunc add
+		map textures/pad_o4texs/airplanecockpit022b
+		blendFunc add
 	}
 }
 
@@ -630,20 +629,20 @@ q3map_surfacelight 10
 textures/pad_o4texs/patschefinger
 {
 	{
-	rgbGen identity
-	map $lightmap
+		rgbGen identity
+		map $lightmap
 	}
 	{
-	map textures/pad_o4texs/001
-	blendFunc GL_DST_COLOR GL_SRC_ALPHA
-	rgbGen identity
-	alphaGen lightingSpecular
+		map textures/pad_o4texs/001
+		blendFunc GL_DST_COLOR GL_SRC_ALPHA
+		rgbGen identity
+		alphaGen lightingSpecular
 	}
 	{
-	map textures/pad_o4texs/badspiegel
-	tcgen environment
-	blendFunc GL_ONE GL_ONE
-	rgbGen identity
+		map textures/pad_o4texs/badspiegel
+		tcgen environment
+		blendFunc GL_ONE GL_ONE
+		rgbGen identity
 	}
 }
 
@@ -653,21 +652,21 @@ textures/pad_o4texs/patschefinger
 
 textures/pad_o4texs/glass-nonglare-001
 {
-surfaceparm trans
-qer_trans 	0.5
+	surfaceparm trans
+	qer_trans 	0.5
 	{
-	map textures/pad_o4texs/glass-nonglare-001
-	blendFunc GL_ONE GL_ONE
+		map textures/pad_o4texs/glass-nonglare-001
+		blendFunc GL_ONE GL_ONE
 	}
 }
 
 textures/pad_o4texs/glass-nonglare-002
 {
-surfaceparm trans
-qer_trans 	0.5
+	surfaceparm trans
+	qer_trans 	0.5
 	{
-	map textures/pad_o4texs/glass-nonglare-002
-	blendFunc GL_ONE GL_ONE
+		map textures/pad_o4texs/glass-nonglare-002
+		blendFunc GL_ONE GL_ONE
 	}
 }
 
@@ -678,41 +677,41 @@ qer_trans 	0.5
 
 textures/pad_o4texs/AcmeTires
 {
-qer_editorimage textures/pad_o4texs/AcmeTires
-surfaceparm trans
-qer_trans .6
-cull none
-surfaceparm nomipmaps
+	qer_editorimage textures/pad_o4texs/acmetires
+	surfaceparm trans
+	qer_trans .6
+	cull none
+	surfaceparm nomipmaps
 	{
-	map textures/pad_o4texs/acmetires
-	blendFunc GL_DST_COLOR GL_ONE
+		map textures/pad_o4texs/acmetires
+		blendFunc GL_DST_COLOR GL_ONE
 	}
 }
 
 textures/pad_o4texs/lueftergitter
 {
-surfaceparm trans
+	surfaceparm trans
 	{
-	map textures/pad_o4texs/lueftergitter
-	blendfunc filter
+		map textures/pad_o4texs/lueftergitter
+		blendfunc filter
 	}
 }
 
 textures/pad_o4texs/lueftergitter2
 {
-surfaceparm trans
+	surfaceparm trans
 	{
-	map textures/pad_o4texs/lueftergitter2
-	blendfunc filter
+		map textures/pad_o4texs/lueftergitter2
+		blendfunc filter
 	}
 }
 
 textures/pad_o4texs/lueftergitter3
 {
-surfaceparm trans
+	surfaceparm trans
 	{
-	map textures/pad_o4texs/lueftergitter3
-	blendfunc filter
+		map textures/pad_o4texs/lueftergitter3
+		blendfunc filter
 	}
 }
 
@@ -726,43 +725,43 @@ surfaceparm trans
 
 textures/pad_o4texs/teppich
 {
-surfaceparm carpetsteps
+	surfaceparm carpetsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/teppich
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/teppich
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
 textures/pad_o4texs/p008Leder
 {
-surfaceparm carpetsteps
+	surfaceparm carpetsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p008leder
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/p008leder
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
 textures/pad_o4texs/p002Leder
 {
-surfaceparm carpetsteps
+	surfaceparm carpetsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p002leder
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/p002leder
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
@@ -771,58 +770,58 @@ surfaceparm carpetsteps
 
 textures/pad_o4texs/p888AluGeb
 {
-surfaceparm metalsteps
+	surfaceparm metalsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p888alugeb
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/p888alugeb
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
 textures/pad_o4texs/p001AluGeb
 {
-surfaceparm metalsteps
+	surfaceparm metalsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p001alugeb
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/p001alugeb
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
 textures/pad_o4texs/zinc01
 {
-surfaceparm metalsteps
+	surfaceparm metalsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/zinc01
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/zinc01
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
 textures/pad_o4texs/metalstep063
 {
-qer_editorimage textures/pad_o4texs/metalstep063
-surfaceparm metalsteps
+	qer_editorimage textures/pad_o4texs/metalstep063
+	surfaceparm metalsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/063
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/063
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
@@ -833,54 +832,54 @@ textures/pad_o4texs/p002Holz
 {
 	surfaceparm woodsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p002holz
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/p002holz
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
 textures/pad_o4texs/p008Holz
 {
-surfaceparm woodsteps
+	surfaceparm woodsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p008holz
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/p008holz
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
 textures/pad_o4texs/p009Holz
 {
-surfaceparm woodsteps
+	surfaceparm woodsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p009holz
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/p009holz
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }
 
 textures/pad_o4texs/p039Holz
 {
-surfaceparm woodsteps
+	surfaceparm woodsteps
 	{
-	map $lightmap
-	rgbGen identity
+		map $lightmap
+		rgbGen identity
 	}
 	{
-	map textures/pad_o4texs/p039holz
-	blendFunc GL_DST_COLOR GL_ZERO
-	rgbGen identity
+		map textures/pad_o4texs/p039holz
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
 	}
 }

--- a/wop/scripts.pk3dir/scripts/pad_asia.shader
+++ b/wop/scripts.pk3dir/scripts/pad_asia.shader
@@ -9,7 +9,7 @@ textures/pad_teehouse/paper
     q3map_surfacelight 80
     surfaceparm nolightmap
     {
-        map textures/pad_teehouse/paper.tga
+        map textures/pad_teehouse/paper
     }
 }
 
@@ -18,7 +18,7 @@ textures/pad_teehouse/reispaper_512
     q3map_surfacelight 80
     surfaceparm nolightmap
     {
-        map textures/pad_teehouse/reispaper_512.tga
+        map textures/pad_teehouse/reispaper_512
     }
 }
 
@@ -28,7 +28,7 @@ textures/pad_teehouse/paper2_blue
     q3map_surfacelight 70
     surfaceparm nolightmap
     {
-        map textures/pad_teehouse/paper2_blue.tga
+        map textures/pad_teehouse/paper2_blue
     }
 }
 
@@ -37,7 +37,7 @@ textures/pad_teehouse/paper2_blue_dark
     q3map_surfacelight 70
     surfaceparm nolightmap
     {
-        map textures/pad_teehouse/paper2_blue_dark.tga
+        map textures/pad_teehouse/paper2_blue_dark
     }
 }
 
@@ -47,7 +47,7 @@ textures/pad_teehouse/paper2_red
     q3map_surfacelight 70
     surfaceparm nolightmap
     {
-        map textures/pad_teehouse/paper2_red.tga
+        map textures/pad_teehouse/paper2_red
     }
 }
 
@@ -57,7 +57,7 @@ textures/pad_teehouse/paper2_red_dark
     q3map_surfacelight 70
     surfaceparm nolightmap
     {
-        map textures/pad_teehouse/paper2_red_dark.tga
+        map textures/pad_teehouse/paper2_red_dark
     }
 }
 
@@ -66,7 +66,7 @@ textures/pad_teehouse/paper_yellow
     q3map_surfacelight 70
     surfaceparm nolightmap
     {
-        map textures/pad_teehouse/paper_yellow.tga
+        map textures/pad_teehouse/paper_yellow
     }
 }
 
@@ -84,7 +84,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/bambusfloor.tga
+map textures/pad_teehouse/bambusfloor
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -99,7 +99,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/shogi02.tga
+map textures/pad_teehouse/shogi02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -113,7 +113,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/shogi03.tga
+map textures/pad_teehouse/shogi03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -127,7 +127,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/wood_black.tga
+map textures/pad_teehouse/wood_black
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -141,7 +141,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/wood01.tga
+map textures/pad_teehouse/wood01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -155,7 +155,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/tee_untersetzer.tga
+map textures/pad_teehouse/tee_untersetzer
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -169,7 +169,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/tatami_border_red_dark.tga
+map textures/pad_teehouse/tatami_border_red_dark
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -183,7 +183,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/tatami_border_red.tga
+map textures/pad_teehouse/tatami_border_red
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -197,7 +197,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/tatami_border_blue_dark.tga
+map textures/pad_teehouse/tatami_border_blue_dark
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -211,7 +211,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/tatami_border_blue.tga
+map textures/pad_teehouse/tatami_border_blue
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -225,7 +225,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/tatami_border_green.tga
+map textures/pad_teehouse/tatami_border_green
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -239,7 +239,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/geflecht_blue.tga
+map textures/pad_teehouse/geflecht_blue
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -253,7 +253,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/geflecht_red.tga
+map textures/pad_teehouse/geflecht_red
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -267,7 +267,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/red_border.tga
+map textures/pad_teehouse/red_border
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -282,7 +282,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/flower_red2.tga
+map textures/pad_teehouse/flower_red2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -296,7 +296,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/flower_blue2.tga
+map textures/pad_teehouse/flower_blue2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -310,7 +310,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/flower_blue3.tga
+map textures/pad_teehouse/flower_blue3
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -324,7 +324,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/flower_red3.tga
+map textures/pad_teehouse/flower_red3
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -338,7 +338,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/flower_red4.tga
+map textures/pad_teehouse/flower_red4
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -352,7 +352,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/flower_blue4.tga
+map textures/pad_teehouse/flower_blue4
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -364,20 +364,20 @@ rgbGen identity
 
 textures/pad_teehouse/art04
 {
-	qer_editorimage textures/pad_teehouse/art04.tga
+	qer_editorimage textures/pad_teehouse/art04
         surfaceparm woodsteps
 	{
-		map textures/pad_teehouse/art04.tga
+		map textures/pad_teehouse/art04
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -385,20 +385,20 @@ textures/pad_teehouse/art04
 
 textures/pad_teehouse/art06
 {
-	qer_editorimage textures/pad_teehouse/art06.tga
+	qer_editorimage textures/pad_teehouse/art06
         surfaceparm woodsteps
 	{
-		map textures/pad_teehouse/art06.tga
+		map textures/pad_teehouse/art06
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3a.tga
+		map textures/pad_gfx02/tinpad3a
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -407,19 +407,19 @@ textures/pad_teehouse/art06
 
 textures/pad_teehouse/cupboarder_red
 {
-	qer_editorimage textures/pad_teehouse/cupboarder_red.tga
+	qer_editorimage textures/pad_teehouse/cupboarder_red
 	{
-		map textures/pad_teehouse/cupboarder_red.tga
+		map textures/pad_teehouse/cupboarder_red
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -427,19 +427,19 @@ textures/pad_teehouse/cupboarder_red
 
 textures/pad_teehouse/cupboarder2_red
 {
-	qer_editorimage textures/pad_teehouse/cupboarder2_red.tga
+	qer_editorimage textures/pad_teehouse/cupboarder2_red
 	{
-		map textures/pad_teehouse/cupboarder2_red.tga
+		map textures/pad_teehouse/cupboarder2_red
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -448,19 +448,19 @@ textures/pad_teehouse/cupboarder2_red
 
 textures/pad_teehouse/cupboarder_blue
 {
-	qer_editorimage textures/pad_teehouse/cupboarder_blue.tga
+	qer_editorimage textures/pad_teehouse/cupboarder_blue
 	{
-		map textures/pad_teehouse/cupboarder_blue.tga
+		map textures/pad_teehouse/cupboarder_blue
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -468,19 +468,19 @@ textures/pad_teehouse/cupboarder_blue
 
 textures/pad_teehouse/cupboarder2_blue
 {
-	qer_editorimage textures/pad_teehouse/cupboarder2_blue.tga
+	qer_editorimage textures/pad_teehouse/cupboarder2_blue
 	{
-		map textures/pad_teehouse/cupboarder2_blue.tga
+		map textures/pad_teehouse/cupboarder2_blue
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -489,19 +489,19 @@ textures/pad_teehouse/cupboarder2_blue
 
 textures/pad_teehouse/flower_red
 {
-	qer_editorimage textures/pad_teehouse/flower_red.tga
+	qer_editorimage textures/pad_teehouse/flower_red
 	{
-		map textures/pad_teehouse/flower_red.tga
+		map textures/pad_teehouse/flower_red
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -509,19 +509,19 @@ textures/pad_teehouse/flower_red
 
 textures/pad_teehouse/flower_blue
 {
-	qer_editorimage textures/pad_teehouse/flower_blue.tga
+	qer_editorimage textures/pad_teehouse/flower_blue
 	{
-		map textures/pad_teehouse/flower_blue.tga
+		map textures/pad_teehouse/flower_blue
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -535,13 +535,13 @@ textures/pad_teehouse/bambuspinsel
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_teehouse/bambuspinsel.tga
+                map textures/pad_teehouse/bambuspinsel
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -560,13 +560,13 @@ textures/pad_teehouse/kirschbluete
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_teehouse/kirschbluete.tga
+                map textures/pad_teehouse/kirschbluete
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -591,27 +591,27 @@ textures/pad_teehouse/matcha02
 {
 q3map_nonplanar
 q3map_shadeangle 60 l
-qer_editorimage textures/pad_teehouse/matcha02.tga
+qer_editorimage textures/pad_teehouse/matcha02
 surfaceparm sandsteps
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_teehouse/matcha02.tga
+map textures/pad_teehouse/matcha02
 blendFunc filter
 }
 }
 
 
 textures/pad_teehouse/color_red
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_teehouse/color_red.tga
+		map textures/pad_teehouse/color_red
                		blendFunc add
 		rgbGen vertex
 	}
@@ -619,13 +619,13 @@ textures/pad_teehouse/color_red
 
 
 textures/pad_teehouse/color_blue
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_teehouse/color_blue.tga
+		map textures/pad_teehouse/color_blue
                		blendFunc add
 		rgbGen vertex
 	}
@@ -633,13 +633,13 @@ textures/pad_teehouse/color_blue
 
 
 textures/pad_teehouse/goldlogo
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_teehouse/goldlogo.tga
+		map textures/pad_teehouse/goldlogo
                		blendFunc add
 		rgbGen vertex
 	}

--- a/wop/scripts.pk3dir/scripts/pad_attic.shader
+++ b/wop/scripts.pk3dir/scripts/pad_attic.shader
@@ -1,6 +1,6 @@
 textures/pad_attic/leiter
 {
-        qer_editorimage textures/pad_attic/leiter.tga
+        qer_editorimage textures/pad_attic/leiter
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -8,7 +8,7 @@ textures/pad_attic/leiter
 	cull none
         nopicmip
 	{
-		map textures/pad_attic/leiter.tga
+		map textures/pad_attic/leiter
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -25,7 +25,7 @@ textures/pad_attic/leiter
 
 textures/pad_attic/clockrad
 {
-        qer_editorimage textures/pad_attic/clockrad.tga
+        qer_editorimage textures/pad_attic/clockrad
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -33,7 +33,7 @@ textures/pad_attic/clockrad
 	cull none
         nopicmip
 	{
-		map textures/pad_attic/clockrad.tga
+		map textures/pad_attic/clockrad
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -50,7 +50,7 @@ textures/pad_attic/clockrad
 
 textures/pad_attic/clockpendel
 {
-        qer_editorimage textures/pad_attic/clockpendel.tga
+        qer_editorimage textures/pad_attic/clockpendel
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -58,7 +58,7 @@ textures/pad_attic/clockpendel
 	cull none
         nopicmip
 	{
-		map textures/pad_attic/clockpendel.tga
+		map textures/pad_attic/clockpendel
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -75,19 +75,19 @@ textures/pad_attic/clockpendel
 
 textures/pad_attic/darkred
 {
-	qer_editorimage textures/pad_attic/darkred.tga
+	qer_editorimage textures/pad_attic/darkred
 	{
-		map textures/pad_attic/darkred.tga
+		map textures/pad_attic/darkred
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -95,19 +95,19 @@ textures/pad_attic/darkred
 
 textures/pad_attic/darkblue
 {
-	qer_editorimage textures/pad_attic/darkblue.tga
+	qer_editorimage textures/pad_attic/darkblue
 	{
-		map textures/pad_attic/darkblue.tga
+		map textures/pad_attic/darkblue
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -116,11 +116,11 @@ textures/pad_attic/darkblue
 
 textures/pad_attic/pad_jail_fly1
 {
-       qer_editorimage textures/pad_attic/pad_jail_fly1.tga
-       surfaceparm trans	
+       qer_editorimage textures/pad_attic/pad_jail_fly1
+       surfaceparm trans
        surfaceparm pointlight
-       surfaceparm nomarks	
-       surfaceparm nodamage        
+       surfaceparm nomarks
+       surfaceparm nodamage
        surfaceparm nonsolid
         surfaceparm nolightmap
         deformVertexes move 2 3 1.5  sin 0 5 0 0.3
@@ -130,18 +130,18 @@ textures/pad_attic/pad_jail_fly1
         cull none
 {
 	map $lightmap
-	rgbGen identity	
+	rgbGen identity
 	blendfunc gl_zero gl_one
 }
 {
-	
-	map textures/pad_attic/pad_jail_fly1.tga
+
+	map textures/pad_attic/pad_jail_fly1
                 tcMod Scroll -5 0.1
                 tcMod turb .3 .25 0 .1
                 blendfunc gl_src_alpha gl_one_minus_src_alpha
 }
 {
- 	map textures/pad_attic/pad_jail_fly2.tga
+ 	map textures/pad_attic/pad_jail_fly2
                 tcMod Scroll 4 -0.5
                 tcMod turb .1 .25 0 -.1
                 blendfunc gl_src_alpha gl_one_minus_src_alpha
@@ -150,11 +150,11 @@ textures/pad_attic/pad_jail_fly1
 
 textures/pad_attic/pad_jail_fly2
 {
-       qer_editorimage textures/pad_attic/pad_jail_fly1.tga
-       surfaceparm trans	
+       qer_editorimage textures/pad_attic/pad_jail_fly1
+       surfaceparm trans
        surfaceparm pointlight
-       surfaceparm nomarks	
-       surfaceparm nodamage        
+       surfaceparm nomarks
+       surfaceparm nodamage
        surfaceparm nonsolid
         surfaceparm nolightmap
         deformVertexes move 1 2.5 2  sin 0 6 0 0.4
@@ -164,18 +164,18 @@ textures/pad_attic/pad_jail_fly2
         cull none
 {
 	map $lightmap
-	rgbGen identity	
+	rgbGen identity
 	blendfunc gl_zero gl_one
 }
 {
-	
-	map textures/pad_attic/pad_jail_fly2.tga
+
+	map textures/pad_attic/pad_jail_fly2
                 tcMod Scroll -4 0.3
                 tcMod turb .2 .3 0 -.1
                 blendfunc gl_src_alpha gl_one_minus_src_alpha
 }
 {
- 	map textures/pad_attic/pad_jail_fly1.tga
+ 	map textures/pad_attic/pad_jail_fly1
                 tcMod Scroll 6 -0.4
                 tcMod turb .2 .25 0 -.2
                 blendfunc gl_src_alpha gl_one_minus_src_alpha
@@ -187,13 +187,13 @@ textures/pad_attic/birdcage
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_attic/birdcage.tga
+                map textures/pad_attic/birdcage
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -212,17 +212,17 @@ textures/pad_attic/birdcage
 
 textures/pad_attic/lampdraht
 {
-	qer_editorimage textures/pad_attic/lampdraht.tga
+	qer_editorimage textures/pad_attic/lampdraht
 	surfaceparm trans
 	surfaceparm nomarks
-             surfaceparm nonsolid		
+             surfaceparm nonsolid
 	surfaceparm nolightmap
 	surfaceparm alphashadow
 	cull none
 	q3map_surfacelight 50
         nopicmip
 		{
-		map textures/pad_attic/lampdraht.tga 
+		map textures/pad_attic/lampdraht
 blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -242,11 +242,11 @@ textures/pad_attic/flare
     deformVertexes autoSprite
     surfaceparm trans
     surfaceparm nomarks
-    surfaceparm nonsolid		
+    surfaceparm nonsolid
     surfaceparm nolightmap
     cull none
           {
-            clampmap textures/pad_attic/flare.tga
+            clampmap textures/pad_attic/flare
             blendFunc GL_ONE GL_ONE
           }
 }
@@ -256,68 +256,68 @@ textures/pad_attic/flareyel
     deformVertexes autoSprite
     surfaceparm trans
     surfaceparm nomarks
-    surfaceparm nonsolid		
+    surfaceparm nonsolid
     surfaceparm nolightmap
     cull none
           {
-            clampmap textures/pad_attic/flareyel.tga
+            clampmap textures/pad_attic/flareyel
             blendFunc GL_ONE GL_ONE
           }
 }
 
 textures/pad_attic/milchglass_1
 {
-	qer_editorimage textures/pad_attic/greyblue.tga
+	qer_editorimage textures/pad_attic/greyblue
 	cull back
 	{
-		map textures/pad_attic/greyblue.tga
+		map textures/pad_attic/greyblue
 		blendfunc add
 	}
 	{
-		map textures/pad_gfx/env2.tga
+		map textures/pad_gfx/env2
 		blendfunc filter
-		tcGen environment 
+		tcGen environment
 	}
 }
 
 textures/pad_attic/milchglass_2
 {
-	qer_editorimage textures/pad_attic/greyblue.tga
+	qer_editorimage textures/pad_attic/greyblue
 	cull back
 	{
-		map textures/pad_attic/greyblue.tga
+		map textures/pad_attic/greyblue
 		blendfunc add
 	}
 	{
-		map textures/pad_gfx/env2.tga
+		map textures/pad_gfx/env2
 		blendfunc filter
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map texturespad_attic/greyblue.tga
+		map texturespad_attic/greyblue
 		blendfunc filter
 	}
 }
 
 textures/pad_attic/milchglass_3
 {
-	qer_editorimage textures/pad_attic/greyblue.tga
+	qer_editorimage textures/pad_attic/greyblue
 	cull back
 	{
-		map textures/pad_attic/greyblue.tga
+		map textures/pad_attic/greyblue
 		blendfunc add
 	}
 	{
-		map textures/pad_gfx/env2.tga
+		map textures/pad_gfx/env2
 		blendfunc filter
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map textures/pad_attic/greyblue.tga
+		map textures/pad_attic/greyblue
 		blendfunc filter
 	}
 	{
-		map textures/pad_attic/greyblue.tga
+		map textures/pad_attic/greyblue
 		blendfunc blend
 	}
 }
@@ -331,11 +331,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/balken.tga
+map textures/pad_attic/balken
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/balken
 {
@@ -345,11 +345,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/balken02.tga
+map textures/pad_attic/balken02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_attic/border001
@@ -360,11 +360,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/border001.tga
+map textures/pad_attic/border001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_attic/border003
@@ -375,11 +375,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/border003.tga
+map textures/pad_attic/border003
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/brettborder
 {
@@ -389,11 +389,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/brettborder.tga
+map textures/pad_attic/brettborder
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/brettborder02
 {
@@ -403,11 +403,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/brettborder02.tga
+map textures/pad_attic/brettborder02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_attic/dach03_1024
@@ -418,11 +418,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/dach03_1024.tga
+map textures/pad_attic/dach03_1024
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/oldstam03
 {
@@ -432,11 +432,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/oldstam03.tga
+map textures/pad_attic/oldstam03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/newspaperfloor2
 {
@@ -446,11 +446,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/newspaperfloor2.tga
+map textures/pad_attic/newspaperfloor2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/oldfloorhalf
 {
@@ -460,11 +460,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/oldfloorhalf.tga
+map textures/pad_attic/oldfloorhalf
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_attic/oldfloorrand02
@@ -475,11 +475,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/oldfloorrand02.tga
+map textures/pad_attic/oldfloorrand02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/oldmetal
 {
@@ -489,11 +489,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/oldmetal.tga
+map textures/pad_attic/oldmetal
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/regalbrett
 {
@@ -503,11 +503,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/regalbrett.tga
+map textures/pad_attic/regalbrett
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/schlaeger
 {
@@ -517,11 +517,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/schlaeger.tga
+map textures/pad_attic/schlaeger
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_attic/schrankboard
@@ -532,11 +532,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/schrankboard.tga
+map textures/pad_attic/schrankboard
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_attic/schrankrollo
@@ -547,11 +547,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/schrankrollo.tga
+map textures/pad_attic/schrankrollo
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 
@@ -563,11 +563,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/woodborder04.tga
+map textures/pad_attic/woodborder04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_attic/woodlatten02
@@ -578,11 +578,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/woodlatten02.tga
+map textures/pad_attic/woodlatten02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_attic/woodlatten02b
 {
@@ -592,11 +592,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_attic/woodlatten02b.tga
+map textures/pad_attic/woodlatten02b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 

--- a/wop/scripts.pk3dir/scripts/pad_bookroom.shader
+++ b/wop/scripts.pk3dir/scripts/pad_bookroom.shader
@@ -1,117 +1,106 @@
 textures/pad_bookroom/fenstergitter
 {
-     cull disable
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     tessSize 64
-    
-     
-        {
-                map textures/pad_bookroom/fenstergitter.tga
-                alphaFunc GE128
+	cull disable
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	tessSize 64
+
+	{
+		map textures/pad_bookroom/fenstergitter
+		alphaFunc GE128
 		depthWrite
 		rgbGen identity
-        }
-        {
+	}
+	{
 		map $lightmap
 		rgbGen identity
 		blendFunc filter
 		depthFunc equal
 	}
-
-
 }
 
 
 textures/pad_bookroom/fenstergitter003
 {
-     cull disable
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     tessSize 64
-    
-     
-        {
-                map textures/pad_bookroom/fenstergitter003.tga
-                alphaFunc GE128
+	cull disable
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	tessSize 64
+
+	{
+		map textures/pad_bookroom/fenstergitter003
+		alphaFunc GE128
 		depthWrite
 		rgbGen identity
-        }
-        {
+	}
+	{
 		map $lightmap
 		rgbGen identity
 		blendFunc filter
 		depthFunc equal
 	}
-
-
 }
 
 
 textures/pad_bookroom/vinesss
 {
-     cull disable
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     tessSize 64
-    
-     
-        {
-                map textures/pad_bookroom/vinesss.tga
-                alphaFunc GE128
+	cull disable
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	tessSize 64
+
+	{
+		map textures/pad_bookroom/vinesss
+		alphaFunc GE128
 		depthWrite
 		rgbGen identity
-        }
-        {
+	}
+	{
 		map $lightmap
 		rgbGen identity
 		blendFunc filter
 		depthFunc equal
 	}
-
-
 }
-
 
 textures/pad_bookroom/goldstab001
 {
-	qer_editorimage textures/pad_bookroom/goldstab001.tga
+	qer_editorimage textures/pad_bookroom/goldstab001
 	{
-		map textures/pad_bookroom/goldstab001.tga
+		map textures/pad_bookroom/goldstab001
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
 }
 
-
 textures/pad_bookroom/goldstab002
 {
-	qer_editorimage textures/pad_bookroom/goldstab002.tga
+	qer_editorimage textures/pad_bookroom/goldstab002
 	{
-		map textures/pad_bookroom/goldstab002.tga
+		map textures/pad_bookroom/goldstab002
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -119,61 +108,59 @@ textures/pad_bookroom/goldstab002
 
 textures/pad_bookroom/goldstab003
 {
-	qer_editorimage textures/pad_bookroom/goldstab003.tga
+	qer_editorimage textures/pad_bookroom/goldstab003
 	{
-		map textures/pad_bookroom/goldstab003.tga
+		map textures/pad_bookroom/goldstab003
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
 }
-
 
 textures/pad_bookroom/goldstab004
 {
-	qer_editorimage textures/pad_bookroom/goldstab004.tga
+	qer_editorimage textures/pad_bookroom/goldstab004
 	{
-		map textures/pad_bookroom/goldstab004.tga
+		map textures/pad_bookroom/goldstab004
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
 }
 
-
 textures/pad_bookroom/goldstab005
 {
-	qer_editorimage textures/pad_bookroom/goldstab005.tga
+	qer_editorimage textures/pad_bookroom/goldstab005
 	{
-		map textures/pad_bookroom/goldstab005.tga
+		map textures/pad_bookroom/goldstab005
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -181,84 +168,80 @@ textures/pad_bookroom/goldstab005
 
 textures/pad_bookroom/goldstab006
 {
-	qer_editorimage textures/pad_bookroom/goldstab006.tga
+	qer_editorimage textures/pad_bookroom/goldstab006
 	{
-		map textures/pad_bookroom/goldstab006.tga
+		map textures/pad_bookroom/goldstab006
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
 }
 
-
 textures/pad_bookroom/bleifenster001
 {
-	qer_editorimage textures/pad_bookroom/bleifenster001.tga
+	qer_editorimage textures/pad_bookroom/bleifenster001
 	surfaceparm trans
-        cull none
-        qer_trans 0.6
-        {
-		map textures/pad_bookroom/bleifenster001.tga
+	cull none
+	qer_trans 0.6
+	{
+		map textures/pad_bookroom/bleifenster001
 		blendfunc gl_dst_color gl_zero
 	}
 }
 
 textures/pad_bookroom/bleifenster002
 {
-	qer_editorimage textures/pad_bookroom/bleifenster002.tga
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     tessSize 64
-        cull none
-        qer_trans 0.6
-        {
-		map textures/pad_bookroom/bleifenster002.tga
-                alphaFunc GE128
+	qer_editorimage textures/pad_bookroom/bleifenster002
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	tessSize 64
+	cull none
+	qer_trans 0.6
+	{
+		map textures/pad_bookroom/bleifenster002
+		alphaFunc GE128
 		blendfunc gl_dst_color gl_zero
 	}
 }
 
-
 textures/pad_bookroom/globusmass
 {
-	qer_editorimage textures/pad_bookroom/globusmass.tga
+	qer_editorimage textures/pad_bookroom/globusmass
 	{
-		map textures/pad_bookroom/globusmass.tga
+		map textures/pad_bookroom/globusmass
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
 }
 
-
 textures/pad_bookroom/lightyy
 {
-    q3map_surfacelight 5
-    surfaceparm nolightmap
-    {
-        map textures/pad_bookroom/lightyy.tga
-    }
+	q3map_surfacelight 5
+	surfaceparm nolightmap
+	{
+		map textures/pad_bookroom/lightyy
+	}
 }
-
 
 textures/pad_bookroom/telepaddy
 {
@@ -266,10 +249,10 @@ textures/pad_bookroom/telepaddy
 	surfaceparm nonsolid
 	cull twosided
 	{
-		map textures/pad_bookroom/telepaddy.tga
+		map textures/pad_bookroom/telepaddy
 		tcGen environment
-                tcMod turb 0 0.25 0 0.2
-                tcmod scroll 1 1
+		tcMod turb 0 0.25 0 0.2
+		tcmod scroll 1 1
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -281,21 +264,21 @@ textures/pad_bookroom/blobbypad
 	surfaceparm nonsolid
 	cull twosided
 
-	deformVertexes wave 30 sin 0 5 0 0.2 
-	deformVertexes wave 100 sin 0 4 0 0.1 
+	deformVertexes wave 30 sin 0 5 0 0.2
+	deformVertexes wave 100 sin 0 4 0 0.1
 	tessSize 48
 	qer_trans 0.5
 	{
-		map textures/pad_bookroom/blobbypad.tga
+		map textures/pad_bookroom/blobbypad
 		tcGen environment
-                tcMod turb 0 0.35 0 0.25
-                tcmod scroll -0.6 -0.8
+		tcMod turb 0 0.35 0 0.25
+		tcmod scroll -0.6 -0.8
 	}
 	{
-		map textures/pad_bookroom/blobbypad.tga
+		map textures/pad_bookroom/blobbypad
 		tcGen environment
-                tcMod turb 0 0.25 0 0.5
-                tcmod scroll 1 1
+		tcMod turb 0 0.25 0 0.5
+		tcmod scroll 1 1
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -303,19 +286,19 @@ textures/pad_bookroom/blobbypad
 
 textures/pad_bookroom/bomarble01
 {
-	qer_editorimage textures/pad_bookroom/bomarble01.tga
+	qer_editorimage textures/pad_bookroom/bomarble01
 	{
-		map textures/pad_bookroom/bomarble01.tga
+		map textures/pad_bookroom/bomarble01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -323,19 +306,19 @@ textures/pad_bookroom/bomarble01
 
 textures/pad_bookroom/bomarble01_dark
 {
-	qer_editorimage textures/pad_bookroom/bomarble01_dark.tga
+	qer_editorimage textures/pad_bookroom/bomarble01_dark
 	{
-		map textures/pad_bookroom/bomarble01_dark.tga
+		map textures/pad_bookroom/bomarble01_dark
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -343,19 +326,19 @@ textures/pad_bookroom/bomarble01_dark
 
 textures/pad_bookroom/bomarble01b
 {
-	qer_editorimage textures/pad_bookroom/bomarble01b.tga
+	qer_editorimage textures/pad_bookroom/bomarble01b
 	{
-		map textures/pad_bookroom/bomarble01b.tga
+		map textures/pad_bookroom/bomarble01b
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -363,19 +346,19 @@ textures/pad_bookroom/bomarble01b
 
 textures/pad_bookroom/bomarble01blue
 {
-	qer_editorimage textures/pad_bookroom/bomarble01blue.tga
+	qer_editorimage textures/pad_bookroom/bomarble01blue
 	{
-		map textures/pad_bookroom/bomarble01blue.tga
+		map textures/pad_bookroom/bomarble01blue
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -383,19 +366,19 @@ textures/pad_bookroom/bomarble01blue
 
 textures/pad_bookroom/bomarble01blue_dark
 {
-	qer_editorimage textures/pad_bookroom/bomarble01blue_dark.tga
+	qer_editorimage textures/pad_bookroom/bomarble01blue_dark
 	{
-		map textures/pad_bookroom/bomarble01blue_dark.tga
+		map textures/pad_bookroom/bomarble01blue_dark
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -403,19 +386,19 @@ textures/pad_bookroom/bomarble01blue_dark
 
 textures/pad_bookroom/bomarble01b_blue
 {
-	qer_editorimage textures/pad_bookroom/bomarble01b_blue.tga
+	qer_editorimage textures/pad_bookroom/bomarble01b_blue
 	{
-		map textures/pad_bookroom/bomarble01b_blue.tga
+		map textures/pad_bookroom/bomarble01b_blue
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -423,180 +406,162 @@ textures/pad_bookroom/bomarble01b_blue
 
 textures/pad_bookroom/bomarble02
 {
-	qer_editorimage textures/pad_bookroom/bomarble02.tga
+	qer_editorimage textures/pad_bookroom/bomarble02
 	{
-		map textures/pad_bookroom/bomarble02.tga
+		map textures/pad_bookroom/bomarble02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
 }
 
-
-
 textures/pad_bookroom/flystars
 {
-       qer_editorimage textures/pad_bookroom/flystars.tga
-       surfaceparm trans	
-       surfaceparm pointlight
-       surfaceparm nomarks	
-       surfaceparm nodamage        
-       surfaceparm nonsolid
-        surfaceparm nolightmap
-        deformVertexes move 2 3 1.5  sin 0 5 0 0.3
-        //deformVertexes move .6 3.3 0  sin 0 5 0 0.4
-        deformVertexes wave 20 sin 0 8 0 .2
-        tessSize 16
-        cull none
-{
-	map $lightmap
-	rgbGen identity	
-	blendfunc gl_zero gl_one
-}
-{
-	
-	map textures/pad_bookroom/flystars.tga
-                tcMod Scroll -5 0.1
-                tcMod turb .3 .25 0 .1
-                blendfunc gl_src_alpha gl_one_minus_src_alpha
-}
-{
- 	map textures/pad_bookroom/flystars2.tga
-                tcMod Scroll 4 -0.5
-                tcMod turb .1 .25 0 -.1
-                blendfunc gl_src_alpha gl_one_minus_src_alpha
-}
+	qer_editorimage textures/pad_bookroom/flystars
+	surfaceparm trans
+	surfaceparm pointlight
+	surfaceparm nomarks
+	surfaceparm nodamage
+	surfaceparm nonsolid
+	surfaceparm nolightmap
+	deformVertexes move 2 3 1.5  sin 0 5 0 0.3
+	//deformVertexes move .6 3.3 0  sin 0 5 0 0.4
+	deformVertexes wave 20 sin 0 8 0 .2
+	tessSize 16
+	cull none
+	{
+		map $lightmap
+		rgbGen identity
+		blendfunc gl_zero gl_one
+	}
+	{
+		map textures/pad_bookroom/flystars
+		tcMod Scroll -5 0.1
+		tcMod turb .3 .25 0 .1
+		blendfunc gl_src_alpha gl_one_minus_src_alpha
+	}
+	{
+		map textures/pad_bookroom/flystars2
+		tcMod Scroll 4 -0.5
+		tcMod turb .1 .25 0 -.1
+		blendfunc gl_src_alpha gl_one_minus_src_alpha
+	}
 }
 
 
 textures/pad_bookroom/pad_flag_blue
 {
-     cull disable
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     tessSize 64
-     deformVertexes wave 30 sin 0 3 0 .2
-     deformVertexes wave 100 sin 0 3 0 .7
-     
-        {
-                map textures/pad_bookroom/pad_flag_blue.tga
-                alphaFunc GE128
+	cull disable
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	tessSize 64
+	deformVertexes wave 30 sin 0 3 0 .2
+	deformVertexes wave 100 sin 0 3 0 .7
+	{
+		map textures/pad_bookroom/pad_flag_blue
+		alphaFunc GE128
 		depthWrite
 		rgbGen vertex
-        }
-        {
+	}
+	{
 		map $lightmap
 		rgbGen identity
 		blendFunc filter
 		depthFunc equal
 	}
-
-
 }
-
 
 textures/pad_bookroom/pad_flag_red
 {
-     cull disable
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     tessSize 64
-     deformVertexes wave 30 sin 0 3 0 .2
-     deformVertexes wave 100 sin 0 3 0 .7
-     
-        {
-                map textures/pad_bookroom/pad_flag_red.tga
-                alphaFunc GE128
+	cull disable
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	tessSize 64
+	deformVertexes wave 30 sin 0 3 0 .2
+	deformVertexes wave 100 sin 0 3 0 .7
+
+	{
+		map textures/pad_bookroom/pad_flag_red
+		alphaFunc GE128
 		depthWrite
 		rgbGen vertex
-        }
-        {
+	}
+	{
 		map $lightmap
 		rgbGen identity
 		blendFunc filter
 		depthFunc equal
 	}
-
-
 }
 
 
 textures/pad_bookroom/beam_pink
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
-        surfaceparm nonsolid
+	surfaceparm trans
+	surfaceparm nomarks
+	surfaceparm nonsolid
 	surfaceparm nolightmap
 	cull none
 	surfaceparm nomipmaps
-        //nopicmip
+	//nopicmip
 	{
-		map textures/pad_bookroom/beam_pink.tga
-                tcMod Scroll .4 0
-                blendFunc add
-        }
-     
+		map textures/pad_bookroom/beam_pink
+		tcMod Scroll .4 0
+		blendFunc add
+	}
 }
 
 textures/pad_bookroom/beam_yellow
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
-        surfaceparm nonsolid
+	surfaceparm trans
+	surfaceparm nomarks
+	surfaceparm nonsolid
 	surfaceparm nolightmap
 	cull none
 	surfaceparm nomipmaps
-        //nopicmip
+	//nopicmip
 	{
-		map textures/pad_bookroom/beam_yellow.tga
-                tcMod Scroll .4 0
-                blendFunc add
-        }
-     
-}
+		map textures/pad_bookroom/beam_yellow
+		tcMod Scroll .4 0
+		blendFunc add
+	}
 
+}
 
 textures/pad_bookroom/portal
 {
-
 	portal
 	surfaceparm nolightmap
 	deformVertexes wave 150 sin 0 1 0 .5
 
-
 	{
-		map textures/pad_bookroom/portal_sfx3.tga
+		map textures/pad_bookroom/portal_sfx3
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
-	//	This blend function is not working on RagePro drivers Mac only
-	//	when it is used on top of portals
+		//	This blend function is not working on RagePro drivers Mac only
+		//	when it is used on top of portals
 		depthWrite
 	}
-
-
-
-
 	{
-		map textures/pad_bookroom/portal_sfx.tga
+		map textures/pad_bookroom/portal_sfx
 		blendfunc gl_one gl_one
 		rgbgen wave inversesawtooth 0 .5 .2 .5
 	}
-
 	{
-		map textures/pad_bookroom/portalfog.tga
+		map textures/pad_bookroom/portalfog
 		blendfunc gl_src_alpha gl_one_minus_src_alpha
 		alphagen portal 1024
-		rgbGen identityLighting	
+		rgbGen identityLighting
 //		tcmod turb sin 0 .5 0 1
 		tcmod rotate .1 //.1
 		tcmod scroll .01 .03
@@ -606,7 +571,7 @@ textures/pad_bookroom/portal
 
 textures/pad_bookroom/hotlava
 {
-	qer_editorimage textures/pad_bookroom/hotlava.tga
+	qer_editorimage textures/pad_bookroom/hotlava
 	q3map_globaltexture
 	surfaceparm trans
 	//surfaceparm nonsolid
@@ -615,13 +580,13 @@ textures/pad_bookroom/hotlava
 	surfaceparm nolightmap
 	q3map_surfacelight 80
 	cull disable
-	
+
 	tesssize 128
 	cull disable
 	//deformVertexes wave 100 sin 3 2 .1 0.1
-	
+
 	{
-		map textures/pad_bookroom/hotlava.tga
+		map textures/pad_bookroom/hotlava
 		tcMod turb 0 .2 0 .1
 	}
 }
@@ -629,937 +594,925 @@ textures/pad_bookroom/hotlava
 
 textures/pad_bookroom/rostgitter
 {
-     cull disable
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     surfaceparm latticesteps
-     tessSize 64
-    
-     
-        {
-                map textures/pad_bookroom/rostgitter.tga
-                alphaFunc GE128
+	cull disable
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	surfaceparm latticesteps
+	tessSize 64
+
+	{
+		map textures/pad_bookroom/rostgitter
+		alphaFunc GE128
 		depthWrite
 		rgbGen vertex
-        }
-        {
+	}
+	{
 		map $lightmap
 		rgbGen identity
 		blendFunc filter
 		depthFunc equal
 	}
-
-
 }
 
 
 textures/pad_bookroom/doc_poe_kid
 {
-     cull disable
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     tessSize 64
-    
-     
-        {
-                map textures/pad_bookroom/doc_poe_kid.tga
-                alphaFunc GE128
+	cull disable
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	tessSize 64
+
+	{
+		map textures/pad_bookroom/doc_poe_kid
+		alphaFunc GE128
 		depthWrite
 		rgbGen identity
-        }
-        {
+	}
+	{
 		map $lightmap
 		rgbGen identity
 		blendFunc filter
 		depthFunc equal
 	}
-
-
 }
 
 textures/pad_bookroom/freud_hari_curie
 {
-     cull disable
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     tessSize 64
-    
-     
-        {
-                map textures/pad_bookroom/freud_hari_curie.tga
-                alphaFunc GE128
+	cull disable
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	tessSize 64
+
+
+	{
+		map textures/pad_bookroom/freud_hari_curie
+		alphaFunc GE128
 		depthWrite
 		rgbGen identity
-        }
-        {
+	}
+	{
 		map $lightmap
 		rgbGen identity
 		blendFunc filter
 		depthFunc equal
 	}
-
-
 }
-
 
 textures/pad_bookroom/zierkante
 {
-     cull disable
-     surfaceparm alphashadow
-     surfaceparm trans	
-     surfaceparm nomarks
-     tessSize 64
-    
-     
-        {
-                map textures/pad_bookroom/zierkante.tga
-                alphaFunc GE128
+	cull disable
+	surfaceparm alphashadow
+	surfaceparm trans
+	surfaceparm nomarks
+	tessSize 64
+
+	{
+		map textures/pad_bookroom/zierkante
+		alphaFunc GE128
 		depthWrite
 		rgbGen identity
-        }
-        {
+	}
+	{
 		map $lightmap
 		rgbGen identity
 		blendFunc filter
 		depthFunc equal
 	}
-
-
 }
 
 
 textures/pad_bookroom/floor_pad03
 {
-surfaceparm carpetsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm carpetsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/floor_pad03
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/floor_pad03.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/tep002
 {
-surfaceparm carpetsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm carpetsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/tep002
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/tep002.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/tep004
 {
-surfaceparm carpetsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm carpetsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/tep004
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/tep004.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/dekostoff001
 {
-surfaceparm carpetsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm carpetsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/dekostoff001
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/dekostoff001.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/dekostoff002
 {
-surfaceparm carpetsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm carpetsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/dekostoff002
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/dekostoff002.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/dekostoff002c
 {
-surfaceparm carpetsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm carpetsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/dekostoff002c
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/dekostoff002c.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/decke005b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/decke005b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/decke005b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/gelan001c
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/gelan001c
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/gelan001c.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/gelan003b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/gelan003b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/gelan003b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/gelan005b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/gelan005b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/gelan005b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/gelan006
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/gelan006
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/gelan006.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/gelan007
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/gelan007
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/gelan007.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/platte02big
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/platte02big
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/platte02big.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/reg001
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/reg001
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/reg001.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/reg002b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/reg002b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/reg002b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/reg002c
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/reg002c
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/reg002c.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/reg003b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/reg003b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/reg003b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/schach001
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/schach001
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/schach001.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/windowboard2
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/windowboard2
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/windowboard2.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/windownutsmall
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/windownutsmall
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/windownutsmall.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodkante001
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodkante001
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodkante001.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodkante002
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodkante002
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodkante002.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodkante003
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodkante003
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodkante003.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodkante004bigc
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodkante004bigc
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodkante004bigc.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodkante005
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodkante005
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodkante005.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodsockel
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodsockel
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodsockel.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodsockelc
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodsockelc
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodsockelc.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier001b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier001b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier001b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier002
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier002
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier002.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier003
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier003
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier003.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier005
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier005
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier005.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 
 textures/pad_bookroom/woodzier005b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier005b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier005b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier005c
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier005c
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier005c.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier006
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier006
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier006.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier006b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier006b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier006b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier007
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier007
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier007.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier008c
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier008c
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier008c.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier011c
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier011c
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier011c.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier012
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier012
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier012.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier001b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier001b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier001b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier015
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier015
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier015.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier018
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier018
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier018.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier019b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier019b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier019b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier019
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier019
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier019.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/wookkante008
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/wookkante008
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/wookkante008.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woood001
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woood001
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woood001.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woood002
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woood002
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woood002.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woood001old2
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woood001old2
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woood001old2.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_wallin/wallcol26
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_wallin/wallcol26
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_wallin/wallcol26.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_wood/wood034
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_wood/wood034
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_wood/wood034.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_wood/wood039
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_wood/wood039
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_wood/wood039.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_wood/wood047
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_wood/wood047
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_wood/wood047.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 
 textures/pad_bookroom/gelaenderstre
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/gelaenderstre
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/gelaenderstre.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/tep001
 {
-surfaceparm carpetsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm carpetsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/tep001
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/tep001.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/wookkante007
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/wookkante007
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/wookkante007.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/wookkante007b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/wookkante007b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/wookkante007b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/woodzier003b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/woodzier003b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/woodzier003b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 textures/pad_bookroom/gelan001b
 {
-surfaceparm woodsteps
-{
-map $lightmap
-rgbGen identity
+	surfaceparm woodsteps
+	{
+		map $lightmap
+		rgbGen identity
+	}
+	{
+		map textures/pad_bookroom/gelan001b
+		blendFunc GL_DST_COLOR GL_ZERO
+		rgbGen identity
+	}
 }
-{
-map textures/pad_bookroom/gelan001b.tga
-blendFunc GL_DST_COLOR GL_ZERO
-rgbGen identity
-}
-} 
 
 
 textures/pad_bookroom/frost-bite
 {
-        qer_editorimage textures/pad_bookroom/frost_bite.tga
+	qer_editorimage textures/pad_bookroom/frost_bite
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_bookroom/frost_color.tga
+	q3map_lightimage textures/pad_bookroom/frost_color
 	q3map_sun	0.754360 0.959199 1.000000 300 50 55
 	q3map_surfacelight 300
 
-        skyparms env/frost-bite512 - -
-//       {
-//		map textures/pad_bookroom/frost-bite.tga
+	skyparms env/frost-bite512 - -
+//	{
+//		map textures/pad_bookroom/frost-bite
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2

--- a/wop/scripts.pk3dir/scripts/pad_cloister.shader
+++ b/wop/scripts.pk3dir/scripts/pad_cloister.shader
@@ -1,10 +1,10 @@
 textures/pad_fountain/utopiaatoll
 {
-        qer_editorimage textures/pad_fountain/utopiaatoll.tga
+        qer_editorimage textures/pad_fountain/utopiaatoll
 
 	surfaceparm noimpact
-	surfaceparm nolightmap             
-                q3map_lightimage textures/pad_fountain/orange02.tga
+	surfaceparm nolightmap
+                q3map_lightimage textures/pad_fountain/orange02
 	q3map_sun	1.000000 0.828885 0.672267 220 100 90
 	q3map_surfacelight 300
 
@@ -16,15 +16,15 @@ textures/pad_fountain/utopiaatoll
 textures/pad_fountain/ground01
 {
 q3map_nonplanar
-q3map_shadeangle 60 l	
+q3map_shadeangle 60 l
 surfaceparm sandsteps
-qer_editorimage textures/pad_fountain/ground01.tga
+qer_editorimage textures/pad_fountain/ground01
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/ground01.tga
+map textures/pad_fountain/ground01
 blendFunc filter
 }
 }
@@ -34,15 +34,15 @@ blendFunc filter
 textures/pad_fountain/stone_01b
 {
 q3map_nonplanar
-q3map_shadeangle 60 l	
+q3map_shadeangle 60 l
 surfaceparm sandsteps
-qer_editorimage textures/pad_fountain/stone_01b.tga
+qer_editorimage textures/pad_fountain/stone_01b
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/stone_01b.tga
+map textures/pad_fountain/stone_01b
 blendFunc filter
 }
 }
@@ -51,15 +51,15 @@ blendFunc filter
 textures/pad_fountain/roughwall008_512
 {
 q3map_nonplanar
-q3map_shadeangle 60 l	
+q3map_shadeangle 60 l
 surfaceparm sandsteps
-qer_editorimage textures/pad_fountain/roughwall008_512.tga
+qer_editorimage textures/pad_fountain/roughwall008_512
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/roughwall008_512.tga
+map textures/pad_fountain/roughwall008_512
 blendFunc filter
 }
 }
@@ -73,7 +73,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/tep003_512.tga
+map textures/pad_fountain/tep003_512
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -88,7 +88,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/dekostoff.tga
+map textures/pad_fountain/dekostoff
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -103,7 +103,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/balken01_512.tga
+map textures/pad_fountain/balken01_512
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -117,7 +117,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/balken01_end.tga
+map textures/pad_fountain/balken01_end
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -132,7 +132,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/blue_woood001old.tga
+map textures/pad_fountain/blue_woood001old
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -146,7 +146,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/red_woood001old.tga
+map textures/pad_fountain/red_woood001old
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -160,7 +160,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/woodleiste01.tga
+map textures/pad_fountain/woodleiste01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -175,7 +175,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/woodleiste02.tga
+map textures/pad_fountain/woodleiste02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -189,7 +189,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_fountain/woodchair01.tga
+map textures/pad_fountain/woodchair01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -198,14 +198,14 @@ rgbGen identity
 
 textures/pad_fountain/seicurve
 {
-          qer_editorimage textures/pad_fountain/seilbrunnen.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_fountain/seilbrunnen
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_fountain/seilbrunnen.tga
+		map textures/pad_fountain/seilbrunnen
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -213,14 +213,14 @@ textures/pad_fountain/seicurve
 
 textures/pad_fountain/oldmetalcurve
 {
-          qer_editorimage textures/pad_fountain/oldmetal.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_fountain/oldmetal
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_fountain/oldmetal.tga
+		map textures/pad_fountain/oldmetal
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}

--- a/wop/scripts.pk3dir/scripts/pad_cyb.shader
+++ b/wop/scripts.pk3dir/scripts/pad_cyb.shader
@@ -1,19 +1,19 @@
 
 textures/pad_cyb/mirroreng_01
 {
-	qer_editorimage textures/pad_cyb/mirroreng_01.tga
+	qer_editorimage textures/pad_cyb/mirroreng_01
 	{
-		map textures/pad_cyb/mirroreng_01.tga
+		map textures/pad_cyb/mirroreng_01
 		rgbGen identity
 	}
 	{
-		map textures/pad_cyb/mirrorglass_02.tga
+		map textures/pad_cyb/mirrorglass_02
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -22,19 +22,19 @@ textures/pad_cyb/mirroreng_01
 
 textures/pad_cyb/mirroreng_02
 {
-	qer_editorimage textures/pad_cyb/mirroreng_02.tga
+	qer_editorimage textures/pad_cyb/mirroreng_02
 	{
-		map textures/pad_cyb/mirroreng_02.tga
+		map textures/pad_cyb/mirroreng_02
 		rgbGen identity
 	}
 	{
-		map textures/pad_cyb/mirrorglass_03.tga
+		map textures/pad_cyb/mirrorglass_03
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -42,13 +42,13 @@ textures/pad_cyb/mirroreng_02
 
 textures/pad_cyb/plas_white
 {
-	qer_editorimage textures/pad_cyb/plas_white.tga
+	qer_editorimage textures/pad_cyb/plas_white
 	{
-		map textures/pad_cyb/plas_white.tga
+		map textures/pad_cyb/plas_white
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -67,40 +67,40 @@ textures/pad_cyb/plas_white
 // *  cybbath: water-shader -> by MopAn, made with particle studio, thanks to the creators
 // *
 // ***********************************************************
-textures/pad_cyb/waterstream 
-{ 
-qer_editorimage textures/pad_cyb/waterstream.tga 
-q3map_globaltexture 
-surfaceparm nonsolid 
-surfaceparm nolightmap 
-surfaceparm trans 
-surfaceparm noimpact 
-surfaceparm water 
-tessSize 32 
-deformVertexes move 0.2 0.5 0 sin 0 1 0.2 0.2 
-deformVertexes move 0.5 0.3 0 sin 0 1 0 0.4 
-//deformVertexes wave 32 sin 0 10 0 .2 
-cull disable 
-{ 
-map textures/pad_cyb/waterstream.tga 
-blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR 
-tcMod scale 0.4 0.55 
-tcMod turb .1 .08 .25 .08 
-tcMod scroll 0.005 -1 
-} 
-{ 
-map textures/pad_cyb/waterstream.tga 
-blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR 
-tcMod scale 0.5 0.45 
-tcMod turb .1 .05 .25 .08 
-tcMod scroll 0.008 -0.6 
-} 
-} 
+textures/pad_cyb/waterstream
+{
+qer_editorimage textures/pad_cyb/waterstream
+q3map_globaltexture
+surfaceparm nonsolid
+surfaceparm nolightmap
+surfaceparm trans
+surfaceparm noimpact
+surfaceparm water
+tessSize 32
+deformVertexes move 0.2 0.5 0 sin 0 1 0.2 0.2
+deformVertexes move 0.5 0.3 0 sin 0 1 0 0.4
+//deformVertexes wave 32 sin 0 10 0 .2
+cull disable
+{
+map textures/pad_cyb/waterstream
+blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
+tcMod scale 0.4 0.55
+tcMod turb .1 .08 .25 .08
+tcMod scroll 0.005 -1
+}
+{
+map textures/pad_cyb/waterstream
+blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
+tcMod scale 0.5 0.45
+tcMod turb .1 .05 .25 .08
+tcMod scroll 0.008 -0.6
+}
+}
 
 
 textures/pad_cyb/bubbles2_1
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -110,7 +110,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.093287 -41.198784 541 sawtooth 0 1 1.000725 0.195925
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 20.229958
 AlphaGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
 rgbGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
@@ -121,7 +121,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_2
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -131,7 +131,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.769913 -21.519264 489 sawtooth 0 1 0.622631 0.252309
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 2.200842
 AlphaGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
 rgbGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
@@ -142,7 +142,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_3
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -152,7 +152,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.625161 -6.980746 407 sawtooth 0 1 1.213530 0.445164
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 19.405041
 AlphaGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
 rgbGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
@@ -163,7 +163,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_4
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -173,7 +173,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.668365 -12.663155 459 sawtooth 0 1 1.085688 0.300365
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 11.414990
 AlphaGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
 rgbGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
@@ -184,7 +184,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_5
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -194,7 +194,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.763139 -30.482132 551 sawtooth 0 1 0.288759 0.189146
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 1.619465
 AlphaGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
 rgbGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
@@ -205,7 +205,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_6
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -215,7 +215,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.834942 -10.679131 430 sawtooth 0 1 1.237915 0.365962
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate -2.907956
 AlphaGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
 rgbGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
@@ -226,7 +226,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_7
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -236,7 +236,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.454388 -41.883984 527 sawtooth 0 1 0.402287 0.207241
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 3.890042
 AlphaGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
 rgbGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
@@ -247,7 +247,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_8
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -257,7 +257,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.112141 -36.627399 516 sawtooth 0 1 0.784623 0.218790
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 24.587999
 AlphaGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
 rgbGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
@@ -268,7 +268,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_9
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -278,7 +278,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 13.988351 -11.087501 503 sawtooth 0 1 1.044519 0.235235
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 12.468795
 AlphaGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
 rgbGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
@@ -289,7 +289,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_10
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -299,7 +299,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 10.265741 7.714635 531 sawtooth 0 1 0.524331 0.144779
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 12.796563
 AlphaGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
 rgbGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
@@ -310,7 +310,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_11
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -320,7 +320,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 25.100649 4.780672 486 sawtooth 0 1 0.907308 0.255448
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate 16.214331
 AlphaGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
 rgbGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
@@ -331,7 +331,7 @@ blendfunc add
 
 textures/pad_cyb/bubbles2_12
 {
-qer_editorimage textures/pad_cyb/bubbles2.tga
+qer_editorimage textures/pad_cyb/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -341,7 +341,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 12.983425 -1.691125 395 sawtooth 0 1 0.845538 0.495670
 {
-clampmap textures/pad_cyb/bubbles2.tga
+clampmap textures/pad_cyb/bubbles2
 tcMod rotate -2.724845
 AlphaGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
 rgbGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
@@ -352,13 +352,13 @@ blendfunc add
 
 
 textures/pad_cyb/pad_cyb_rust1
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
-   
+
         {
-		map textures/pad_cyb/pad_cyb_rust1.tga
+		map textures/pad_cyb/pad_cyb_rust1
                		blendFunc add
 		rgbGen vertex
 	}
@@ -367,7 +367,7 @@ textures/pad_cyb/pad_cyb_rust1
 
 textures/pad_cyb/screw1
 {
-        qer_editorimage textures/pad_cyb/screw1.tga
+        qer_editorimage textures/pad_cyb/screw1
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -375,7 +375,7 @@ textures/pad_cyb/screw1
 	cull none
         nopicmip
 	{
-		map textures/pad_cyb/screw1.tga
+		map textures/pad_cyb/screw1
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -398,7 +398,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_objects02/pad_tuch.tga
+map textures/pad_objects02/pad_tuch
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -412,7 +412,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_harm/metalline03b.tga
+map textures/pad_harm/metalline03b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -426,7 +426,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cyb/schie04.tga
+map textures/pad_cyb/schie04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -434,8 +434,8 @@ rgbGen identity
 
 textures/pad_cyb/toiletwater
 {
-	qer_editorimage textures/pad_cyb/wat_002.tga
-	q3map_lightimage textures/pad_cyb/wat_002.tga
+	qer_editorimage textures/pad_cyb/wat_002
+	q3map_lightimage textures/pad_cyb/wat_002
 	surfaceparm nodrop
 	surfaceparm noimpact
 	// surfaceparm nolightmap
@@ -443,13 +443,13 @@ textures/pad_cyb/toiletwater
 	surfaceparm nonsolid
 	surfaceparm trans
 	cull disable
-	deformVertexes wave 30 sin 0 4 0 0.2 
-	deformVertexes wave 100 sin 0 4 0 0.7 
+	deformVertexes wave 30 sin 0 4 0 0.2
+	deformVertexes wave 100 sin 0 4 0 0.7
 	tessSize 48
 	qer_trans 0.5
-	
+
 	{
-		map textures/pad_cyb/wat002.tga
+		map textures/pad_cyb/wat002
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.4 0.3 1 0.05
@@ -461,19 +461,19 @@ textures/pad_cyb/toiletwater
 
 textures/pad_cyb/marble_toilet002
 {
-	qer_editorimage textures/pad_cyb/marble_toilet002.tga
-	
+	qer_editorimage textures/pad_cyb/marble_toilet002
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_cyb/marble_toilet002.tga
+		map textures/pad_cyb/marble_toilet002
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_effects/pad_marblefx1.tga
+		map textures/pad_effects/pad_marblefx1
 		tcgen environment
 		blendfunc add
 		rgbgen identity

--- a/wop/scripts.pk3dir/scripts/pad_effects.shader
+++ b/wop/scripts.pk3dir/scripts/pad_effects.shader
@@ -1,18 +1,18 @@
 textures/pad_marblefx/marble22
 {
-	qer_editorimage textures/pad_marble/marble22.tga
-	
+	qer_editorimage textures/pad_marble/marble22
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_marble/marble22.tga
+		map textures/pad_marble/marble22
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_effects/pad_marblefx1.tga
+		map textures/pad_effects/pad_marblefx1
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -21,19 +21,19 @@ textures/pad_marblefx/marble22
 
 textures/pad_marblefx/marble27
 {
-	qer_editorimage textures/pad_marble/marble27.tga
-	
+	qer_editorimage textures/pad_marble/marble27
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_marble/marble27.tga
+		map textures/pad_marble/marble27
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_effects/pad_marblefx1.tga
+		map textures/pad_effects/pad_marblefx1
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -42,19 +42,19 @@ textures/pad_marblefx/marble27
 
 textures/pad_marblefx/marble17
 {
-	qer_editorimage textures/pad_marblefx/marble17.tga
-	
+	qer_editorimage textures/pad_marblefx/marble17
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_marblefx/marble17.tga
+		map textures/pad_marblefx/marble17
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_effects/pad_marblefx1.tga
+		map textures/pad_effects/pad_marblefx1
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -63,19 +63,19 @@ textures/pad_marblefx/marble17
 
 textures/pad_marblefx/marble10
 {
-	qer_editorimage textures/pad_marblefx/marble10.tga
-	
+	qer_editorimage textures/pad_marblefx/marble10
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_marblefx/marble10.tga
+		map textures/pad_marblefx/marble10
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_effects/pad_marblefx1.tga
+		map textures/pad_effects/pad_marblefx1
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -88,7 +88,7 @@ textures/pad_marblefx/marble10
 
 textures/particles/smoke_1
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -98,7 +98,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -6.939269 -6.384233 85.880608 sawtooth 0 1 0.289346 0.500282
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.856960
 AlphaGen wave sawtooth 0.910858 -0.835838 0.289346 0.500282
 rgbGen wave sawtooth 0.836573 -0.747200 0.289346 0.500282
@@ -109,7 +109,7 @@ blendfunc blend
 
 textures/particles/smoke_2
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -119,7 +119,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.945118 -7.180432 129.940796 sawtooth 0 1 0.412030 0.376360
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 12.846309
 AlphaGen wave sawtooth 1.095105 -0.964296 0.412030 0.376360
 rgbGen wave sawtooth 0.832240 -0.750917 0.412030 0.376360
@@ -130,7 +130,7 @@ blendfunc blend
 
 textures/particles/smoke_3
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -140,7 +140,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.028154 4.169074 117.624290 sawtooth 0 1 0.992584 0.342096
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.964446
 AlphaGen wave sawtooth 0.969442 -0.865819 0.992584 0.342096
 rgbGen wave sawtooth 0.957768 -0.981552 0.992584 0.342096
@@ -151,7 +151,7 @@ blendfunc blend
 
 textures/particles/smoke_4
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -161,7 +161,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.269272 -8.604949 85.946678 sawtooth 0 1 0.927458 0.481238
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.892118
 AlphaGen wave sawtooth 0.971249 -1.046257 0.927458 0.481238
 rgbGen wave sawtooth 0.923368 -0.929664 0.927458 0.481238
@@ -172,7 +172,7 @@ blendfunc blend
 
 textures/particles/smoke_5
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -182,7 +182,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.379093 6.909052 113.207039 sawtooth 0 1 0.709464 0.422816
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.320322
 AlphaGen wave sawtooth 0.906073 -0.713605 0.709464 0.422816
 rgbGen wave sawtooth 0.978253 -0.982626 0.709464 0.422816
@@ -193,7 +193,7 @@ blendfunc blend
 
 textures/particles/smoke_6
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -203,7 +203,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.884490 -5.924822 48.065464 sawtooth 0 1 0.818781 0.923456
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 12.313150
 AlphaGen wave sawtooth 0.922871 -0.997610 0.818781 0.923456
 rgbGen wave sawtooth 0.972662 -0.898206 0.818781 0.923456
@@ -214,7 +214,7 @@ blendfunc blend
 
 textures/particles/smoke_7
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -224,7 +224,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 26.218987 -0.041475 123.659401 sawtooth 0 1 0.008026 0.340546
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 14.944151
 AlphaGen wave sawtooth 1.087982 -1.253288 0.008026 0.340546
 rgbGen wave sawtooth 0.954057 -0.931190 0.008026 0.340546
@@ -235,7 +235,7 @@ blendfunc blend
 
 textures/particles/smoke_8
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -245,7 +245,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.477392 -5.943108 53.472839 sawtooth 0 1 0.297647 0.914743
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.231696
 AlphaGen wave sawtooth 1.030497 -0.839213 0.297647 0.914743
 rgbGen wave sawtooth 1.097531 -1.082025 0.297647 0.914743
@@ -256,7 +256,7 @@ blendfunc blend
 
 textures/particles/smoke_9
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -266,7 +266,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -10.276326 5.444337 93.154129 sawtooth 0 1 0.831843 0.504581
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.797907
 AlphaGen wave sawtooth 0.931281 -0.967421 0.831843 0.504581
 rgbGen wave sawtooth 0.818726 -0.899786 0.831843 0.504581
@@ -277,7 +277,7 @@ blendfunc blend
 
 textures/particles/smoke_10
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -287,7 +287,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.618435 12.536134 143.811890 sawtooth 0 1 0.788293 0.336172
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 13.632771
 AlphaGen wave sawtooth 1.046458 -1.073980 0.788293 0.336172
 rgbGen wave sawtooth 1.184362 -1.236778 0.788293 0.336172
@@ -298,7 +298,7 @@ blendfunc blend
 
 textures/particles/smoke_11
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -308,7 +308,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -15.355134 -3.806510 118.534966 sawtooth 0 1 0.579394 0.385944
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.128452
 AlphaGen wave sawtooth 1.081439 -1.220988 0.579394 0.385944
 rgbGen wave sawtooth 0.896231 -0.984152 0.579394 0.385944
@@ -319,7 +319,7 @@ blendfunc blend
 
 textures/particles/smoke_12
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -329,7 +329,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 13.461285 10.031071 73.598740 sawtooth 0 1 0.087191 0.654698
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 14.777520
 AlphaGen wave sawtooth 1.006705 -1.061852 0.087191 0.654698
 rgbGen wave sawtooth 0.855068 -0.779489 0.087191 0.654698
@@ -340,7 +340,7 @@ blendfunc blend
 
 textures/particles/smoke_13
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -350,7 +350,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.429579 -3.013232 84.057297 sawtooth 0 1 0.008026 0.545726
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.633442
 AlphaGen wave sawtooth 0.965474 -0.875719 0.008026 0.545726
 rgbGen wave sawtooth 1.133128 -1.051610 0.008026 0.545726
@@ -361,7 +361,7 @@ blendfunc blend
 
 textures/particles/smoke_14
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -371,7 +371,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.585922 -7.593271 96.890709 sawtooth 0 1 0.386120 0.412948
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.521409
 AlphaGen wave sawtooth 0.928443 -0.782888 0.386120 0.412948
 rgbGen wave sawtooth 0.902152 -0.834800 0.386120 0.412948
@@ -382,7 +382,7 @@ blendfunc blend
 
 textures/particles/smoke_15
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -392,7 +392,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.404958 -6.015783 101.459351 sawtooth 0 1 0.731498 0.395550
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 12.642140
 AlphaGen wave sawtooth 0.953053 -0.803140 0.731498 0.395550
 rgbGen wave sawtooth 1.111777 -1.210953 0.731498 0.395550
@@ -403,7 +403,7 @@ blendfunc blend
 
 textures/particles/smoke_16
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -413,7 +413,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 4.656298 -2.504164 84.544159 sawtooth 0 1 0.753899 0.496673
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 12.551805
 AlphaGen wave sawtooth 1.048015 -0.869658 0.753899 0.496673
 rgbGen wave sawtooth 0.973846 -0.900208 0.753899 0.496673
@@ -424,7 +424,7 @@ blendfunc blend
 
 textures/particles/smoke_17
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -434,7 +434,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.355882 11.416430 103.902374 sawtooth 0 1 0.128574 0.456181
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 13.204291
 AlphaGen wave sawtooth 0.980410 -1.175857 0.128574 0.456181
 rgbGen wave sawtooth 0.823060 -0.899500 0.128574 0.456181
@@ -445,7 +445,7 @@ blendfunc blend
 
 textures/particles/smoke_18
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -455,7 +455,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.295161 8.240472 43.423256 sawtooth 0 1 0.870815 0.985385
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.081637
 AlphaGen wave sawtooth 1.044627 -1.128108 0.870815 0.985385
 rgbGen wave sawtooth 0.929655 -0.830924 0.870815 0.985385
@@ -466,7 +466,7 @@ blendfunc blend
 
 textures/particles/smoke_19
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -476,7 +476,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.019771 10.853085 135.160812 sawtooth 0 1 0.357585 0.352587
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.368328
 AlphaGen wave sawtooth 1.087457 -1.188003 0.357585 0.352587
 rgbGen wave sawtooth 0.899197 -0.889459 0.357585 0.352587
@@ -487,7 +487,7 @@ blendfunc blend
 
 textures/particles/smoke_20
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -497,7 +497,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.793026 2.544403 127.858986 sawtooth 0 1 0.271554 0.373392
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.599139
 AlphaGen wave sawtooth 0.902148 -0.812198 0.271554 0.373392
 rgbGen wave sawtooth 1.005512 -0.942732 0.271554 0.373392
@@ -508,7 +508,7 @@ blendfunc blend
 
 textures/particles/smoke_21
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -518,7 +518,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.345068 -3.657920 71.518494 sawtooth 0 1 0.001099 0.685430
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.216651
 AlphaGen wave sawtooth 1.016758 -1.146797 0.001099 0.685430
 rgbGen wave sawtooth 1.186523 -1.162880 0.001099 0.685430
@@ -529,7 +529,7 @@ blendfunc blend
 
 textures/particles/smoke_22
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -539,7 +539,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.392414 5.140803 53.178219 sawtooth 0 1 0.706015 0.796534
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 11.084781
 AlphaGen wave sawtooth 0.908417 -1.048698 0.706015 0.796534
 rgbGen wave sawtooth 1.179174 -1.158943 0.706015 0.796534
@@ -550,7 +550,7 @@ blendfunc blend
 
 textures/particles/smoke_23
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -560,7 +560,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -17.109825 -14.071120 98.836731 sawtooth 0 1 0.774163 0.411382
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 14.660329
 AlphaGen wave sawtooth 0.950368 -0.965938 0.774163 0.411382
 rgbGen wave sawtooth 0.823304 -0.917908 0.774163 0.411382
@@ -571,7 +571,7 @@ blendfunc blend
 
 textures/particles/smoke_24
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -581,7 +581,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.810009 0.620142 50.984493 sawtooth 0 1 0.096835 0.800816
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.988494
 AlphaGen wave sawtooth 1.004349 -1.198367 0.096835 0.800816
 rgbGen wave sawtooth 0.957988 -1.007266 0.096835 0.800816
@@ -592,7 +592,7 @@ blendfunc blend
 
 textures/particles/smoke_25
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -602,7 +602,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.332218 4.659520 127.977509 sawtooth 0 1 0.839686 0.343509
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.848384
 AlphaGen wave sawtooth 0.940248 -1.052367 0.839686 0.343509
 rgbGen wave sawtooth 0.828895 -0.771981 0.839686 0.343509
@@ -613,7 +613,7 @@ blendfunc blend
 
 textures/particles/smoke_26
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -623,7 +623,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 24.519669 -0.010577 110.834763 sawtooth 0 1 0.582812 0.381220
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.397504
 AlphaGen wave sawtooth 1.098846 -1.164760 0.582812 0.381220
 rgbGen wave sawtooth 0.874868 -0.830735 0.582812 0.381220
@@ -634,7 +634,7 @@ blendfunc blend
 
 textures/particles/smoke_27
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -644,7 +644,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.306522 -14.182501 91.389076 sawtooth 0 1 0.715201 0.466840
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.555498
 AlphaGen wave sawtooth 0.946565 -0.885034 0.715201 0.466840
 rgbGen wave sawtooth 1.057979 -1.146901 0.715201 0.466840
@@ -655,7 +655,7 @@ blendfunc blend
 
 textures/particles/smoke_28
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -665,7 +665,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.206702 -14.449759 91.654655 sawtooth 0 1 0.910825 0.506390
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.492325
 AlphaGen wave sawtooth 1.084393 -1.095813 0.910825 0.506390
 rgbGen wave sawtooth 1.122495 -1.138142 0.910825 0.506390
@@ -676,7 +676,7 @@ blendfunc blend
 
 textures/particles/smoke_29
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -686,7 +686,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.121578 8.072025 106.152489 sawtooth 0 1 0.646748 0.454082
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.302011
 AlphaGen wave sawtooth 0.959188 -1.113825 0.646748 0.454082
 rgbGen wave sawtooth 1.078231 -1.080761 0.646748 0.454082
@@ -697,7 +697,7 @@ blendfunc blend
 
 textures/particles/smoke_30
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -707,7 +707,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.812543 7.632322 114.315247 sawtooth 0 1 0.607685 0.348730
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.866603
 AlphaGen wave sawtooth 0.948213 -1.141377 0.607685 0.348730
 rgbGen wave sawtooth 1.031770 -1.108740 0.607685 0.348730
@@ -718,7 +718,7 @@ blendfunc blend
 
 textures/particles/smoke_31
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -728,7 +728,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.616240 8.487638 139.070587 sawtooth 0 1 0.797082 0.354472
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.559160
 AlphaGen wave sawtooth 0.967269 -1.032804 0.797082 0.354472
 rgbGen wave sawtooth 0.939116 -0.936805 0.797082 0.354472
@@ -739,7 +739,7 @@ blendfunc blend
 
 textures/particles/smoke_32
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -749,7 +749,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.324331 -8.677237 105.810257 sawtooth 0 1 0.542375 0.411713
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.752281
 AlphaGen wave sawtooth 0.999063 -0.908112 0.542375 0.411713
 rgbGen wave sawtooth 1.157567 -1.208939 0.542375 0.411713
@@ -760,7 +760,7 @@ blendfunc blend
 
 textures/particles/smoke_33
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -770,7 +770,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.354257 -0.140947 62.301701 sawtooth 0 1 0.768914 0.710426
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.329967
 AlphaGen wave sawtooth 1.084533 -1.080316 0.768914 0.710426
 rgbGen wave sawtooth 1.166576 -1.095434 0.768914 0.710426
@@ -781,7 +781,7 @@ blendfunc blend
 
 textures/particles/smoke_34
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -791,7 +791,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.644679 -0.003863 87.381866 sawtooth 0 1 0.312937 0.479702
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 14.972838
 AlphaGen wave sawtooth 1.045897 -1.164888 0.312937 0.479702
 rgbGen wave sawtooth 0.822913 -0.798910 0.312937 0.479702
@@ -802,7 +802,7 @@ blendfunc blend
 
 textures/particles/smoke_35
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -812,7 +812,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.087338 -2.451592 113.849030 sawtooth 0 1 0.985687 0.359891
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.053164
 AlphaGen wave sawtooth 1.058208 -0.862749 0.985687 0.359891
 rgbGen wave sawtooth 1.090353 -1.146974 0.985687 0.359891
@@ -823,7 +823,7 @@ blendfunc blend
 
 textures/particles/smoke_36
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -833,7 +833,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.774775 3.221578 94.302666 sawtooth 0 1 0.979827 0.444570
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 11.750084
 AlphaGen wave sawtooth 0.996243 -0.973385 0.979827 0.444570
 rgbGen wave sawtooth 0.942582 -1.031327 0.979827 0.444570
@@ -844,7 +844,7 @@ blendfunc blend
 
 textures/particles/smoke_37
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -854,7 +854,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 11.836599 1.337401 116.234505 sawtooth 0 1 0.407910 0.410949
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.295571
 AlphaGen wave sawtooth 1.013816 -1.166414 0.407910 0.410949
 rgbGen wave sawtooth 1.040486 -0.975655 0.407910 0.410949
@@ -865,7 +865,7 @@ blendfunc blend
 
 textures/particles/smoke_38
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -875,7 +875,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.533556 -7.486302 93.571205 sawtooth 0 1 0.645619 0.467119
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.564470
 AlphaGen wave sawtooth 1.014310 -1.124793 0.645619 0.467119
 rgbGen wave sawtooth 0.847450 -0.795895 0.645619 0.467119
@@ -886,7 +886,7 @@ blendfunc blend
 
 textures/particles/smoke_39
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -896,7 +896,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -20.364191 2.380052 89.824013 sawtooth 0 1 0.096194 0.535137
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 13.397779
 AlphaGen wave sawtooth 0.939674 -0.784793 0.096194 0.535137
 rgbGen wave sawtooth 0.883731 -0.862535 0.096194 0.535137
@@ -907,7 +907,7 @@ blendfunc blend
 
 textures/particles/smoke_40
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -917,7 +917,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.577989 11.014657 137.338181 sawtooth 0 1 0.876125 0.346415
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.386670
 AlphaGen wave sawtooth 0.916877 -0.728022 0.876125 0.346415
 rgbGen wave sawtooth 1.113449 -1.069134 0.876125 0.346415
@@ -928,7 +928,7 @@ blendfunc blend
 
 textures/particles/smoke_41
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -938,7 +938,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.164047 -4.741383 68.137306 sawtooth 0 1 0.367626 0.624193
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 6.331522
 AlphaGen wave sawtooth 1.020127 -0.824912 0.367626 0.624193
 rgbGen wave sawtooth 1.062777 -0.963900 0.367626 0.624193
@@ -949,7 +949,7 @@ blendfunc blend
 
 textures/particles/smoke_42
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -959,7 +959,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.730497 -4.556999 43.462521 sawtooth 0 1 0.591113 0.993090
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.990814
 AlphaGen wave sawtooth 0.913422 -0.795395 0.591113 0.993090
 rgbGen wave sawtooth 0.911881 -0.911176 0.591113 0.993090
@@ -970,7 +970,7 @@ blendfunc blend
 
 textures/particles/smoke_43
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -980,7 +980,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.116012 14.961886 111.689575 sawtooth 0 1 0.858058 0.395474
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 14.787591
 AlphaGen wave sawtooth 1.009799 -0.937892 0.858058 0.395474
 rgbGen wave sawtooth 0.998285 -1.065722 0.858058 0.395474
@@ -991,7 +991,7 @@ blendfunc blend
 
 textures/particles/smoke_44
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1001,7 +1001,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.031915 1.297677 104.411438 sawtooth 0 1 0.455000 0.413908
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.989990
 AlphaGen wave sawtooth 0.941108 -1.079693 0.455000 0.413908
 rgbGen wave sawtooth 0.992621 -1.038597 0.455000 0.413908
@@ -1012,7 +1012,7 @@ blendfunc blend
 
 textures/particles/smoke_45
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1022,7 +1022,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.348561 -15.756088 89.186478 sawtooth 0 1 0.819056 0.449288
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 12.159337
 AlphaGen wave sawtooth 0.927418 -0.924140 0.819056 0.449288
 rgbGen wave sawtooth 0.868239 -0.799814 0.819056 0.449288
@@ -1033,7 +1033,7 @@ blendfunc blend
 
 textures/particles/smoke_46
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1043,7 +1043,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.221885 -0.527929 117.230270 sawtooth 0 1 0.587848 0.389735
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 6.935179
 AlphaGen wave sawtooth 0.930067 -0.810843 0.587848 0.389735
 rgbGen wave sawtooth 0.937187 -0.915827 0.587848 0.389735
@@ -1054,7 +1054,7 @@ blendfunc blend
 
 textures/particles/smoke_47
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1064,7 +1064,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.644331 -8.751081 48.194199 sawtooth 0 1 0.574969 0.918589
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 14.924620
 AlphaGen wave sawtooth 0.962203 -0.864000 0.574969 0.918589
 rgbGen wave sawtooth 1.038545 -0.957198 0.574969 0.918589
@@ -1075,7 +1075,7 @@ blendfunc blend
 
 textures/particles/smoke_48
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1085,7 +1085,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.822900 -18.359270 115.465012 sawtooth 0 1 0.223334 0.403410
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.560381
 AlphaGen wave sawtooth 0.984756 -0.932673 0.223334 0.403410
 rgbGen wave sawtooth 1.026325 -0.976278 0.223334 0.403410
@@ -1096,7 +1096,7 @@ blendfunc blend
 
 textures/particles/smoke_49
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1106,7 +1106,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -18.207163 -1.042411 141.541168 sawtooth 0 1 0.363689 0.335504
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 12.128819
 AlphaGen wave sawtooth 0.953426 -0.998172 0.363689 0.335504
 rgbGen wave sawtooth 1.035823 -0.975539 0.363689 0.335504
@@ -1117,7 +1117,7 @@ blendfunc blend
 
 textures/particles/smoke_50
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1127,7 +1127,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.186595 -7.426748 62.873730 sawtooth 0 1 0.389203 0.688108
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.276345
 AlphaGen wave sawtooth 0.908191 -0.927094 0.389203 0.688108
 rgbGen wave sawtooth 1.004157 -1.028922 0.389203 0.688108
@@ -1138,7 +1138,7 @@ blendfunc blend
 
 textures/particles/smoke_51
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1148,7 +1148,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.888407 4.709627 77.944557 sawtooth 0 1 0.912198 0.600843
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 13.568071
 AlphaGen wave sawtooth 1.049455 -0.901886 0.912198 0.600843
 rgbGen wave sawtooth 1.175829 -1.134327 0.912198 0.600843
@@ -1159,7 +1159,7 @@ blendfunc blend
 
 textures/particles/smoke_52
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1169,7 +1169,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.114715 0.100571 60.797070 sawtooth 0 1 0.396527 0.706048
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 13.566851
 AlphaGen wave sawtooth 0.952498 -0.910169 0.396527 0.706048
 rgbGen wave sawtooth 1.041267 -1.055846 0.396527 0.706048
@@ -1180,7 +1180,7 @@ blendfunc blend
 
 textures/particles/smoke_53
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1190,7 +1190,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -14.800844 -1.346836 117.268730 sawtooth 0 1 0.177404 0.345516
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 6.045869
 AlphaGen wave sawtooth 0.901373 -0.938893 0.177404 0.345516
 rgbGen wave sawtooth 1.039546 -1.088177 0.177404 0.345516
@@ -1201,7 +1201,7 @@ blendfunc blend
 
 textures/particles/smoke_54
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1211,7 +1211,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.575153 7.514966 63.703548 sawtooth 0 1 0.529099 0.667257
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 11.272470
 AlphaGen wave sawtooth 0.976479 -1.164956 0.529099 0.667257
 rgbGen wave sawtooth 1.149510 -1.182815 0.529099 0.667257
@@ -1222,7 +1222,7 @@ blendfunc blend
 
 textures/particles/smoke_55
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1232,7 +1232,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.234108 -10.823921 86.519264 sawtooth 0 1 0.842067 0.514840
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.027040
 AlphaGen wave sawtooth 0.923359 -1.019596 0.842067 0.514840
 rgbGen wave sawtooth 0.974651 -0.932136 0.842067 0.514840
@@ -1243,7 +1243,7 @@ blendfunc blend
 
 textures/particles/smoke_56
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1253,7 +1253,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 15.023762 -2.102916 106.462135 sawtooth 0 1 0.443190 0.376507
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.105655
 AlphaGen wave sawtooth 0.953883 -0.816324 0.443190 0.376507
 rgbGen wave sawtooth 1.033271 -0.934767 0.443190 0.376507
@@ -1264,7 +1264,7 @@ blendfunc blend
 
 textures/particles/smoke_57
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1274,7 +1274,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -6.370625 6.112958 117.935081 sawtooth 0 1 0.515336 0.362439
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 6.346782
 AlphaGen wave sawtooth 1.081787 -1.198666 0.515336 0.362439
 rgbGen wave sawtooth 1.141014 -1.045940 0.515336 0.362439
@@ -1285,7 +1285,7 @@ blendfunc blend
 
 textures/particles/smoke_58
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1295,7 +1295,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.639777 -3.537818 61.274212 sawtooth 0 1 0.046968 0.754983
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 13.397779
 AlphaGen wave sawtooth 1.029374 -0.927595 0.046968 0.754983
 rgbGen wave sawtooth 0.925394 -0.896820 0.046968 0.754983
@@ -1306,7 +1306,7 @@ blendfunc blend
 
 textures/particles/smoke_59
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1316,7 +1316,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.313442 9.927258 53.856941 sawtooth 0 1 0.278787 0.851644
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.657063
 AlphaGen wave sawtooth 1.083605 -1.104437 0.278787 0.851644
 rgbGen wave sawtooth 1.166832 -1.133558 0.278787 0.851644
@@ -1327,7 +1327,7 @@ blendfunc blend
 
 textures/particles/smoke_60
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1337,7 +1337,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.025082 1.234976 117.096115 sawtooth 0 1 0.655080 0.414065
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 13.236946
 AlphaGen wave sawtooth 1.088543 -1.282733 0.655080 0.414065
 rgbGen wave sawtooth 1.000604 -0.912513 0.655080 0.414065
@@ -1348,7 +1348,7 @@ blendfunc blend
 
 textures/particles/smoke_61
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1358,7 +1358,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.649643 -0.653677 87.181816 sawtooth 0 1 0.359478 0.560512
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.180639
 AlphaGen wave sawtooth 1.045598 -0.872161 0.359478 0.560512
 rgbGen wave sawtooth 0.885757 -0.984017 0.359478 0.560512
@@ -1369,7 +1369,7 @@ blendfunc blend
 
 textures/particles/smoke_62
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1379,7 +1379,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.083308 3.391936 67.218987 sawtooth 0 1 0.629261 0.599217
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 14.131748
 AlphaGen wave sawtooth 0.917963 -1.086480 0.629261 0.599217
 rgbGen wave sawtooth 0.934538 -0.890149 0.629261 0.599217
@@ -1390,7 +1390,7 @@ blendfunc blend
 
 textures/particles/smoke_63
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1400,7 +1400,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.883634 -0.031350 79.042839 sawtooth 0 1 0.434034 0.592007
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 14.423811
 AlphaGen wave sawtooth 1.065673 -1.228965 0.434034 0.592007
 rgbGen wave sawtooth 1.135667 -1.154964 0.434034 0.592007
@@ -1411,7 +1411,7 @@ blendfunc blend
 
 textures/particles/smoke_64
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1421,7 +1421,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.275754 -2.090931 86.076912 sawtooth 0 1 0.148473 0.560858
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.306589
 AlphaGen wave sawtooth 0.906720 -0.742170 0.148473 0.560858
 rgbGen wave sawtooth 0.934257 -0.881286 0.148473 0.560858
@@ -1432,7 +1432,7 @@ blendfunc blend
 
 textures/particles/smoke_65
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1442,7 +1442,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.519611 2.526426 59.142303 sawtooth 0 1 0.490127 0.770934
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.968322
 AlphaGen wave sawtooth 0.909882 -0.726398 0.490127 0.770934
 rgbGen wave sawtooth 1.065926 -1.046367 0.490127 0.770934
@@ -1453,7 +1453,7 @@ blendfunc blend
 
 textures/particles/smoke_66
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1463,7 +1463,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.002649 -9.208313 97.708618 sawtooth 0 1 0.822718 0.501769
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.018006
 AlphaGen wave sawtooth 0.906818 -0.729340 0.822718 0.501769
 rgbGen wave sawtooth 1.153734 -1.065618 0.822718 0.501769
@@ -1474,7 +1474,7 @@ blendfunc blend
 
 textures/particles/smoke_67
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1484,7 +1484,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.749091 -8.428467 102.368423 sawtooth 0 1 0.424574 0.446581
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.591449
 AlphaGen wave sawtooth 0.999655 -1.112104 0.424574 0.446581
 rgbGen wave sawtooth 1.072860 -1.113392 0.424574 0.446581
@@ -1495,7 +1495,7 @@ blendfunc blend
 
 textures/particles/smoke_68
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1505,7 +1505,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.483619 3.255467 51.843319 sawtooth 0 1 0.204016 0.803211
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.071993
 AlphaGen wave sawtooth 0.951540 -0.974398 0.204016 0.803211
 rgbGen wave sawtooth 1.077718 -1.150490 0.204016 0.803211
@@ -1516,7 +1516,7 @@ blendfunc blend
 
 textures/particles/smoke_69
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1526,7 +1526,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -15.505955 -12.722219 93.158661 sawtooth 0 1 0.762352 0.432813
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.993042
 AlphaGen wave sawtooth 0.957399 -0.947456 0.762352 0.432813
 rgbGen wave sawtooth 1.011969 -1.089886 0.762352 0.432813
@@ -1537,7 +1537,7 @@ blendfunc blend
 
 textures/particles/smoke_70
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1547,7 +1547,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.216509 1.777797 131.790558 sawtooth 0 1 0.476485 0.340504
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.308817
 AlphaGen wave sawtooth 1.053142 -1.164186 0.476485 0.340504
 rgbGen wave sawtooth 1.058101 -0.995340 0.476485 0.340504
@@ -1558,7 +1558,7 @@ blendfunc blend
 
 textures/particles/smoke_71
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1568,7 +1568,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.693591 3.604417 121.370155 sawtooth 0 1 0.162908 0.401857
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.610553
 AlphaGen wave sawtooth 1.070849 -0.893738 0.162908 0.401857
 rgbGen wave sawtooth 1.170544 -1.081634 0.162908 0.401857
@@ -1579,7 +1579,7 @@ blendfunc blend
 
 textures/particles/smoke_72
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1589,7 +1589,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.475215 20.477882 116.297134 sawtooth 0 1 0.350017 0.369068
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.439039
 AlphaGen wave sawtooth 1.089056 -0.966573 0.350017 0.369068
 rgbGen wave sawtooth 1.168822 -1.126350 0.350017 0.369068
@@ -1600,7 +1600,7 @@ blendfunc blend
 
 textures/particles/smoke_73
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1610,7 +1610,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.118082 21.737192 113.090508 sawtooth 0 1 0.868801 0.362014
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.591510
 AlphaGen wave sawtooth 1.091180 -1.072741 0.868801 0.362014
 rgbGen wave sawtooth 0.875698 -0.867040 0.868801 0.362014
@@ -1621,7 +1621,7 @@ blendfunc blend
 
 textures/particles/smoke_74
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1631,7 +1631,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.798365 8.568650 93.088654 sawtooth 0 1 0.069002 0.457812
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.497757
 AlphaGen wave sawtooth 1.064373 -0.872588 0.069002 0.457812
 rgbGen wave sawtooth 1.158690 -1.139619 0.069002 0.457812
@@ -1642,7 +1642,7 @@ blendfunc blend
 
 textures/particles/smoke_75
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1652,7 +1652,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.798648 11.458564 145.556488 sawtooth 0 1 0.062593 0.337884
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.250923
 AlphaGen wave sawtooth 0.913660 -1.041929 0.062593 0.337884
 rgbGen wave sawtooth 0.810926 -0.737458 0.062593 0.337884
@@ -1663,7 +1663,7 @@ blendfunc blend
 
 textures/particles/smoke_76
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1673,7 +1673,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.664803 6.044099 47.861584 sawtooth 0 1 0.096530 0.907045
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.624378
 AlphaGen wave sawtooth 1.032499 -0.933125 0.096530 0.907045
 rgbGen wave sawtooth 1.176171 -1.127931 0.096530 0.907045
@@ -1684,7 +1684,7 @@ blendfunc blend
 
 textures/particles/smoke_77
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1694,7 +1694,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.822771 -2.348790 53.128712 sawtooth 0 1 0.370098 0.802071
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.501877
 AlphaGen wave sawtooth 1.025468 -1.077624 0.370098 0.802071
 rgbGen wave sawtooth 1.167260 -1.143306 0.370098 0.802071
@@ -1705,7 +1705,7 @@ blendfunc blend
 
 textures/particles/smoke_78
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1715,7 +1715,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.991846 4.261580 94.523895 sawtooth 0 1 0.075594 0.434443
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 8.066195
 AlphaGen wave sawtooth 1.090619 -1.006760 0.075594 0.434443
 rgbGen wave sawtooth 0.965728 -0.930207 0.075594 0.434443
@@ -1726,7 +1726,7 @@ blendfunc blend
 
 textures/particles/smoke_79
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1736,7 +1736,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.798648 -1.201153 81.028267 sawtooth 0 1 0.588946 0.571321
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 13.057497
 AlphaGen wave sawtooth 1.069939 -1.111023 0.588946 0.571321
 rgbGen wave sawtooth 0.916312 -0.913373 0.588946 0.571321
@@ -1747,7 +1747,7 @@ blendfunc blend
 
 textures/particles/smoke_80
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1757,7 +1757,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 14.575624 9.561610 112.531677 sawtooth 0 1 0.726188 0.386098
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 11.559343
 AlphaGen wave sawtooth 0.966970 -1.038182 0.726188 0.386098
 rgbGen wave sawtooth 1.042500 -1.120570 0.726188 0.386098
@@ -1768,7 +1768,7 @@ blendfunc blend
 
 textures/particles/smoke_81
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1778,7 +1778,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.618456 -4.432334 49.250370 sawtooth 0 1 0.274178 0.957847
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 12.938169
 AlphaGen wave sawtooth 0.994266 -0.885076 0.274178 0.957847
 rgbGen wave sawtooth 0.808411 -0.905475 0.274178 0.957847
@@ -1789,7 +1789,7 @@ blendfunc blend
 
 textures/particles/smoke_82
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1799,7 +1799,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.229699 -0.110414 99.495506 sawtooth 0 1 0.033692 0.473710
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.744347
 AlphaGen wave sawtooth 1.008090 -1.123334 0.033692 0.473710
 rgbGen wave sawtooth 0.990326 -0.949440 0.033692 0.473710
@@ -1810,7 +1810,7 @@ blendfunc blend
 
 textures/particles/smoke_83
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1820,7 +1820,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.074748 3.242458 101.583549 sawtooth 0 1 0.187170 0.428949
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.180548
 AlphaGen wave sawtooth 0.942970 -0.770009 0.187170 0.428949
 rgbGen wave sawtooth 0.821375 -0.852690 0.187170 0.428949
@@ -1831,7 +1831,7 @@ blendfunc blend
 
 textures/particles/smoke_84
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1841,7 +1841,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 9.817342 -10.070479 71.111519 sawtooth 0 1 0.047456 0.669931
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.339366
 AlphaGen wave sawtooth 1.080639 -1.264428 0.047456 0.669931
 rgbGen wave sawtooth 1.147655 -1.048283 0.047456 0.669931
@@ -1852,7 +1852,7 @@ blendfunc blend
 
 textures/particles/smoke_85
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1862,7 +1862,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.543313 -0.099550 51.457840 sawtooth 0 1 0.945402 0.790881
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.946135
 AlphaGen wave sawtooth 1.058684 -0.867132 0.945402 0.790881
 rgbGen wave sawtooth 1.164977 -1.117536 0.945402 0.790881
@@ -1873,7 +1873,7 @@ blendfunc blend
 
 textures/particles/smoke_86
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1883,7 +1883,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -14.192396 -9.072642 84.809929 sawtooth 0 1 0.461348 0.462935
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 12.607959
 AlphaGen wave sawtooth 1.049767 -1.148274 0.461348 0.462935
 rgbGen wave sawtooth 0.996771 -0.936091 0.461348 0.462935
@@ -1894,7 +1894,7 @@ blendfunc blend
 
 textures/particles/smoke_87
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1904,7 +1904,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.838804 7.591372 75.339882 sawtooth 0 1 0.618152 0.575314
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.651631
 AlphaGen wave sawtooth 0.978494 -0.819315 0.618152 0.575314
 rgbGen wave sawtooth 0.831007 -0.878838 0.618152 0.575314
@@ -1915,7 +1915,7 @@ blendfunc blend
 
 textures/particles/smoke_88
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1925,7 +1925,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.123973 -0.894436 123.552048 sawtooth 0 1 0.517594 0.338506
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.543077
 AlphaGen wave sawtooth 0.908954 -0.772274 0.517594 0.338506
 rgbGen wave sawtooth 1.003510 -0.946156 0.517594 0.338506
@@ -1936,7 +1936,7 @@ blendfunc blend
 
 textures/particles/smoke_89
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1946,7 +1946,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 16.905676 4.863203 128.915512 sawtooth 0 1 0.625233 0.342719
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.610523
 AlphaGen wave sawtooth 0.994327 -0.806839 0.625233 0.342719
 rgbGen wave sawtooth 0.920316 -0.979666 0.625233 0.342719
@@ -1957,7 +1957,7 @@ blendfunc blend
 
 textures/particles/smoke_90
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1967,7 +1967,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.246242 1.030688 82.852608 sawtooth 0 1 0.285501 0.539135
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 6.315653
 AlphaGen wave sawtooth 0.939601 -0.866277 0.285501 0.539135
 rgbGen wave sawtooth 0.918290 -0.849669 0.285501 0.539135
@@ -1978,7 +1978,7 @@ blendfunc blend
 
 textures/particles/smoke_91
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1988,7 +1988,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.131275 3.139940 71.495941 sawtooth 0 1 0.234169 0.679151
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 14.159520
 AlphaGen wave sawtooth 0.903870 -1.015110 0.234169 0.679151
 rgbGen wave sawtooth 1.025593 -1.083673 0.234169 0.679151
@@ -1999,7 +1999,7 @@ blendfunc blend
 
 textures/particles/smoke_92
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2009,7 +2009,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.821755 -0.319315 68.022377 sawtooth 0 1 0.640461 0.701724
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.220710
 AlphaGen wave sawtooth 1.097943 -0.993100 0.640461 0.701724
 rgbGen wave sawtooth 1.093527 -1.114142 0.640461 0.701724
@@ -2020,7 +2020,7 @@ blendfunc blend
 
 textures/particles/smoke_93
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2030,7 +2030,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 23.148304 7.725038 115.483650 sawtooth 0 1 0.345592 0.367446
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.669026
 AlphaGen wave sawtooth 1.040104 -0.889544 0.345592 0.367446
 rgbGen wave sawtooth 0.853114 -0.947401 0.345592 0.367446
@@ -2041,7 +2041,7 @@ blendfunc blend
 
 textures/particles/smoke_94
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2051,7 +2051,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -21.078329 -5.268201 123.649216 sawtooth 0 1 0.936583 0.355572
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 10.807673
 AlphaGen wave sawtooth 0.986514 -1.128602 0.936583 0.355572
 rgbGen wave sawtooth 1.048433 -1.123975 0.936583 0.355572
@@ -2062,7 +2062,7 @@ blendfunc blend
 
 textures/particles/smoke_95
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2072,7 +2072,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.163071 1.103677 116.418556 sawtooth 0 1 0.225043 0.413312
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 11.394544
 AlphaGen wave sawtooth 0.956722 -0.819736 0.225043 0.413312
 rgbGen wave sawtooth 1.076424 -1.141072 0.225043 0.413312
@@ -2083,7 +2083,7 @@ blendfunc blend
 
 textures/particles/smoke_96
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2093,7 +2093,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.758558 3.697800 82.175201 sawtooth 0 1 0.046419 0.493278
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.375072
 AlphaGen wave sawtooth 1.092889 -0.999948 0.046419 0.493278
 rgbGen wave sawtooth 0.969231 -0.933308 0.046419 0.493278
@@ -2104,7 +2104,7 @@ blendfunc blend
 
 textures/particles/smoke_97
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2114,7 +2114,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 17.314335 -13.365162 113.248283 sawtooth 0 1 0.515732 0.406675
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 9.100772
 AlphaGen wave sawtooth 1.089514 -0.992251 0.515732 0.406675
 rgbGen wave sawtooth 0.981219 -1.066454 0.515732 0.406675
@@ -2125,7 +2125,7 @@ blendfunc blend
 
 textures/particles/smoke_98
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2135,7 +2135,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.154598 -0.282348 98.174957 sawtooth 0 1 0.764824 0.500038
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 7.770470
 AlphaGen wave sawtooth 1.094336 -1.272875 0.764824 0.500038
 rgbGen wave sawtooth 1.120872 -1.141499 0.764824 0.500038
@@ -2146,7 +2146,7 @@ blendfunc blend
 
 textures/particles/smoke_99
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2156,7 +2156,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 10.581910 -11.240653 85.292511 sawtooth 0 1 0.366222 0.476105
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 5.021668
 AlphaGen wave sawtooth 0.934266 -0.897186 0.366222 0.476105
 rgbGen wave sawtooth 0.833924 -0.852361 0.366222 0.476105
@@ -2167,7 +2167,7 @@ blendfunc blend
 
 textures/particles/smoke_100
 {
-qer_editorimage textures/particles/rauch.tga
+qer_editorimage textures/particles/rauch
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2177,7 +2177,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.207306 16.188437 137.671707 sawtooth 0 1 0.159948 0.349854
 {
-clampmap textures/particles/rauch.tga
+clampmap textures/particles/rauch
 tcMod rotate 13.743553
 AlphaGen wave sawtooth 0.958687 -1.000040 0.159948 0.349854
 rgbGen wave sawtooth 0.916337 -1.006119 0.159948 0.349854
@@ -2192,7 +2192,7 @@ blendfunc blend
 
 textures/particles/fire_1
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2202,7 +2202,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.092655 25.865967 126.450356 sawtooth 0 1 0.040193 0.374587
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 5.256050
 AlphaGen wave sawtooth 0.934907 -0.743477 0.040193 0.374587
 rgbGen wave sawtooth 0.973309 -0.919898 0.040193 0.374587
@@ -2213,7 +2213,7 @@ blendfunc add
 
 textures/particles/fire_2
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2223,7 +2223,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 11.519916 3.532670 69.201515 sawtooth 0 1 0.413648 0.586455
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 13.329417
 AlphaGen wave sawtooth 1.001669 -0.973696 0.413648 0.586455
 rgbGen wave sawtooth 0.989557 -0.905316 0.413648 0.586455
@@ -2234,7 +2234,7 @@ blendfunc add
 
 textures/particles/fire_3
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2244,7 +2244,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.467540 -0.563699 123.544167 sawtooth 0 1 0.073214 0.346415
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 9.326303
 AlphaGen wave sawtooth 1.045494 -0.970241 0.073214 0.346415
 rgbGen wave sawtooth 0.995819 -1.061162 0.073214 0.346415
@@ -2255,7 +2255,7 @@ blendfunc add
 
 textures/particles/fire_4
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2265,7 +2265,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.409666 -2.503888 45.641773 sawtooth 0 1 0.790460 0.957120
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.279214
 AlphaGen wave sawtooth 1.084814 -1.128120 0.790460 0.957120
 rgbGen wave sawtooth 1.141441 -1.223148 0.790460 0.957120
@@ -2276,7 +2276,7 @@ blendfunc add
 
 textures/particles/fire_5
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2286,7 +2286,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.353253 7.919044 118.762054 sawtooth 0 1 0.393048 0.349481
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 13.312021
 AlphaGen wave sawtooth 1.099097 -1.246190 0.393048 0.349481
 rgbGen wave sawtooth 1.096664 -1.061467 0.393048 0.349481
@@ -2297,7 +2297,7 @@ blendfunc add
 
 textures/particles/fire_6
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2307,7 +2307,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.827013 10.550961 123.069984 sawtooth 0 1 0.632893 0.391215
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.270638
 AlphaGen wave sawtooth 1.015421 -1.103467 0.632893 0.391215
 rgbGen wave sawtooth 0.982696 -1.072570 0.632893 0.391215
@@ -2318,7 +2318,7 @@ blendfunc add
 
 textures/particles/fire_7
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2328,7 +2328,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.204574 -0.449692 115.490707 sawtooth 0 1 0.411206 0.424988
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.510148
 AlphaGen wave sawtooth 0.926795 -0.953731 0.411206 0.424988
 rgbGen wave sawtooth 0.849355 -0.871349 0.411206 0.424988
@@ -2339,7 +2339,7 @@ blendfunc add
 
 textures/particles/fire_8
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2349,7 +2349,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.608938 12.021394 91.102928 sawtooth 0 1 0.873989 0.466800
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.985657
 AlphaGen wave sawtooth 0.980776 -1.027500 0.873989 0.466800
 rgbGen wave sawtooth 1.110361 -1.197092 0.873989 0.466800
@@ -2360,7 +2360,7 @@ blendfunc add
 
 textures/particles/fire_9
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2370,7 +2370,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.900666 -3.212608 77.127556 sawtooth 0 1 0.634541 0.602102
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 10.781732
 AlphaGen wave sawtooth 1.023893 -0.919074 0.634541 0.602102
 rgbGen wave sawtooth 1.149058 -1.119855 0.634541 0.602102
@@ -2381,7 +2381,7 @@ blendfunc add
 
 textures/particles/fire_10
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2391,7 +2391,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.598431 -7.272936 114.080032 sawtooth 0 1 0.852260 0.387651
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.418622
 AlphaGen wave sawtooth 0.940638 -0.780593 0.852260 0.387651
 rgbGen wave sawtooth 1.097238 -1.032670 0.852260 0.387651
@@ -2402,7 +2402,7 @@ blendfunc add
 
 textures/particles/fire_11
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2412,7 +2412,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.760044 -22.540638 122.156731 sawtooth 0 1 0.271523 0.364568
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 10.641347
 AlphaGen wave sawtooth 1.010086 -1.169619 0.271523 0.364568
 rgbGen wave sawtooth 0.912101 -0.875298 0.271523 0.364568
@@ -2423,7 +2423,7 @@ blendfunc add
 
 textures/particles/fire_12
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2433,7 +2433,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -10.992389 -8.658035 75.840759 sawtooth 0 1 0.699362 0.551160
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 13.211005
 AlphaGen wave sawtooth 0.931135 -1.039848 0.699362 0.551160
 rgbGen wave sawtooth 0.864125 -0.865624 0.699362 0.551160
@@ -2444,7 +2444,7 @@ blendfunc add
 
 textures/particles/fire_13
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2454,7 +2454,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.467978 -7.670099 82.217995 sawtooth 0 1 0.883999 0.573803
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.841487
 AlphaGen wave sawtooth 1.020926 -1.147279 0.883999 0.573803
 rgbGen wave sawtooth 0.962090 -0.890759 0.883999 0.573803
@@ -2465,7 +2465,7 @@ blendfunc add
 
 textures/particles/fire_14
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2475,7 +2475,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.049909 9.526320 84.034889 sawtooth 0 1 0.500107 0.476798
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.552599
 AlphaGen wave sawtooth 1.021775 -1.083184 0.500107 0.476798
 rgbGen wave sawtooth 0.935087 -0.941878 0.500107 0.476798
@@ -2486,7 +2486,7 @@ blendfunc add
 
 textures/particles/fire_15
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2496,7 +2496,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.556802 1.788882 138.045471 sawtooth 0 1 0.566912 0.361336
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.802515
 AlphaGen wave sawtooth 1.044475 -0.976327 0.566912 0.361336
 rgbGen wave sawtooth 1.156005 -1.218760 0.566912 0.361336
@@ -2507,7 +2507,7 @@ blendfunc add
 
 textures/particles/fire_16
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2517,7 +2517,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.579810 12.707578 137.130951 sawtooth 0 1 0.989685 0.339052
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.749107
 AlphaGen wave sawtooth 0.960787 -1.098663 0.989685 0.339052
 rgbGen wave sawtooth 0.806067 -0.753377 0.989685 0.339052
@@ -2528,7 +2528,7 @@ blendfunc add
 
 textures/particles/fire_17
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2538,7 +2538,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.346302 -2.116523 64.950180 sawtooth 0 1 0.033479 0.666280
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 9.660481
 AlphaGen wave sawtooth 0.978774 -1.113916 0.033479 0.666280
 rgbGen wave sawtooth 0.908707 -0.940419 0.033479 0.666280
@@ -2549,7 +2549,7 @@ blendfunc add
 
 textures/particles/fire_18
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2559,7 +2559,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.445938 -0.283519 98.616936 sawtooth 0 1 0.717154 0.460968
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 10.024873
 AlphaGen wave sawtooth 1.003439 -0.962453 0.717154 0.460968
 rgbGen wave sawtooth 0.932743 -1.016300 0.717154 0.460968
@@ -2570,7 +2570,7 @@ blendfunc add
 
 textures/particles/fire_19
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2580,7 +2580,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.212684 -11.580784 92.164925 sawtooth 0 1 0.451796 0.444003
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.262733
 AlphaGen wave sawtooth 1.074883 -1.137355 0.451796 0.444003
 rgbGen wave sawtooth 0.883743 -0.979080 0.451796 0.444003
@@ -2591,7 +2591,7 @@ blendfunc add
 
 textures/particles/fire_20
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2601,7 +2601,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.053777 0.753608 120.018623 sawtooth 0 1 0.787713 0.335862
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.607593
 AlphaGen wave sawtooth 1.043522 -1.226469 0.787713 0.335862
 rgbGen wave sawtooth 1.100595 -1.198587 0.787713 0.335862
@@ -2612,7 +2612,7 @@ blendfunc add
 
 textures/particles/fire_21
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2622,7 +2622,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.606667 -4.276110 120.011703 sawtooth 0 1 0.053743 0.385426
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.426588
 AlphaGen wave sawtooth 0.973049 -1.020725 0.053743 0.385426
 rgbGen wave sawtooth 0.984661 -0.984268 0.053743 0.385426
@@ -2633,7 +2633,7 @@ blendfunc add
 
 textures/particles/fire_22
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2643,7 +2643,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -10.247495 1.857717 106.628471 sawtooth 0 1 0.116672 0.460618
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.915799
 AlphaGen wave sawtooth 0.984194 -1.169008 0.116672 0.460618
 rgbGen wave sawtooth 1.028498 -0.975021 0.116672 0.460618
@@ -2654,7 +2654,7 @@ blendfunc add
 
 textures/particles/fire_23
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2664,7 +2664,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.621730 -4.623235 47.792816 sawtooth 0 1 0.539506 0.928954
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.385723
 AlphaGen wave sawtooth 1.060131 -0.897815 0.539506 0.928954
 rgbGen wave sawtooth 1.154491 -1.104444 0.539506 0.928954
@@ -2675,7 +2675,7 @@ blendfunc add
 
 textures/particles/fire_24
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2685,7 +2685,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.922271 -4.041907 97.514481 sawtooth 0 1 0.217505 0.473286
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.976531
 AlphaGen wave sawtooth 0.916071 -0.983389 0.217505 0.473286
 rgbGen wave sawtooth 0.826673 -0.811905 0.217505 0.473286
@@ -2696,7 +2696,7 @@ blendfunc add
 
 textures/particles/fire_25
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2706,7 +2706,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.024816 -7.044024 141.928055 sawtooth 0 1 0.254799 0.349944
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.907559
 AlphaGen wave sawtooth 0.900299 -0.875414 0.254799 0.349944
 rgbGen wave sawtooth 1.118906 -1.137971 0.254799 0.349944
@@ -2717,7 +2717,7 @@ blendfunc add
 
 textures/particles/fire_26
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2727,7 +2727,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.046926 1.450716 116.731552 sawtooth 0 1 0.523728 0.368098
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.267556
 AlphaGen wave sawtooth 0.942500 -0.884716 0.523728 0.368098
 rgbGen wave sawtooth 1.030464 -0.935102 0.523728 0.368098
@@ -2738,7 +2738,7 @@ blendfunc add
 
 textures/particles/fire_27
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2748,7 +2748,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.390987 -22.234499 121.613243 sawtooth 0 1 0.152135 0.362792
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 12.233191
 AlphaGen wave sawtooth 0.942982 -1.024839 0.152135 0.362792
 rgbGen wave sawtooth 0.944621 -0.890783 0.152135 0.362792
@@ -2759,7 +2759,7 @@ blendfunc add
 
 textures/particles/fire_28
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2769,7 +2769,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 11.289130 9.057802 119.670174 sawtooth 0 1 0.739677 0.384431
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.309641
 AlphaGen wave sawtooth 1.030137 -0.881079 0.739677 0.384431
 rgbGen wave sawtooth 0.813575 -0.740584 0.739677 0.384431
@@ -2780,7 +2780,7 @@ blendfunc add
 
 textures/particles/fire_29
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2790,7 +2790,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.522344 -2.226942 112.193542 sawtooth 0 1 0.783380 0.419471
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.109439
 AlphaGen wave sawtooth 0.917017 -0.914606 0.783380 0.419471
 rgbGen wave sawtooth 1.175426 -1.196957 0.783380 0.419471
@@ -2801,7 +2801,7 @@ blendfunc add
 
 textures/particles/fire_30
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2811,7 +2811,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.208554 2.602637 60.923038 sawtooth 0 1 0.348430 0.669302
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 13.715476
 AlphaGen wave sawtooth 1.091266 -0.954414 0.348430 0.669302
 rgbGen wave sawtooth 1.097885 -1.189889 0.348430 0.669302
@@ -2822,7 +2822,7 @@ blendfunc add
 
 textures/particles/fire_31
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2832,7 +2832,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.235404 -18.934641 128.810699 sawtooth 0 1 0.135289 0.335017
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.920041
 AlphaGen wave sawtooth 1.003391 -0.830247 0.135289 0.335017
 rgbGen wave sawtooth 0.806177 -0.802896 0.135289 0.335017
@@ -2843,7 +2843,7 @@ blendfunc add
 
 textures/particles/fire_32
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2853,7 +2853,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.209000 0.031177 49.782745 sawtooth 0 1 0.807367 0.969811
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.332011
 AlphaGen wave sawtooth 1.048466 -1.005478 0.807367 0.969811
 rgbGen wave sawtooth 1.070870 -1.018638 0.807367 0.969811
@@ -2864,7 +2864,7 @@ blendfunc add
 
 textures/particles/fire_33
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2874,7 +2874,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.326980 6.155188 66.951309 sawtooth 0 1 0.137547 0.624574
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.595019
 AlphaGen wave sawtooth 0.964931 -0.830985 0.137547 0.624574
 rgbGen wave sawtooth 0.908951 -1.000674 0.137547 0.624574
@@ -2885,7 +2885,7 @@ blendfunc add
 
 textures/particles/fire_34
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2895,7 +2895,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 21.143967 3.835182 111.427406 sawtooth 0 1 0.750938 0.388875
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.824884
 AlphaGen wave sawtooth 0.917103 -1.110840 0.750938 0.388875
 rgbGen wave sawtooth 0.948222 -1.001657 0.750938 0.388875
@@ -2906,7 +2906,7 @@ blendfunc add
 
 textures/particles/fire_35
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2916,7 +2916,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.438050 1.705741 109.646225 sawtooth 0 1 0.268227 0.409490
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 12.786492
 AlphaGen wave sawtooth 1.026200 -0.894476 0.268227 0.409490
 rgbGen wave sawtooth 1.185522 -1.145991 0.268227 0.409490
@@ -2927,7 +2927,7 @@ blendfunc add
 
 textures/particles/fire_36
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2937,7 +2937,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.077808 0.453541 124.796425 sawtooth 0 1 0.328837 0.360120
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 10.783563
 AlphaGen wave sawtooth 0.991372 -0.992355 0.328837 0.360120
 rgbGen wave sawtooth 1.125645 -1.184780 0.328837 0.360120
@@ -2948,7 +2948,7 @@ blendfunc add
 
 textures/particles/fire_37
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2958,7 +2958,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.802804 -1.479153 46.639740 sawtooth 0 1 0.980438 0.874043
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 12.025056
 AlphaGen wave sawtooth 0.963924 -0.873705 0.980438 0.874043
 rgbGen wave sawtooth 1.137083 -1.037925 0.980438 0.874043
@@ -2969,7 +2969,7 @@ blendfunc add
 
 textures/particles/fire_38
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2979,7 +2979,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.174780 -1.080936 134.630524 sawtooth 0 1 0.253182 0.365080
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.448225
 AlphaGen wave sawtooth 1.060680 -1.086749 0.253182 0.365080
 rgbGen wave sawtooth 1.002496 -1.040055 0.253182 0.365080
@@ -2990,7 +2990,7 @@ blendfunc add
 
 textures/particles/fire_39
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3000,7 +3000,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.177956 -0.556153 96.087563 sawtooth 0 1 0.801233 0.457314
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 9.448988
 AlphaGen wave sawtooth 0.914545 -1.110382 0.801233 0.457314
 rgbGen wave sawtooth 1.164501 -1.193759 0.801233 0.457314
@@ -3011,7 +3011,7 @@ blendfunc add
 
 textures/particles/fire_40
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3021,7 +3021,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.583808 1.872746 126.497231 sawtooth 0 1 0.842769 0.380167
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.717399
 AlphaGen wave sawtooth 1.039903 -0.999441 0.842769 0.380167
 rgbGen wave sawtooth 0.979205 -1.049181 0.842769 0.380167
@@ -3032,7 +3032,7 @@ blendfunc add
 
 textures/particles/fire_41
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3042,7 +3042,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.228266 1.086951 107.539970 sawtooth 0 1 0.033692 0.426737
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 10.484481
 AlphaGen wave sawtooth 0.953743 -0.990310 0.033692 0.426737
 rgbGen wave sawtooth 1.191284 -1.149397 0.033692 0.426737
@@ -3053,7 +3053,7 @@ blendfunc add
 
 textures/particles/fire_42
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3063,7 +3063,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -13.680698 5.663084 69.844330 sawtooth 0 1 0.954527 0.689991
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.412549
 AlphaGen wave sawtooth 1.094195 -1.007797 0.954527 0.689991
 rgbGen wave sawtooth 0.881423 -0.797421 0.954527 0.689991
@@ -3074,7 +3074,7 @@ blendfunc add
 
 textures/particles/fire_43
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3084,7 +3084,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.127196 -8.089557 126.681290 sawtooth 0 1 0.150914 0.339826
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.793420
 AlphaGen wave sawtooth 1.080224 -1.165743 0.150914 0.339826
 rgbGen wave sawtooth 1.186926 -1.279473 0.150914 0.339826
@@ -3095,7 +3095,7 @@ blendfunc add
 
 textures/particles/fire_44
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3105,7 +3105,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.308326 -5.467181 109.459915 sawtooth 0 1 0.812891 0.371841
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.157384
 AlphaGen wave sawtooth 0.901849 -0.818613 0.812891 0.371841
 rgbGen wave sawtooth 0.995733 -0.990207 0.812891 0.371841
@@ -3116,7 +3116,7 @@ blendfunc add
 
 textures/particles/fire_45
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3126,7 +3126,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.067106 4.022991 86.248894 sawtooth 0 1 0.332804 0.467786
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 9.157537
 AlphaGen wave sawtooth 0.965798 -0.879424 0.332804 0.467786
 rgbGen wave sawtooth 1.109311 -1.083715 0.332804 0.467786
@@ -3137,7 +3137,7 @@ blendfunc add
 
 textures/particles/fire_46
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3147,7 +3147,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.692383 -6.496933 85.529167 sawtooth 0 1 0.006623 0.521809
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.854000
 AlphaGen wave sawtooth 0.952541 -0.960189 0.006623 0.521809
 rgbGen wave sawtooth 0.864895 -0.812418 0.006623 0.521809
@@ -3158,7 +3158,7 @@ blendfunc add
 
 textures/particles/fire_47
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3168,7 +3168,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.126766 -5.919113 119.314644 sawtooth 0 1 0.285226 0.385762
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.970092
 AlphaGen wave sawtooth 1.042216 -0.883197 0.285226 0.385762
 rgbGen wave sawtooth 1.132664 -1.056194 0.285226 0.385762
@@ -3179,7 +3179,7 @@ blendfunc add
 
 textures/particles/fire_48
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3189,7 +3189,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -10.723325 -2.046094 67.926079 sawtooth 0 1 0.947905 0.641220
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.935331
 AlphaGen wave sawtooth 0.946962 -0.972250 0.947905 0.641220
 rgbGen wave sawtooth 0.835633 -0.862639 0.947905 0.641220
@@ -3200,7 +3200,7 @@ blendfunc add
 
 textures/particles/fire_49
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3210,7 +3210,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.752842 -4.096520 49.675163 sawtooth 0 1 0.624378 0.815363
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 12.910398
 AlphaGen wave sawtooth 0.906311 -0.922675 0.624378 0.815363
 rgbGen wave sawtooth 0.831617 -0.763363 0.624378 0.815363
@@ -3221,7 +3221,7 @@ blendfunc add
 
 textures/particles/fire_50
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3231,7 +3231,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.072746 13.491298 81.592239 sawtooth 0 1 0.505173 0.515748
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 5.508133
 AlphaGen wave sawtooth 1.074120 -1.126508 0.505173 0.515748
 rgbGen wave sawtooth 0.927104 -0.832933 0.505173 0.515748
@@ -3242,7 +3242,7 @@ blendfunc add
 
 textures/particles/fire_51
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3252,7 +3252,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.511560 0.322000 56.992935 sawtooth 0 1 0.828974 0.840762
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 10.457320
 AlphaGen wave sawtooth 0.964754 -1.136323 0.828974 0.840762
 rgbGen wave sawtooth 0.901810 -0.832279 0.828974 0.840762
@@ -3263,7 +3263,7 @@ blendfunc add
 
 textures/particles/fire_52
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3273,7 +3273,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -15.414845 -10.046732 95.017227 sawtooth 0 1 0.953032 0.516024
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 12.512741
 AlphaGen wave sawtooth 1.017484 -1.137135 0.953032 0.516024
 rgbGen wave sawtooth 0.945732 -0.898291 0.953032 0.516024
@@ -3284,7 +3284,7 @@ blendfunc add
 
 textures/particles/fire_53
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3294,7 +3294,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -6.483476 -1.856334 52.135616 sawtooth 0 1 0.187750 0.786591
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 9.349498
 AlphaGen wave sawtooth 1.032017 -0.864611 0.187750 0.786591
 rgbGen wave sawtooth 0.864028 -0.816483 0.187750 0.786591
@@ -3305,7 +3305,7 @@ blendfunc add
 
 textures/particles/fire_54
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3315,7 +3315,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.388479 -0.355953 81.171722 sawtooth 0 1 0.452956 0.498123
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.268441
 AlphaGen wave sawtooth 1.007663 -1.183773 0.452956 0.498123
 rgbGen wave sawtooth 0.960076 -0.949886 0.452956 0.498123
@@ -3326,7 +3326,7 @@ blendfunc add
 
 textures/particles/fire_55
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3336,7 +3336,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -14.909748 2.953199 73.545647 sawtooth 0 1 0.421277 0.554199
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.253090
 AlphaGen wave sawtooth 0.965999 -1.160616 0.421277 0.554199
 rgbGen wave sawtooth 0.871609 -0.788632 0.421277 0.554199
@@ -3347,7 +3347,7 @@ blendfunc add
 
 textures/particles/fire_56
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3357,7 +3357,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.196961 2.392792 122.165161 sawtooth 0 1 0.619556 0.379393
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 10.605334
 AlphaGen wave sawtooth 0.920386 -0.740016 0.619556 0.379393
 rgbGen wave sawtooth 1.119114 -1.080590 0.619556 0.379393
@@ -3368,7 +3368,7 @@ blendfunc add
 
 textures/particles/fire_57
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3378,7 +3378,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 19.174351 -4.033445 91.271988 sawtooth 0 1 0.861415 0.509604
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.912290
 AlphaGen wave sawtooth 1.099670 -1.209445 0.861415 0.509604
 rgbGen wave sawtooth 1.069442 -1.031065 0.861415 0.509604
@@ -3389,7 +3389,7 @@ blendfunc add
 
 textures/particles/fire_58
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3399,7 +3399,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.415060 -4.622040 62.363213 sawtooth 0 1 0.952116 0.793563
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.329844
 AlphaGen wave sawtooth 0.941432 -0.957308 0.952116 0.793563
 rgbGen wave sawtooth 1.197937 -1.232859 0.952116 0.793563
@@ -3410,7 +3410,7 @@ blendfunc add
 
 textures/particles/fire_59
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3420,7 +3420,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.171461 -11.106880 112.404991 sawtooth 0 1 0.356548 0.397856
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 13.258919
 AlphaGen wave sawtooth 0.928712 -0.978207 0.356548 0.397856
 rgbGen wave sawtooth 0.988482 -0.983785 0.356548 0.397856
@@ -3431,7 +3431,7 @@ blendfunc add
 
 textures/particles/fire_60
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3441,7 +3441,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.261872 0.827419 99.414772 sawtooth 0 1 0.658467 0.474698
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.421735
 AlphaGen wave sawtooth 0.907471 -1.068297 0.658467 0.474698
 rgbGen wave sawtooth 0.836988 -0.774178 0.658467 0.474698
@@ -3452,7 +3452,7 @@ blendfunc add
 
 textures/particles/fire_61
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3462,7 +3462,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.086418 -3.843678 77.296440 sawtooth 0 1 0.555742 0.568427
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 10.558336
 AlphaGen wave sawtooth 0.970705 -0.803372 0.555742 0.568427
 rgbGen wave sawtooth 0.850795 -0.887451 0.555742 0.568427
@@ -3473,7 +3473,7 @@ blendfunc add
 
 textures/particles/fire_62
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3483,7 +3483,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.331643 1.927673 132.985687 sawtooth 0 1 0.280770 0.351159
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 12.223426
 AlphaGen wave sawtooth 0.910797 -0.824277 0.280770 0.351159
 rgbGen wave sawtooth 0.854421 -0.898938 0.280770 0.351159
@@ -3494,7 +3494,7 @@ blendfunc add
 
 textures/particles/fire_63
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3504,7 +3504,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.523577 -3.903372 76.850685 sawtooth 0 1 0.039491 0.541935
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.913815
 AlphaGen wave sawtooth 1.044139 -0.954958 0.039491 0.541935
 rgbGen wave sawtooth 1.057747 -1.153175 0.039491 0.541935
@@ -3515,7 +3515,7 @@ blendfunc add
 
 textures/particles/fire_64
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3525,7 +3525,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.243537 -8.910438 64.406433 sawtooth 0 1 0.184332 0.649404
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 9.325998
 AlphaGen wave sawtooth 0.949611 -0.939729 0.184332 0.649404
 rgbGen wave sawtooth 1.105087 -1.090899 0.184332 0.649404
@@ -3536,7 +3536,7 @@ blendfunc add
 
 textures/particles/fire_65
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3546,7 +3546,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.750813 2.145282 51.485710 sawtooth 0 1 0.033540 0.891789
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.617481
 AlphaGen wave sawtooth 0.952156 -0.971218 0.033540 0.891789
 rgbGen wave sawtooth 0.988177 -1.025938 0.033540 0.891789
@@ -3557,7 +3557,7 @@ blendfunc add
 
 textures/particles/fire_66
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3567,7 +3567,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.772879 -3.388453 63.401558 sawtooth 0 1 0.011017 0.786288
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.061007
 AlphaGen wave sawtooth 0.940687 -1.060472 0.011017 0.786288
 rgbGen wave sawtooth 1.186316 -1.146175 0.011017 0.786288
@@ -3578,7 +3578,7 @@ blendfunc add
 
 textures/particles/fire_67
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3588,7 +3588,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.184125 -5.272770 136.434097 sawtooth 0 1 0.286111 0.333659
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.151647
 AlphaGen wave sawtooth 1.020328 -1.208768 0.286111 0.333659
 rgbGen wave sawtooth 0.993402 -1.008701 0.286111 0.333659
@@ -3599,7 +3599,7 @@ blendfunc add
 
 textures/particles/fire_68
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3609,7 +3609,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -10.783943 14.150462 127.421082 sawtooth 0 1 0.256111 0.386965
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 10.738396
 AlphaGen wave sawtooth 0.911365 -1.074865 0.256111 0.386965
 rgbGen wave sawtooth 0.896976 -0.973220 0.256111 0.386965
@@ -3620,7 +3620,7 @@ blendfunc add
 
 textures/particles/fire_69
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3630,7 +3630,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.419373 11.268311 95.422157 sawtooth 0 1 0.239265 0.490708
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 13.364819
 AlphaGen wave sawtooth 1.055174 -0.875976 0.239265 0.490708
 rgbGen wave sawtooth 1.192053 -1.205032 0.239265 0.490708
@@ -3641,7 +3641,7 @@ blendfunc add
 
 textures/particles/fire_70
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3651,7 +3651,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.649901 -2.762739 53.685146 sawtooth 0 1 0.823817 0.794563
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.297952
 AlphaGen wave sawtooth 1.078973 -1.224296 0.823817 0.794563
 rgbGen wave sawtooth 0.994903 -1.082427 0.823817 0.794563
@@ -3662,7 +3662,7 @@ blendfunc add
 
 textures/particles/fire_71
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3672,7 +3672,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.944730 -2.972605 53.603539 sawtooth 0 1 0.001465 0.882946
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 12.730643
 AlphaGen wave sawtooth 0.986160 -0.887652 0.001465 0.882946
 rgbGen wave sawtooth 1.190759 -1.245128 0.001465 0.882946
@@ -3683,7 +3683,7 @@ blendfunc add
 
 textures/particles/fire_72
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3693,7 +3693,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.174064 4.944053 84.603020 sawtooth 0 1 0.380535 0.567738
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.089633
 AlphaGen wave sawtooth 1.032298 -1.015958 0.380535 0.567738
 rgbGen wave sawtooth 1.117124 -1.076690 0.380535 0.567738
@@ -3704,7 +3704,7 @@ blendfunc add
 
 textures/particles/fire_73
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3714,7 +3714,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.439022 5.947978 122.248924 sawtooth 0 1 0.958159 0.374279
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.875240
 AlphaGen wave sawtooth 1.052373 -0.870330 0.958159 0.374279
 rgbGen wave sawtooth 0.835585 -0.807205 0.958159 0.374279
@@ -3725,7 +3725,7 @@ blendfunc add
 
 textures/particles/fire_74
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3735,7 +3735,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 4.256944 -1.068729 128.361679 sawtooth 0 1 0.177587 0.366386
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.327952
 AlphaGen wave sawtooth 0.977193 -1.171590 0.177587 0.366386
 rgbGen wave sawtooth 1.178491 -1.081451 0.177587 0.366386
@@ -3746,7 +3746,7 @@ blendfunc add
 
 textures/particles/fire_75
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3756,7 +3756,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.252118 3.436501 50.562702 sawtooth 0 1 0.265847 0.930167
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 13.008057
 AlphaGen wave sawtooth 1.022336 -1.036821 0.265847 0.930167
 rgbGen wave sawtooth 0.983953 -0.959084 0.265847 0.930167
@@ -3767,7 +3767,7 @@ blendfunc add
 
 textures/particles/fire_76
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3777,7 +3777,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.187028 -0.705561 124.460434 sawtooth 0 1 0.384930 0.379524
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 14.634998
 AlphaGen wave sawtooth 1.021079 -1.136152 0.384930 0.379524
 rgbGen wave sawtooth 1.195764 -1.232304 0.384930 0.379524
@@ -3788,7 +3788,7 @@ blendfunc add
 
 textures/particles/fire_77
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3798,7 +3798,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -14.397352 7.305333 123.896477 sawtooth 0 1 0.086947 0.341355
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 12.731254
 AlphaGen wave sawtooth 0.915271 -0.908637 0.086947 0.341355
 rgbGen wave sawtooth 0.928397 -0.848143 0.086947 0.341355
@@ -3809,7 +3809,7 @@ blendfunc add
 
 textures/particles/fire_78
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3819,7 +3819,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.886426 0.010071 70.015739 sawtooth 0 1 0.486709 0.698582
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.222114
 AlphaGen wave sawtooth 0.974728 -0.995071 0.486709 0.698582
 rgbGen wave sawtooth 1.148021 -1.197085 0.486709 0.698582
@@ -3830,7 +3830,7 @@ blendfunc add
 
 textures/particles/fire_79
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3840,7 +3840,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.817660 3.126696 69.701607 sawtooth 0 1 0.360240 0.585952
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.217231
 AlphaGen wave sawtooth 0.950545 -0.872753 0.360240 0.585952
 rgbGen wave sawtooth 0.951421 -0.887548 0.360240 0.585952
@@ -3851,7 +3851,7 @@ blendfunc add
 
 textures/particles/fire_80
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3861,7 +3861,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.520870 -3.120530 84.905968 sawtooth 0 1 0.565203 0.557385
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.946653
 AlphaGen wave sawtooth 0.968862 -0.982589 0.565203 0.557385
 rgbGen wave sawtooth 0.828431 -0.770223 0.565203 0.557385
@@ -3872,7 +3872,7 @@ blendfunc add
 
 textures/particles/fire_81
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3882,7 +3882,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.211836 3.547980 73.978439 sawtooth 0 1 0.297220 0.565445
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 13.137455
 AlphaGen wave sawtooth 0.913044 -0.988137 0.297220 0.565445
 rgbGen wave sawtooth 1.194043 -1.145643 0.297220 0.565445
@@ -3893,7 +3893,7 @@ blendfunc add
 
 textures/particles/fire_82
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3903,7 +3903,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.709435 -0.990188 79.442856 sawtooth 0 1 0.965667 0.557803
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.926420
 AlphaGen wave sawtooth 0.942799 -0.882110 0.965667 0.557803
 rgbGen wave sawtooth 0.918522 -0.966829 0.965667 0.557803
@@ -3914,7 +3914,7 @@ blendfunc add
 
 textures/particles/fire_83
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3924,7 +3924,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.302882 1.824500 112.787743 sawtooth 0 1 0.762535 0.418903
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.312784
 AlphaGen wave sawtooth 0.912122 -0.783816 0.762535 0.418903
 rgbGen wave sawtooth 1.031269 -0.971401 0.762535 0.418903
@@ -3935,7 +3935,7 @@ blendfunc add
 
 textures/particles/fire_84
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3945,7 +3945,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -14.252396 2.379599 80.320801 sawtooth 0 1 0.515610 0.581997
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 12.893003
 AlphaGen wave sawtooth 0.987918 -1.097302 0.515610 0.581997
 rgbGen wave sawtooth 1.172582 -1.086261 0.515610 0.581997
@@ -3956,7 +3956,7 @@ blendfunc add
 
 textures/particles/fire_85
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3966,7 +3966,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.778992 0.420745 85.181000 sawtooth 0 1 0.372265 0.486280
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.008637
 AlphaGen wave sawtooth 0.953847 -1.088403 0.372265 0.486280
 rgbGen wave sawtooth 1.114048 -1.204611 0.372265 0.486280
@@ -3977,7 +3977,7 @@ blendfunc add
 
 textures/particles/fire_86
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -3987,7 +3987,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.166037 -3.007463 63.920742 sawtooth 0 1 0.795831 0.641145
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.226539
 AlphaGen wave sawtooth 1.044438 -1.184622 0.795831 0.641145
 rgbGen wave sawtooth 0.888919 -0.836277 0.795831 0.641145
@@ -3998,7 +3998,7 @@ blendfunc add
 
 textures/particles/fire_87
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4008,7 +4008,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.043047 1.626384 81.114708 sawtooth 0 1 0.645619 0.586077
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.442091
 AlphaGen wave sawtooth 0.967379 -0.875561 0.645619 0.586077
 rgbGen wave sawtooth 1.009467 -1.050841 0.645619 0.586077
@@ -4019,7 +4019,7 @@ blendfunc add
 
 textures/particles/fire_88
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4029,7 +4029,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.896330 -1.973176 116.996948 sawtooth 0 1 0.546281 0.387431
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.919096
 AlphaGen wave sawtooth 0.982022 -0.959566 0.546281 0.387431
 rgbGen wave sawtooth 0.813477 -0.731837 0.546281 0.387431
@@ -4040,7 +4040,7 @@ blendfunc add
 
 textures/particles/fire_89
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4050,7 +4050,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.997374 -10.359497 73.002106 sawtooth 0 1 0.999237 0.557917
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.593158
 AlphaGen wave sawtooth 1.049968 -0.977328 0.999237 0.557917
 rgbGen wave sawtooth 0.800818 -0.874322 0.999237 0.557917
@@ -4061,7 +4061,7 @@ blendfunc add
 
 textures/particles/fire_90
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4071,7 +4071,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.454459 -1.147523 131.124588 sawtooth 0 1 0.770531 0.359118
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.797388
 AlphaGen wave sawtooth 1.066710 -0.894800 0.770531 0.359118
 rgbGen wave sawtooth 1.122446 -1.135316 0.770531 0.359118
@@ -4082,7 +4082,7 @@ blendfunc add
 
 textures/particles/fire_91
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4092,7 +4092,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.732399 0.266624 79.590729 sawtooth 0 1 0.908933 0.532355
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.110569
 AlphaGen wave sawtooth 1.046904 -1.179849 0.908933 0.532355
 rgbGen wave sawtooth 0.943095 -0.998569 0.908933 0.532355
@@ -4103,7 +4103,7 @@ blendfunc add
 
 textures/particles/fire_92
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4113,7 +4113,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.120850 0.999508 101.568657 sawtooth 0 1 0.094974 0.485487
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.441572
 AlphaGen wave sawtooth 1.054637 -0.993472 0.094974 0.485487
 rgbGen wave sawtooth 0.812452 -0.809372 0.094974 0.485487
@@ -4124,7 +4124,7 @@ blendfunc add
 
 textures/particles/fire_93
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4134,7 +4134,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.029064 2.911096 61.412460 sawtooth 0 1 0.297586 0.664389
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 7.194586
 AlphaGen wave sawtooth 1.088104 -1.152944 0.297586 0.664389
 rgbGen wave sawtooth 0.961968 -0.934236 0.297586 0.664389
@@ -4145,7 +4145,7 @@ blendfunc add
 
 textures/particles/fire_94
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4155,7 +4155,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.201245 -2.893126 114.699684 sawtooth 0 1 0.074984 0.367413
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 9.644612
 AlphaGen wave sawtooth 1.081548 -1.020566 0.074984 0.367413
 rgbGen wave sawtooth 0.940483 -1.037657 0.074984 0.367413
@@ -4166,7 +4166,7 @@ blendfunc add
 
 textures/particles/fire_95
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4176,7 +4176,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.718305 -9.106564 43.345249 sawtooth 0 1 0.274117 0.912399
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 6.099277
 AlphaGen wave sawtooth 1.086029 -1.146229 0.274117 0.912399
 rgbGen wave sawtooth 0.881326 -0.897174 0.274117 0.912399
@@ -4187,7 +4187,7 @@ blendfunc add
 
 textures/particles/fire_96
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4197,7 +4197,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.066628 0.641771 58.605980 sawtooth 0 1 0.039399 0.826219
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.165685
 AlphaGen wave sawtooth 0.961306 -1.084533 0.039399 0.826219
 rgbGen wave sawtooth 0.949467 -0.953804 0.039399 0.826219
@@ -4208,7 +4208,7 @@ blendfunc add
 
 textures/particles/fire_97
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4218,7 +4218,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.061462 -19.425692 112.565392 sawtooth 0 1 0.865169 0.378936
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.551104
 AlphaGen wave sawtooth 0.985885 -0.889294 0.865169 0.378936
 rgbGen wave sawtooth 1.018488 -1.064464 0.865169 0.378936
@@ -4229,7 +4229,7 @@ blendfunc add
 
 textures/particles/fire_98
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4239,7 +4239,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.294532 2.792584 48.324635 sawtooth 0 1 0.357250 0.835275
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 11.254463
 AlphaGen wave sawtooth 1.091217 -1.254192 0.357250 0.835275
 rgbGen wave sawtooth 1.042219 -1.034837 0.357250 0.835275
@@ -4250,7 +4250,7 @@ blendfunc add
 
 textures/particles/fire_99
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4260,7 +4260,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.458437 7.213293 53.673435 sawtooth 0 1 0.476699 0.868345
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 5.199591
 AlphaGen wave sawtooth 1.073827 -0.934730 0.476699 0.868345
 rgbGen wave sawtooth 1.046529 -0.966927 0.476699 0.868345
@@ -4271,7 +4271,7 @@ blendfunc add
 
 textures/particles/fire_100
 {
-qer_editorimage textures/particles/firewirl.tga
+qer_editorimage textures/particles/firewirl
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4281,7 +4281,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.584978 10.656072 59.188740 sawtooth 0 1 0.315653 0.679658
 {
-clampmap textures/particles/firewirl.tga
+clampmap textures/particles/firewirl
 tcMod rotate 8.146459
 AlphaGen wave sawtooth 0.912427 -0.949007 0.315653 0.679658
 rgbGen wave sawtooth 1.072738 -1.081689 0.315653 0.679658
@@ -4296,7 +4296,7 @@ blendfunc add
 
 textures/particles/steam_1
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4306,7 +4306,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.851600 -11.145912 76.376968 sawtooth 0 1 0.861660 0.624931
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.430983
 AlphaGen wave sawtooth 0.950984 -0.854076 0.861660 0.624931
 rgbGen wave sawtooth 1.177575 -1.201444 0.861660 0.624931
@@ -4317,7 +4317,7 @@ blendfunc add
 
 textures/particles/steam_2
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4327,7 +4327,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.859928 -0.038810 124.016708 sawtooth 0 1 0.632038 0.390451
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 10.422529
 AlphaGen wave sawtooth 0.961409 -1.116413 0.632038 0.390451
 rgbGen wave sawtooth 1.107407 -1.196316 0.632038 0.390451
@@ -4338,7 +4338,7 @@ blendfunc add
 
 textures/particles/steam_3
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4348,7 +4348,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.566449 -5.555306 84.868629 sawtooth 0 1 0.547197 0.535522
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 6.069979
 AlphaGen wave sawtooth 0.911621 -0.999997 0.547197 0.535522
 rgbGen wave sawtooth 0.876223 -0.780087 0.547197 0.535522
@@ -4359,7 +4359,7 @@ blendfunc add
 
 textures/particles/steam_4
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4369,7 +4369,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.738917 -1.634229 118.610947 sawtooth 0 1 0.480392 0.388129
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.989227
 AlphaGen wave sawtooth 1.016129 -1.167299 0.480392 0.388129
 rgbGen wave sawtooth 1.032661 -1.114356 0.480392 0.388129
@@ -4380,7 +4380,7 @@ blendfunc add
 
 textures/particles/steam_5
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4390,7 +4390,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.045616 -4.212263 66.421219 sawtooth 0 1 0.999237 0.678139
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.488113
 AlphaGen wave sawtooth 1.054350 -1.092688 0.999237 0.678139
 rgbGen wave sawtooth 0.801196 -0.896338 0.999237 0.678139
@@ -4401,7 +4401,7 @@ blendfunc add
 
 textures/particles/steam_6
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4411,7 +4411,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.907621 -4.634807 132.762878 sawtooth 0 1 0.263314 0.366255
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.092959
 AlphaGen wave sawtooth 0.913642 -1.091815 0.263314 0.366255
 rgbGen wave sawtooth 1.175719 -1.169594 0.263314 0.366255
@@ -4422,7 +4422,7 @@ blendfunc add
 
 textures/particles/steam_7
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4432,7 +4432,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.222928 -2.182096 111.887833 sawtooth 0 1 0.887722 0.372780
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.082888
 AlphaGen wave sawtooth 1.030442 -0.877099 0.887722 0.372780
 rgbGen wave sawtooth 1.016193 -1.021012 0.887722 0.372780
@@ -4443,7 +4443,7 @@ blendfunc add
 
 textures/particles/steam_8
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4453,7 +4453,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -13.331541 -0.256306 71.362953 sawtooth 0 1 0.399457 0.640343
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.650624
 AlphaGen wave sawtooth 1.059526 -1.095032 0.399457 0.640343
 rgbGen wave sawtooth 0.958416 -1.039024 0.399457 0.640343
@@ -4464,7 +4464,7 @@ blendfunc add
 
 textures/particles/steam_9
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4474,7 +4474,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.128495 6.194472 129.124435 sawtooth 0 1 0.249763 0.381628
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.601794
 AlphaGen wave sawtooth 1.080792 -0.913398 0.249763 0.381628
 rgbGen wave sawtooth 0.926041 -0.874218 0.249763 0.381628
@@ -4485,7 +4485,7 @@ blendfunc add
 
 textures/particles/steam_10
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4495,7 +4495,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.853637 -1.812951 50.308670 sawtooth 0 1 0.324900 0.958071
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.056520
 AlphaGen wave sawtooth 1.049559 -1.077459 0.324900 0.958071
 rgbGen wave sawtooth 0.809729 -0.854900 0.324900 0.958071
@@ -4506,7 +4506,7 @@ blendfunc add
 
 textures/particles/steam_11
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4516,7 +4516,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.537927 -2.715674 97.755341 sawtooth 0 1 0.226081 0.483425
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 14.658803
 AlphaGen wave sawtooth 1.042888 -1.112098 0.226081 0.483425
 rgbGen wave sawtooth 1.118870 -1.117341 0.226081 0.483425
@@ -4527,7 +4527,7 @@ blendfunc add
 
 textures/particles/steam_12
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4537,7 +4537,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.283571 -5.007671 72.661545 sawtooth 0 1 0.730644 0.577973
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.600909
 AlphaGen wave sawtooth 0.979678 -1.071618 0.730644 0.577973
 rgbGen wave sawtooth 0.947465 -0.861235 0.730644 0.577973
@@ -4548,7 +4548,7 @@ blendfunc add
 
 textures/particles/steam_13
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4558,7 +4558,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -13.301744 2.009047 107.590317 sawtooth 0 1 0.972533 0.448599
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.061708
 AlphaGen wave sawtooth 1.015824 -1.212259 0.972533 0.448599
 rgbGen wave sawtooth 1.076046 -1.033512 0.972533 0.448599
@@ -4569,7 +4569,7 @@ blendfunc add
 
 textures/particles/steam_14
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4579,7 +4579,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 11.507901 2.176366 121.923607 sawtooth 0 1 0.417676 0.351672
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 6.957457
 AlphaGen wave sawtooth 0.913190 -0.767391 0.417676 0.351672
 rgbGen wave sawtooth 0.916691 -0.906140 0.417676 0.351672
@@ -4590,7 +4590,7 @@ blendfunc add
 
 textures/particles/steam_15
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4600,7 +4600,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 10.255661 -5.614790 66.004486 sawtooth 0 1 0.112491 0.711661
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 10.579089
 AlphaGen wave sawtooth 1.055089 -1.106244 0.112491 0.711661
 rgbGen wave sawtooth 0.844826 -0.783340 0.112491 0.711661
@@ -4611,7 +4611,7 @@ blendfunc add
 
 textures/particles/steam_16
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4621,7 +4621,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.237539 10.076818 88.336021 sawtooth 0 1 0.260628 0.551568
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.789880
 AlphaGen wave sawtooth 1.041948 -0.982406 0.260628 0.551568
 rgbGen wave sawtooth 0.943657 -0.966286 0.260628 0.551568
@@ -4632,7 +4632,7 @@ blendfunc add
 
 textures/particles/steam_17
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4642,7 +4642,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 9.567821 -4.755998 95.393707 sawtooth 0 1 0.802728 0.420753
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.797876
 AlphaGen wave sawtooth 1.043046 -0.931281 0.802728 0.420753
 rgbGen wave sawtooth 1.097043 -1.044578 0.802728 0.420753
@@ -4653,7 +4653,7 @@ blendfunc add
 
 textures/particles/steam_18
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4663,7 +4663,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.885550 -2.588591 120.309792 sawtooth 0 1 0.497635 0.382421
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 12.128513
 AlphaGen wave sawtooth 0.900189 -1.088763 0.497635 0.382421
 rgbGen wave sawtooth 0.963860 -0.900769 0.497635 0.382421
@@ -4674,7 +4674,7 @@ blendfunc add
 
 textures/particles/steam_19
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4684,7 +4684,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.534829 0.814973 64.340530 sawtooth 0 1 0.265999 0.713272
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 11.929533
 AlphaGen wave sawtooth 1.082690 -1.261852 0.265999 0.713272
 rgbGen wave sawtooth 0.832460 -0.932429 0.265999 0.713272
@@ -4695,7 +4695,7 @@ blendfunc add
 
 textures/particles/steam_20
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4705,7 +4705,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.068601 -4.478627 124.436234 sawtooth 0 1 0.811151 0.360596
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 11.764122
 AlphaGen wave sawtooth 1.077978 -1.223838 0.811151 0.360596
 rgbGen wave sawtooth 1.165661 -1.187448 0.811151 0.360596
@@ -4716,7 +4716,7 @@ blendfunc add
 
 textures/particles/steam_21
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4726,7 +4726,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.422696 -0.031856 116.208611 sawtooth 0 1 0.633106 0.407981
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.007141
 AlphaGen wave sawtooth 0.917512 -0.822105 0.633106 0.407981
 rgbGen wave sawtooth 1.177306 -1.276055 0.633106 0.407981
@@ -4737,7 +4737,7 @@ blendfunc add
 
 textures/particles/steam_22
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4747,7 +4747,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -10.725885 7.425058 57.020008 sawtooth 0 1 0.046419 0.775385
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 14.812006
 AlphaGen wave sawtooth 1.059191 -0.961452 0.046419 0.775385
 rgbGen wave sawtooth 1.103635 -1.027476 0.046419 0.775385
@@ -4758,7 +4758,7 @@ blendfunc add
 
 textures/particles/steam_23
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4768,7 +4768,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.154024 -14.669550 131.771454 sawtooth 0 1 0.248421 0.365887
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 11.175726
 AlphaGen wave sawtooth 0.913495 -0.970705 0.248421 0.365887
 rgbGen wave sawtooth 1.125095 -1.220115 0.248421 0.365887
@@ -4779,7 +4779,7 @@ blendfunc add
 
 textures/particles/steam_24
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4789,7 +4789,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.311843 6.378160 115.984917 sawtooth 0 1 0.566515 0.427896
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 11.018556
 AlphaGen wave sawtooth 0.903735 -0.779263 0.566515 0.427896
 rgbGen wave sawtooth 0.930815 -0.840678 0.566515 0.427896
@@ -4800,7 +4800,7 @@ blendfunc add
 
 textures/particles/steam_25
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4810,7 +4810,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.509778 -2.076105 44.521255 sawtooth 0 1 0.363079 0.934145
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.941465
 AlphaGen wave sawtooth 0.975436 -1.063726 0.363079 0.934145
 rgbGen wave sawtooth 0.922025 -0.956056 0.363079 0.934145
@@ -4821,7 +4821,7 @@ blendfunc add
 
 textures/particles/steam_26
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4831,7 +4831,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.148485 -8.073049 122.130287 sawtooth 0 1 0.782952 0.396536
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.593341
 AlphaGen wave sawtooth 0.927973 -0.901367 0.782952 0.396536
 rgbGen wave sawtooth 0.924320 -0.938215 0.782952 0.396536
@@ -4842,7 +4842,7 @@ blendfunc add
 
 textures/particles/steam_27
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4852,7 +4852,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.956821 24.447697 116.611214 sawtooth 0 1 0.483993 0.409828
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 10.552843
 AlphaGen wave sawtooth 0.934535 -0.953511 0.483993 0.409828
 rgbGen wave sawtooth 0.958379 -0.987381 0.483993 0.409828
@@ -4863,7 +4863,7 @@ blendfunc add
 
 textures/particles/steam_28
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4873,7 +4873,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.600849 -0.417745 51.644657 sawtooth 0 1 0.958037 0.865958
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.586688
 AlphaGen wave sawtooth 0.937880 -1.097851 0.958037 0.865958
 rgbGen wave sawtooth 1.086142 -1.176992 0.958037 0.865958
@@ -4884,7 +4884,7 @@ blendfunc add
 
 textures/particles/steam_29
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4894,7 +4894,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.055177 -2.776444 59.586998 sawtooth 0 1 0.696646 0.768511
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.417982
 AlphaGen wave sawtooth 0.961434 -0.803464 0.696646 0.768511
 rgbGen wave sawtooth 1.144200 -1.124360 0.696646 0.768511
@@ -4905,7 +4905,7 @@ blendfunc add
 
 textures/particles/steam_30
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4915,7 +4915,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.020151 -5.708313 59.869133 sawtooth 0 1 0.572100 0.667556
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.351085
 AlphaGen wave sawtooth 0.960646 -0.960469 0.572100 0.667556
 rgbGen wave sawtooth 0.839296 -0.796017 0.572100 0.667556
@@ -4926,7 +4926,7 @@ blendfunc add
 
 textures/particles/steam_31
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4936,7 +4936,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.364089 -24.862083 117.214699 sawtooth 0 1 0.156011 0.413563
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.836879
 AlphaGen wave sawtooth 0.954848 -0.769424 0.156011 0.413563
 rgbGen wave sawtooth 0.870315 -0.810770 0.156011 0.413563
@@ -4947,7 +4947,7 @@ blendfunc add
 
 textures/particles/steam_32
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4957,7 +4957,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.300814 0.732087 119.384506 sawtooth 0 1 0.011444 0.377009
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 11.678671
 AlphaGen wave sawtooth 1.026756 -1.019474 0.011444 0.377009
 rgbGen wave sawtooth 0.958672 -0.933399 0.011444 0.377009
@@ -4968,7 +4968,7 @@ blendfunc add
 
 textures/particles/steam_33
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4978,7 +4978,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.925403 7.192833 97.465172 sawtooth 0 1 0.770531 0.502893
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 11.613667
 AlphaGen wave sawtooth 0.954646 -0.789645 0.770531 0.502893
 rgbGen wave sawtooth 1.034333 -1.031779 0.770531 0.502893
@@ -4989,7 +4989,7 @@ blendfunc add
 
 textures/particles/steam_34
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4999,7 +4999,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.626701 1.458168 116.472565 sawtooth 0 1 0.687216 0.351332
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 6.036714
 AlphaGen wave sawtooth 1.002078 -1.197964 0.687216 0.351332
 rgbGen wave sawtooth 1.126927 -1.049760 0.687216 0.351332
@@ -5010,7 +5010,7 @@ blendfunc add
 
 textures/particles/steam_35
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5020,7 +5020,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.155244 -2.488752 57.365097 sawtooth 0 1 0.011628 0.771951
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 11.554766
 AlphaGen wave sawtooth 0.955196 -1.014115 0.011628 0.771951
 rgbGen wave sawtooth 1.096432 -1.165310 0.011628 0.771951
@@ -5031,7 +5031,7 @@ blendfunc add
 
 textures/particles/steam_36
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5041,7 +5041,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.268653 -2.176199 75.312172 sawtooth 0 1 0.563219 0.610789
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.185217
 AlphaGen wave sawtooth 0.982351 -0.890362 0.563219 0.610789
 rgbGen wave sawtooth 0.937980 -0.964229 0.563219 0.610789
@@ -5052,7 +5052,7 @@ blendfunc add
 
 textures/particles/steam_37
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5062,7 +5062,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.379602 -6.555643 43.851223 sawtooth 0 1 0.893551 0.986156
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 14.708243
 AlphaGen wave sawtooth 0.974905 -1.164797 0.893551 0.986156
 rgbGen wave sawtooth 1.171679 -1.143147 0.893551 0.986156
@@ -5073,7 +5073,7 @@ blendfunc add
 
 textures/particles/steam_38
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5083,7 +5083,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.660718 -1.356656 49.433968 sawtooth 0 1 0.081973 0.830196
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.606769
 AlphaGen wave sawtooth 0.965853 -0.775912 0.081973 0.830196
 rgbGen wave sawtooth 1.033601 -0.966964 0.081973 0.830196
@@ -5094,7 +5094,7 @@ blendfunc add
 
 textures/particles/steam_39
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5104,7 +5104,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.379170 -3.019318 95.645653 sawtooth 0 1 0.606159 0.494663
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 12.699820
 AlphaGen wave sawtooth 0.996030 -0.825291 0.606159 0.494663
 rgbGen wave sawtooth 0.812488 -0.806375 0.606159 0.494663
@@ -5115,7 +5115,7 @@ blendfunc add
 
 textures/particles/steam_40
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5125,7 +5125,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.172062 2.513479 76.322739 sawtooth 0 1 0.252327 0.581418
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.857692
 AlphaGen wave sawtooth 1.039341 -0.912378 0.252327 0.581418
 rgbGen wave sawtooth 0.803174 -0.833543 0.252327 0.581418
@@ -5136,7 +5136,7 @@ blendfunc add
 
 textures/particles/steam_41
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5146,7 +5146,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -6.784805 -9.008121 56.212852 sawtooth 0 1 0.178411 0.774432
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 12.937254
 AlphaGen wave sawtooth 0.950240 -0.988223 0.178411 0.774432
 rgbGen wave sawtooth 1.039338 -1.000082 0.178411 0.774432
@@ -5157,7 +5157,7 @@ blendfunc add
 
 textures/particles/steam_42
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5167,7 +5167,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.155707 -6.383517 40.643684 sawtooth 0 1 0.828791 0.988238
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.400708
 AlphaGen wave sawtooth 0.971987 -0.873321 0.828791 0.988238
 rgbGen wave sawtooth 0.952861 -0.856346 0.828791 0.988238
@@ -5178,7 +5178,7 @@ blendfunc add
 
 textures/particles/steam_43
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5188,7 +5188,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 16.832890 8.111264 107.116348 sawtooth 0 1 0.017853 0.404386
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.012696
 AlphaGen wave sawtooth 1.014835 -1.014487 0.017853 0.404386
 rgbGen wave sawtooth 0.987664 -0.977456 0.017853 0.404386
@@ -5199,7 +5199,7 @@ blendfunc add
 
 textures/particles/steam_44
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5209,7 +5209,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.635640 4.101224 107.220848 sawtooth 0 1 0.693991 0.382305
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.972381
 AlphaGen wave sawtooth 0.937513 -1.070153 0.693991 0.382305
 rgbGen wave sawtooth 0.906925 -0.950258 0.693991 0.382305
@@ -5220,7 +5220,7 @@ blendfunc add
 
 textures/particles/steam_45
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5230,7 +5230,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 9.173224 0.940380 54.296585 sawtooth 0 1 0.347850 0.762502
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.617084
 AlphaGen wave sawtooth 1.026975 -0.956593 0.347850 0.762502
 rgbGen wave sawtooth 1.105710 -1.099670 0.347850 0.762502
@@ -5241,7 +5241,7 @@ blendfunc add
 
 textures/particles/steam_46
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5251,7 +5251,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.484691 -3.320047 51.567081 sawtooth 0 1 0.378796 0.921586
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.299997
 AlphaGen wave sawtooth 0.900665 -0.712226 0.378796 0.921586
 rgbGen wave sawtooth 0.892532 -0.810800 0.378796 0.921586
@@ -5262,7 +5262,7 @@ blendfunc add
 
 textures/particles/steam_47
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5272,7 +5272,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.403458 3.230261 56.795151 sawtooth 0 1 0.565111 0.718496
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 6.893063
 AlphaGen wave sawtooth 0.944264 -1.043614 0.565111 0.718496
 rgbGen wave sawtooth 1.009992 -1.048961 0.565111 0.718496
@@ -5283,7 +5283,7 @@ blendfunc add
 
 textures/particles/steam_48
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5293,7 +5293,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 4.594651 0.140790 61.313404 sawtooth 0 1 0.740654 0.721057
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 14.302347
 AlphaGen wave sawtooth 1.035887 -0.879687 0.740654 0.721057
 rgbGen wave sawtooth 1.129014 -1.127027 0.740654 0.721057
@@ -5304,7 +5304,7 @@ blendfunc add
 
 textures/particles/steam_49
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5314,7 +5314,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.849854 1.515383 48.522266 sawtooth 0 1 0.495071 0.949575
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.707847
 AlphaGen wave sawtooth 0.903595 -0.891272 0.495071 0.949575
 rgbGen wave sawtooth 0.934904 -0.845451 0.495071 0.949575
@@ -5325,7 +5325,7 @@ blendfunc add
 
 textures/particles/steam_50
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5335,7 +5335,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.491375 -6.066702 105.395111 sawtooth 0 1 0.801202 0.393328
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 6.960204
 AlphaGen wave sawtooth 1.018247 -1.089764 0.801202 0.393328
 rgbGen wave sawtooth 1.042769 -1.102509 0.801202 0.393328
@@ -5346,7 +5346,7 @@ blendfunc add
 
 textures/particles/steam_51
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5356,7 +5356,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -6.159848 -3.630268 134.659775 sawtooth 0 1 0.556352 0.336662
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.000366
 AlphaGen wave sawtooth 1.082171 -0.965365 0.556352 0.336662
 rgbGen wave sawtooth 1.047261 -1.095337 0.556352 0.336662
@@ -5367,7 +5367,7 @@ blendfunc add
 
 textures/particles/steam_52
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5377,7 +5377,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.257544 -9.801443 120.433403 sawtooth 0 1 0.237678 0.371917
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.195135
 AlphaGen wave sawtooth 0.964663 -1.102246 0.237678 0.371917
 rgbGen wave sawtooth 1.111960 -1.144264 0.237678 0.371917
@@ -5388,7 +5388,7 @@ blendfunc add
 
 textures/particles/steam_53
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5398,7 +5398,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.720393 3.162540 52.687775 sawtooth 0 1 0.081271 0.937030
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.468886
 AlphaGen wave sawtooth 0.969814 -1.061303 0.081271 0.937030
 rgbGen wave sawtooth 0.988592 -0.927027 0.081271 0.937030
@@ -5409,7 +5409,7 @@ blendfunc add
 
 textures/particles/steam_54
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5419,7 +5419,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.550067 -1.832080 69.812660 sawtooth 0 1 0.656514 0.610493
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.442793
 AlphaGen wave sawtooth 1.031785 -0.909741 0.656514 0.610493
 rgbGen wave sawtooth 0.857338 -0.861089 0.656514 0.610493
@@ -5430,7 +5430,7 @@ blendfunc add
 
 textures/particles/steam_55
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5440,7 +5440,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -16.123848 -6.912881 110.486565 sawtooth 0 1 0.604755 0.418464
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 12.609179
 AlphaGen wave sawtooth 0.944819 -0.745833 0.604755 0.418464
 rgbGen wave sawtooth 1.105429 -1.016135 0.604755 0.418464
@@ -5451,7 +5451,7 @@ blendfunc add
 
 textures/particles/steam_56
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5461,7 +5461,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 10.503769 -6.797222 102.056839 sawtooth 0 1 0.179327 0.480067
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.582781
 AlphaGen wave sawtooth 1.021354 -1.067089 0.179327 0.480067
 rgbGen wave sawtooth 1.091134 -1.000443 0.179327 0.480067
@@ -5472,7 +5472,7 @@ blendfunc add
 
 textures/particles/steam_57
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5482,7 +5482,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.192111 -0.660853 66.928673 sawtooth 0 1 0.950255 0.644931
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 6.779229
 AlphaGen wave sawtooth 0.931794 -1.110565 0.950255 0.644931
 rgbGen wave sawtooth 1.181640 -1.184231 0.950255 0.644931
@@ -5493,7 +5493,7 @@ blendfunc add
 
 textures/particles/steam_58
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5503,7 +5503,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.142779 -11.682321 102.027603 sawtooth 0 1 0.661550 0.483353
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 12.550890
 AlphaGen wave sawtooth 1.028281 -0.907630 0.661550 0.483353
 rgbGen wave sawtooth 0.860732 -0.766433 0.661550 0.483353
@@ -5514,7 +5514,7 @@ blendfunc add
 
 textures/particles/steam_59
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5524,7 +5524,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.088942 -16.556780 74.896355 sawtooth 0 1 0.538438 0.613212
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 14.782708
 AlphaGen wave sawtooth 0.934639 -0.888513 0.538438 0.613212
 rgbGen wave sawtooth 1.147227 -1.107569 0.538438 0.613212
@@ -5535,7 +5535,7 @@ blendfunc add
 
 textures/particles/steam_60
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5545,7 +5545,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 11.412406 5.550622 61.979218 sawtooth 0 1 0.671072 0.676264
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.725120
 AlphaGen wave sawtooth 1.017307 -0.947133 0.671072 0.676264
 rgbGen wave sawtooth 0.831886 -0.829984 0.671072 0.676264
@@ -5556,7 +5556,7 @@ blendfunc add
 
 textures/particles/steam_61
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5566,7 +5566,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 4.418547 -6.428156 51.403984 sawtooth 0 1 0.641987 0.819441
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 14.679251
 AlphaGen wave sawtooth 0.905133 -1.058086 0.641987 0.819441
 rgbGen wave sawtooth 1.054280 -1.112464 0.641987 0.819441
@@ -5577,7 +5577,7 @@ blendfunc add
 
 textures/particles/steam_62
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5587,7 +5587,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.181958 -2.320007 98.833969 sawtooth 0 1 0.801111 0.431616
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 6.187170
 AlphaGen wave sawtooth 1.055034 -1.062670 0.801111 0.431616
 rgbGen wave sawtooth 1.193506 -1.187014 0.801111 0.431616
@@ -5598,7 +5598,7 @@ blendfunc add
 
 textures/particles/steam_63
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5608,7 +5608,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.432374 1.199218 81.574791 sawtooth 0 1 0.437696 0.536030
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 11.422316
 AlphaGen wave sawtooth 1.053600 -1.178072 0.437696 0.536030
 rgbGen wave sawtooth 0.833436 -0.890619 0.437696 0.536030
@@ -5619,7 +5619,7 @@ blendfunc add
 
 textures/particles/steam_64
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5629,7 +5629,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 4.063802 -8.344232 133.748001 sawtooth 0 1 0.605060 0.361559
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 10.507370
 AlphaGen wave sawtooth 0.980813 -1.030943 0.605060 0.361559
 rgbGen wave sawtooth 1.186340 -1.170040 0.605060 0.361559
@@ -5640,7 +5640,7 @@ blendfunc add
 
 textures/particles/steam_65
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5650,7 +5650,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -13.601385 0.764330 135.273590 sawtooth 0 1 0.786462 0.356951
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.694296
 AlphaGen wave sawtooth 1.056535 -0.940120 0.786462 0.356951
 rgbGen wave sawtooth 1.023164 -1.065337 0.786462 0.356951
@@ -5661,7 +5661,7 @@ blendfunc add
 
 textures/particles/steam_66
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5671,7 +5671,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -15.083706 11.343871 102.760338 sawtooth 0 1 0.043641 0.386371
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.043031
 AlphaGen wave sawtooth 0.997146 -0.890765 0.043641 0.386371
 rgbGen wave sawtooth 1.108408 -1.095245 0.043641 0.386371
@@ -5682,7 +5682,7 @@ blendfunc add
 
 textures/particles/steam_67
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5692,7 +5692,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 9.372140 13.520548 74.292084 sawtooth 0 1 0.830561 0.573461
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.261513
 AlphaGen wave sawtooth 0.993558 -1.062816 0.830561 0.573461
 rgbGen wave sawtooth 0.849281 -0.902075 0.830561 0.573461
@@ -5703,7 +5703,7 @@ blendfunc add
 
 textures/particles/steam_68
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5713,7 +5713,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 19.875334 16.840231 118.882347 sawtooth 0 1 0.454878 0.370127
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 14.098178
 AlphaGen wave sawtooth 1.023203 -1.135041 0.454878 0.370127
 rgbGen wave sawtooth 0.981927 -0.957143 0.454878 0.370127
@@ -5724,7 +5724,7 @@ blendfunc add
 
 textures/particles/steam_69
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5734,7 +5734,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.419428 -10.370455 130.015915 sawtooth 0 1 0.858547 0.340143
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.513321
 AlphaGen wave sawtooth 0.975607 -0.962722 0.858547 0.340143
 rgbGen wave sawtooth 1.173705 -1.110614 0.858547 0.340143
@@ -5745,7 +5745,7 @@ blendfunc add
 
 textures/particles/steam_70
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5755,7 +5755,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 4.060127 -8.763881 132.114349 sawtooth 0 1 0.316324 0.343236
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.930479
 AlphaGen wave sawtooth 0.908643 -0.912091 0.316324 0.343236
 rgbGen wave sawtooth 1.029841 -0.991085 0.316324 0.343236
@@ -5766,7 +5766,7 @@ blendfunc add
 
 textures/particles/steam_71
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5776,7 +5776,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.222468 -0.264640 91.792778 sawtooth 0 1 0.577502 0.530219
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 10.861080
 AlphaGen wave sawtooth 1.034849 -0.894702 0.577502 0.530219
 rgbGen wave sawtooth 1.178539 -1.254778 0.577502 0.530219
@@ -5787,7 +5787,7 @@ blendfunc add
 
 textures/particles/steam_72
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5797,7 +5797,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.616869 6.944197 53.293148 sawtooth 0 1 0.095126 0.896621
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.785424
 AlphaGen wave sawtooth 0.973965 -0.800113 0.095126 0.896621
 rgbGen wave sawtooth 0.954839 -0.935542 0.095126 0.896621
@@ -5808,7 +5808,7 @@ blendfunc add
 
 textures/particles/steam_73
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5818,7 +5818,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.986874 1.850237 60.531849 sawtooth 0 1 0.075503 0.738345
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.568926
 AlphaGen wave sawtooth 1.058025 -0.933662 0.075503 0.738345
 rgbGen wave sawtooth 1.056502 -0.996176 0.075503 0.738345
@@ -5829,7 +5829,7 @@ blendfunc add
 
 textures/particles/steam_74
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5839,7 +5839,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 15.002353 -0.479863 139.168137 sawtooth 0 1 0.896420 0.336683
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.072298
 AlphaGen wave sawtooth 1.053319 -0.886962 0.896420 0.336683
 rgbGen wave sawtooth 0.989044 -0.965035 0.896420 0.336683
@@ -5850,7 +5850,7 @@ blendfunc add
 
 textures/particles/steam_75
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5860,7 +5860,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 22.437111 -7.171051 122.838135 sawtooth 0 1 0.477096 0.345188
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.671896
 AlphaGen wave sawtooth 1.084265 -0.945326 0.477096 0.345188
 rgbGen wave sawtooth 1.087692 -1.073064 0.477096 0.345188
@@ -5871,7 +5871,7 @@ blendfunc add
 
 textures/particles/steam_76
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5881,7 +5881,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 11.109951 4.346410 71.275169 sawtooth 0 1 0.053438 0.671827
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.800867
 AlphaGen wave sawtooth 1.091375 -1.015098 0.053438 0.671827
 rgbGen wave sawtooth 1.040181 -1.057750 0.053438 0.671827
@@ -5892,7 +5892,7 @@ blendfunc add
 
 textures/particles/steam_77
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5902,7 +5902,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.998752 -4.636353 46.944153 sawtooth 0 1 0.718741 0.962744
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.095828
 AlphaGen wave sawtooth 1.081219 -1.242424 0.718741 0.962744
 rgbGen wave sawtooth 0.950041 -0.981802 0.718741 0.962744
@@ -5913,7 +5913,7 @@ blendfunc add
 
 textures/particles/steam_78
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5923,7 +5923,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.435888 -1.731604 52.495972 sawtooth 0 1 0.874569 0.840115
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.663167
 AlphaGen wave sawtooth 1.011551 -1.113892 0.874569 0.840115
 rgbGen wave sawtooth 1.047578 -1.131837 0.874569 0.840115
@@ -5934,7 +5934,7 @@ blendfunc add
 
 textures/particles/steam_79
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5944,7 +5944,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.030206 -4.224197 53.660629 sawtooth 0 1 0.123692 0.826344
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.227363
 AlphaGen wave sawtooth 1.083795 -1.217008 0.123692 0.826344
 rgbGen wave sawtooth 0.982904 -1.010123 0.123692 0.826344
@@ -5955,7 +5955,7 @@ blendfunc add
 
 textures/particles/steam_80
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5965,7 +5965,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.858616 -3.262615 82.913147 sawtooth 0 1 0.099521 0.505001
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.942076
 AlphaGen wave sawtooth 1.054668 -1.112586 0.099521 0.505001
 rgbGen wave sawtooth 1.131822 -1.159145 0.099521 0.505001
@@ -5976,7 +5976,7 @@ blendfunc add
 
 textures/particles/steam_81
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5986,7 +5986,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.410435 4.674620 94.010773 sawtooth 0 1 0.659841 0.429647
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 14.223609
 AlphaGen wave sawtooth 1.053911 -0.956880 0.659841 0.429647
 rgbGen wave sawtooth 0.852358 -0.793344 0.659841 0.429647
@@ -5997,7 +5997,7 @@ blendfunc add
 
 textures/particles/steam_82
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6007,7 +6007,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.742176 5.114626 85.512398 sawtooth 0 1 0.847072 0.582783
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.011475
 AlphaGen wave sawtooth 0.909479 -0.983450 0.847072 0.582783
 rgbGen wave sawtooth 1.121592 -1.166134 0.847072 0.582783
@@ -6018,7 +6018,7 @@ blendfunc add
 
 textures/particles/steam_83
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6028,7 +6028,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.155590 -11.583459 92.889198 sawtooth 0 1 0.047914 0.481323
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.525895
 AlphaGen wave sawtooth 0.921277 -0.967391 0.047914 0.481323
 rgbGen wave sawtooth 0.901993 -0.952998 0.047914 0.481323
@@ -6039,7 +6039,7 @@ blendfunc add
 
 textures/particles/steam_84
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6049,7 +6049,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.381885 4.435768 85.353188 sawtooth 0 1 0.579150 0.511752
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 6.812494
 AlphaGen wave sawtooth 0.944160 -0.779574 0.579150 0.511752
 rgbGen wave sawtooth 0.824268 -0.887585 0.579150 0.511752
@@ -6060,7 +6060,7 @@ blendfunc add
 
 textures/particles/steam_85
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6070,7 +6070,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.874664 7.437418 121.837502 sawtooth 0 1 0.373699 0.379156
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 14.664907
 AlphaGen wave sawtooth 0.920728 -1.105676 0.373699 0.379156
 rgbGen wave sawtooth 0.864077 -0.855327 0.373699 0.379156
@@ -6081,7 +6081,7 @@ blendfunc add
 
 textures/particles/steam_86
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6091,7 +6091,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -19.810753 -13.716913 131.741821 sawtooth 0 1 0.492508 0.361774
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 10.574205
 AlphaGen wave sawtooth 0.926624 -1.081750 0.492508 0.361774
 rgbGen wave sawtooth 1.019379 -0.971389 0.492508 0.361774
@@ -6102,7 +6102,7 @@ blendfunc add
 
 textures/particles/steam_87
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6112,7 +6112,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.335160 -11.507196 97.583206 sawtooth 0 1 0.672109 0.495966
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 12.667470
 AlphaGen wave sawtooth 1.074303 -0.966677 0.672109 0.495966
 rgbGen wave sawtooth 1.004169 -0.921870 0.672109 0.495966
@@ -6123,7 +6123,7 @@ blendfunc add
 
 textures/particles/steam_88
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6133,7 +6133,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 6.202159 -8.750676 93.077972 sawtooth 0 1 0.397900 0.482556
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 6.482589
 AlphaGen wave sawtooth 1.015488 -0.827207 0.397900 0.482556
 rgbGen wave sawtooth 1.049007 -0.969344 0.397900 0.482556
@@ -6144,7 +6144,7 @@ blendfunc add
 
 textures/particles/steam_89
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6154,7 +6154,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.929560 -13.954226 129.678406 sawtooth 0 1 0.218848 0.370730
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 9.566790
 AlphaGen wave sawtooth 1.003165 -1.114783 0.218848 0.370730
 rgbGen wave sawtooth 0.825416 -0.858403 0.218848 0.370730
@@ -6165,7 +6165,7 @@ blendfunc add
 
 textures/particles/steam_90
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6175,7 +6175,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.678058 21.910069 140.489746 sawtooth 0 1 0.189520 0.337196
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 11.201361
 AlphaGen wave sawtooth 0.938301 -1.037333 0.189520 0.337196
 rgbGen wave sawtooth 0.904715 -0.813169 0.189520 0.337196
@@ -6186,7 +6186,7 @@ blendfunc add
 
 textures/particles/steam_91
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6196,7 +6196,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.425862 -6.971515 99.711441 sawtooth 0 1 0.111026 0.494022
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.808100
 AlphaGen wave sawtooth 0.918476 -1.005777 0.111026 0.494022
 rgbGen wave sawtooth 0.819874 -0.869701 0.111026 0.494022
@@ -6207,7 +6207,7 @@ blendfunc add
 
 textures/particles/steam_92
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6217,7 +6217,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.019570 5.670334 49.700977 sawtooth 0 1 0.061983 0.981724
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 10.392621
 AlphaGen wave sawtooth 0.974227 -0.863109 0.061983 0.981724
 rgbGen wave sawtooth 1.117905 -1.192624 0.061983 0.981724
@@ -6228,7 +6228,7 @@ blendfunc add
 
 textures/particles/steam_93
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6238,7 +6238,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.641641 0.323873 44.077721 sawtooth 0 1 0.266610 0.927167
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.082522
 AlphaGen wave sawtooth 0.958064 -0.867125 0.266610 0.927167
 rgbGen wave sawtooth 0.869509 -0.817740 0.266610 0.927167
@@ -6249,7 +6249,7 @@ blendfunc add
 
 textures/particles/steam_94
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6259,7 +6259,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 2.646167 -0.926432 60.436375 sawtooth 0 1 0.331980 0.807885
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 10.899228
 AlphaGen wave sawtooth 1.049028 -1.205094 0.331980 0.807885
 rgbGen wave sawtooth 0.998431 -0.948189 0.331980 0.807885
@@ -6270,7 +6270,7 @@ blendfunc add
 
 textures/particles/steam_95
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6280,7 +6280,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -7.915985 1.788416 82.444527 sawtooth 0 1 0.349895 0.532338
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 8.491013
 AlphaGen wave sawtooth 0.931520 -1.074535 0.349895 0.532338
 rgbGen wave sawtooth 1.023286 -0.988473 0.349895 0.532338
@@ -6291,7 +6291,7 @@ blendfunc add
 
 textures/particles/steam_96
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6301,7 +6301,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.900966 2.241626 139.214523 sawtooth 0 1 0.681722 0.343344
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.305185
 AlphaGen wave sawtooth 0.957204 -0.910431 0.681722 0.343344
 rgbGen wave sawtooth 0.886184 -0.789883 0.681722 0.343344
@@ -6312,7 +6312,7 @@ blendfunc add
 
 textures/particles/steam_97
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6322,7 +6322,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 8.713972 0.272034 80.799423 sawtooth 0 1 0.460463 0.543914
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 13.229011
 AlphaGen wave sawtooth 0.935011 -0.954073 0.460463 0.543914
 rgbGen wave sawtooth 1.154711 -1.078735 0.460463 0.543914
@@ -6333,7 +6333,7 @@ blendfunc add
 
 textures/particles/steam_98
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6343,7 +6343,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -6.439054 1.159017 135.963425 sawtooth 0 1 0.497513 0.362848
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.424085
 AlphaGen wave sawtooth 1.073223 -0.981112 0.497513 0.362848
 rgbGen wave sawtooth 1.130882 -1.080297 0.497513 0.362848
@@ -6354,7 +6354,7 @@ blendfunc add
 
 textures/particles/steam_99
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6364,7 +6364,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.885020 -4.129549 136.734924 sawtooth 0 1 0.830317 0.353599
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 5.421461
 AlphaGen wave sawtooth 0.924207 -0.728663 0.830317 0.353599
 rgbGen wave sawtooth 0.889993 -0.828391 0.830317 0.353599
@@ -6375,7 +6375,7 @@ blendfunc add
 
 textures/particles/steam_100
 {
-qer_editorimage textures/particles/steam.tga
+qer_editorimage textures/particles/steam
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -6385,7 +6385,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -5.133010 6.476621 122.296761 sawtooth 0 1 0.344096 0.403629
 {
-clampmap textures/particles/steam.tga
+clampmap textures/particles/steam
 tcMod rotate 7.120121
 AlphaGen wave sawtooth 0.926618 -1.116913 0.344096 0.403629
 rgbGen wave sawtooth 1.147398 -1.200363 0.344096 0.403629
@@ -6395,8 +6395,8 @@ blendfunc add
 }
 
 textures/pad_wop/padbubble
-{       	
-	qer_editorimage textures/pad_wop/padbubble.tga
+{
+	qer_editorimage textures/pad_wop/padbubble
 	qer_trans 0.5
 	surfaceparm nonsolid
         surfaceparm nolightmap
@@ -6405,7 +6405,7 @@ textures/pad_wop/padbubble
 	surfaceparm trans
 	cull none
 	{
-		map textures/pad_wop/padbubble.tga
+		map textures/pad_wop/padbubble
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbgen vertex
 		depthWrite
@@ -6426,19 +6426,19 @@ textures/pad_wop/padjump_red
              	surfaceparm nomarks
 	surfaceparm nolightmap
 	cull none
-	
+
 	{
-		Map textures/pad_wop/padjump_red.tga
+		Map textures/pad_wop/padjump_red
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 0 1 0 1
                 //tcMod rotate 103
-	}	
+	}
 	{
-		Map textures/pad_wop/padjump_red2.tga
+		Map textures/pad_wop/padjump_red2
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 1 1 0 1
                //tcMod rotate -140
-	}	
+	}
 }
 
 
@@ -6452,19 +6452,19 @@ textures/pad_wop/padjump_blue
              	surfaceparm nomarks
 	surfaceparm nolightmap
 	cull none
-	
+
 	{
-		Map textures/pad_wop/padjump_blue.tga
+		Map textures/pad_wop/padjump_blue
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 0 1 0 1
                 //tcMod rotate 103
-	}	
+	}
 	{
-		Map textures/pad_wop/padjump_blue2.tga
+		Map textures/pad_wop/padjump_blue2
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 1 1 0 1
                //tcMod rotate -140
-	}	
+	}
 }
 
 textures/pad_wop/padjump_purple
@@ -6477,19 +6477,19 @@ textures/pad_wop/padjump_purple
              	surfaceparm nomarks
 	surfaceparm nolightmap
 	cull none
-	
+
 	{
-		Map textures/pad_wop/padjump_purple.tga
+		Map textures/pad_wop/padjump_purple
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 0 1 0 1
                 //tcMod rotate 103
-	}	
+	}
 	{
-		Map textures/pad_wop/padjump_purple2.tga
+		Map textures/pad_wop/padjump_purple2
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 1 1 0 1
                //tcMod rotate -140
-	}	
+	}
 }
 
 textures/pad_wop/padjump_green
@@ -6502,19 +6502,19 @@ textures/pad_wop/padjump_green
              	surfaceparm nomarks
 	surfaceparm nolightmap
 	cull none
-	
+
 	{
-		Map textures/pad_wop/padjump_green.tga
+		Map textures/pad_wop/padjump_green
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 0 1 0 1
                 //tcMod rotate 103
-	}	
+	}
 	{
-		Map textures/pad_wop/padjump_green2.tga
+		Map textures/pad_wop/padjump_green2
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 1 1 0 1
                //tcMod rotate -140
-	}	
+	}
 }
 
 textures/pad_wop/padjump_yellow
@@ -6527,19 +6527,19 @@ textures/pad_wop/padjump_yellow
              	surfaceparm nomarks
 	surfaceparm nolightmap
 	cull none
-	
+
 	{
-		Map textures/pad_wop/padjump_yellow.tga
+		Map textures/pad_wop/padjump_yellow
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 0 1 0 1
                 //tcMod rotate 103
-	}	
+	}
 	{
-		Map textures/pad_wop/padjump_yellow2.tga
+		Map textures/pad_wop/padjump_yellow2
 		blendFunc GL_ONE GL_ONE
                 rgbgen wave triangle 1 1 0 1
                //tcMod rotate -140
-	}	
+	}
 }
 
 // =================
@@ -6553,29 +6553,29 @@ textures/pad_wop/padtele
 	cull none
 	surfaceparm nonsolid
               surfaceparm trans
-	q3map_lightimage textures/pad_wop/padtele.tga	
+	q3map_lightimage textures/pad_wop/padtele
 	q3map_surfacelight 100
 
 	{
-		map textures/pad_wop/padtele_electric.tga
+		map textures/pad_wop/padtele_electric
 		blendFunc add
                 	rgbgen wave triangle 1.8 2 0 7
                 	tcMod scroll 0 -1
 	}
 	{
-		map textures/pad_wop/padtele_electric.tga
+		map textures/pad_wop/padtele_electric
 		blendFunc add
                 	rgbgen wave triangle 1 1.1 1 5
                 	tcMod scale  -1 1.5
                 	tcMod scroll 0 1.5
 	}
 	{
-		map textures/pad_wop/padtele.tga
+		map textures/pad_wop/padtele
 		blendFunc add
                 	rgbgen wave triangle 2 1.4 3 7.7
                 	tcMod scroll 0 0.8
 	}
-	
+
 }
 
 textures/pad_wop/padtele_blue
@@ -6585,29 +6585,29 @@ textures/pad_wop/padtele_blue
 	cull none
 	surfaceparm nonsolid
               surfaceparm trans
-	q3map_lightimage textures/pad_wop/padtele_blue.tga	
+	q3map_lightimage textures/pad_wop/padtele_blue
 	q3map_surfacelight 100
 
 	{
-		map textures/pad_wop/padtele_electric_blue.tga
+		map textures/pad_wop/padtele_electric_blue
 		blendFunc add
                 	rgbgen wave triangle 1.8 2 0 7
                 	tcMod scroll 0 -1
 	}
 	{
-		map textures/pad_wop/padtele_electric_blue.tga
+		map textures/pad_wop/padtele_electric_blue
 		blendFunc add
                 	rgbgen wave triangle 1 1.1 1 5
                 	tcMod scale  -1 1.5
                 	tcMod scroll 0 1.5
 	}
 	{
-		map textures/pad_wop/padtele_blue.tga
+		map textures/pad_wop/padtele_blue
 		blendFunc add
                 	rgbgen wave triangle 2 1.4 3 7.7
                 	tcMod scroll 0 0.8
 	}
-	
+
 }
 
 textures/pad_wop/padtele_green
@@ -6617,29 +6617,29 @@ textures/pad_wop/padtele_green
 	cull none
 	surfaceparm nonsolid
               surfaceparm trans
-	q3map_lightimage textures/pad_wop/padtele_green.tga	
+	q3map_lightimage textures/pad_wop/padtele_green
 	q3map_surfacelight 100
 
 	{
-		map textures/pad_wop/padtele_electric_green.tga
+		map textures/pad_wop/padtele_electric_green
 		blendFunc add
                 	rgbgen wave triangle 1.8 2 0 7
                 	tcMod scroll 0 -1
 	}
 	{
-		map textures/pad_wop/padtele_electric_green.tga
+		map textures/pad_wop/padtele_electric_green
 		blendFunc add
                 	rgbgen wave triangle 1 1.1 1 5
                 	tcMod scale  -1 1.5
                 	tcMod scroll 0 1.5
 	}
 	{
-		map textures/pad_wop/padtele_green.tga
+		map textures/pad_wop/padtele_green
 		blendFunc add
                 	rgbgen wave triangle 2 1.4 3 7.7
                 	tcMod scroll 0 0.8
 	}
-	
+
 }
 
 textures/pad_wop/padtele_purple
@@ -6649,29 +6649,29 @@ textures/pad_wop/padtele_purple
 	cull none
 	surfaceparm nonsolid
               surfaceparm trans
-	q3map_lightimage textures/pad_wop/padtele_red.tga	
+	q3map_lightimage textures/pad_wop/padtele_red
 	q3map_surfacelight 100
 
 	{
-		map textures/pad_wop/padtele_electric_purple.tga
+		map textures/pad_wop/padtele_electric_purple
 		blendFunc add
                 	rgbgen wave triangle 1.8 2 0 7
                 	tcMod scroll 0 -1
 	}
 	{
-		map textures/pad_wop/padtele_electric_purple.tga
+		map textures/pad_wop/padtele_electric_purple
 		blendFunc add
                 	rgbgen wave triangle 1 1.1 1 5
                 	tcMod scale  -1 1.5
                 	tcMod scroll 0 1.5
 	}
 	{
-		map textures/pad_wop/padtele_purple.tga
+		map textures/pad_wop/padtele_purple
 		blendFunc add
                 	rgbgen wave triangle 2 1.4 3 7.7
                 	tcMod scroll 0 0.8
 	}
-	
+
 }
 
 textures/pad_wop/padtele_red
@@ -6681,29 +6681,29 @@ textures/pad_wop/padtele_red
 	cull none
 	surfaceparm nonsolid
               surfaceparm trans
-	q3map_lightimage textures/pad_wop/padtele_red.tga	
+	q3map_lightimage textures/pad_wop/padtele_red
 	q3map_surfacelight 100
 
 	{
-		map textures/pad_wop/padtele_electric_red.tga
+		map textures/pad_wop/padtele_electric_red
 		blendFunc add
                 	rgbgen wave triangle 1.8 2 0 7
                 	tcMod scroll 0 -1
 	}
 	{
-		map textures/pad_wop/padtele_electric_red.tga
+		map textures/pad_wop/padtele_electric_red
 		blendFunc add
                 	rgbgen wave triangle 1 1.1 1 5
                 	tcMod scale  -1 1.5
                 	tcMod scroll 0 1.5
 	}
 	{
-		map textures/pad_wop/padtele_red.tga
+		map textures/pad_wop/padtele_red
 		blendFunc add
                 	rgbgen wave triangle 2 1.4 3 7.7
                 	tcMod scroll 0 0.8
 	}
-	
+
 }
 
 
@@ -6713,7 +6713,7 @@ textures/pad_wop/padtele_red
 
 textures/pad_liquidfx/water_calm6
 {
-		qer_editorimage textures/pad_liquidfx/wat06.tga
+		qer_editorimage textures/pad_liquidfx/wat06
 		qer_trans .5
 		q3map_globaltexture
 		surfaceparm trans
@@ -6721,18 +6721,18 @@ textures/pad_liquidfx/water_calm6
 		surfaceparm water
 		cull disable
 
-{ 
-		
-		map textures/pad_liquidfx/wat06.tga
+{
+
+		map textures/pad_liquidfx/wat06
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod transform 1.5 0 1.5 1 1 2
 		tcmod scroll -.05 .001
 	}
-	
-{ 
-		map textures/pad_liquidfx/wat03.tga
+
+{
+		map textures/pad_liquidfx/wat03
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
@@ -6740,18 +6740,18 @@ textures/pad_liquidfx/water_calm6
 		tcmod scroll .025 -.001
 	}
 
-{ 
-		map textures/pad_liquidfx/wat06.tga
+{
+		map textures/pad_liquidfx/wat06
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .25 .5
 		tcmod scroll .001 .025
 	}
-	
+
 {
 		map $lightmap
 		blendFunc GL_dst_color GL_zero
-		rgbgen identity		
+		rgbgen identity
 	}
 }
 
@@ -6759,7 +6759,7 @@ textures/pad_liquidfx/water_calm6
 
 textures/pad_liquidfx/water_calm5
 {
-		qer_editorimage textures/pad_liquidfx/wat05.tga
+		qer_editorimage textures/pad_liquidfx/wat05
 		qer_trans .5
 		q3map_globaltexture
 		surfaceparm trans
@@ -6767,18 +6767,18 @@ textures/pad_liquidfx/water_calm5
 		surfaceparm water
 		cull disable
 
-{ 
-		
-		map textures/pad_liquidfx/wat05.tga
+{
+
+		map textures/pad_liquidfx/wat05
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod transform 1.5 0 1.5 1 1 2
 		tcmod scroll -.05 .001
 	}
-	
-{ 
-		map textures/pad_liquidfx/wat03.tga
+
+{
+		map textures/pad_liquidfx/wat03
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
@@ -6786,18 +6786,18 @@ textures/pad_liquidfx/water_calm5
 		tcmod scroll .025 -.001
 	}
 
-{ 
-		map textures/pad_liquidfx/wat05.tga
+{
+		map textures/pad_liquidfx/wat05
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .25 .5
 		tcmod scroll .001 .025
 	}
-	
+
 {
 		map $lightmap
 		blendFunc GL_dst_color GL_zero
-		rgbgen identity		
+		rgbgen identity
 	}
 }
 
@@ -6805,7 +6805,7 @@ textures/pad_liquidfx/water_calm5
 
 textures/pad_liquidfx/water_calm4
 {
-		qer_editorimage textures/pad_liquidfx/wat04.tga
+		qer_editorimage textures/pad_liquidfx/wat04
 		qer_trans .5
 		q3map_globaltexture
 		surfaceparm trans
@@ -6813,18 +6813,18 @@ textures/pad_liquidfx/water_calm4
 		surfaceparm water
 		cull disable
 
-{ 
-		
-		map textures/pad_liquidfx/wat04.tga
+{
+
+		map textures/pad_liquidfx/wat04
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod transform 1.5 0 1.5 1 1 2
 		tcmod scroll -.05 .001
 	}
-	
-{ 
-		map textures/pad_liquidfx/wat03.tga
+
+{
+		map textures/pad_liquidfx/wat03
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
@@ -6832,18 +6832,18 @@ textures/pad_liquidfx/water_calm4
 		tcmod scroll .025 -.001
 	}
 
-{ 
-		map textures/pad_liquidfx/wat04.tga
+{
+		map textures/pad_liquidfx/wat04
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .25 .5
 		tcmod scroll .001 .025
 	}
-	
+
 {
 		map $lightmap
 		blendFunc GL_dst_color GL_zero
-		rgbgen identity		
+		rgbgen identity
 	}
 }
 
@@ -6851,7 +6851,7 @@ textures/pad_liquidfx/water_calm4
 
 textures/pad_liquidfx/water_calm3
 {
-		qer_editorimage textures/pad_liquidfx/wat03.tga
+		qer_editorimage textures/pad_liquidfx/wat03
 		qer_trans .5
 		q3map_globaltexture
 		surfaceparm trans
@@ -6859,18 +6859,18 @@ textures/pad_liquidfx/water_calm3
 		surfaceparm water
 		cull disable
 
-{ 
-		
-		map textures/pad_liquidfx/wat03.tga
+{
+
+		map textures/pad_liquidfx/wat03
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod transform 1.5 0 1.5 1 1 2
 		tcmod scroll -.05 .001
 	}
-	
-{ 
-		map textures/pad_liquidfx/wat02.tga
+
+{
+		map textures/pad_liquidfx/wat02
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
@@ -6878,18 +6878,18 @@ textures/pad_liquidfx/water_calm3
 		tcmod scroll .025 -.001
 	}
 
-{ 
-		map textures/pad_liquidfx/wat03.tga
+{
+		map textures/pad_liquidfx/wat03
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .25 .5
 		tcmod scroll .001 .025
 	}
-	
+
 {
 		map $lightmap
 		blendFunc GL_dst_color GL_zero
-		rgbgen identity		
+		rgbgen identity
 	}
 }
 
@@ -6897,7 +6897,7 @@ textures/pad_liquidfx/water_calm3
 
 textures/pad_liquidfx/water_calm2
 {
-		qer_editorimage textures/pad_liquidfx/wat02.tga
+		qer_editorimage textures/pad_liquidfx/wat02
 		qer_trans .5
 		q3map_globaltexture
 		surfaceparm trans
@@ -6905,18 +6905,18 @@ textures/pad_liquidfx/water_calm2
 		surfaceparm water
 		cull disable
 
-{ 
-		
-		map textures/pad_liquidfx/wat02.tga
+{
+
+		map textures/pad_liquidfx/wat02
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod transform 1.5 0 1.5 1 1 2
 		tcmod scroll -.05 .001
 	}
-	
-{ 
-		map textures/pad_liquidfx/wat03.tga
+
+{
+		map textures/pad_liquidfx/wat03
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
@@ -6924,25 +6924,25 @@ textures/pad_liquidfx/water_calm2
 		tcmod scroll .025 -.001
 	}
 
-{ 
-		map textures/pad_liquidfx/wat02.tga
+{
+		map textures/pad_liquidfx/wat02
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .25 .5
 		tcmod scroll .001 .025
 	}
-	
+
 {
 		map $lightmap
 		blendFunc GL_dst_color GL_zero
-		rgbgen identity		
+		rgbgen identity
 	}
 }
 
 
 textures/pad_liquidfx/water_calm1
 {
-		qer_editorimage textures/pad_liquidfx/wat01.tga
+		qer_editorimage textures/pad_liquidfx/wat01
 		qer_trans .5
 		q3map_globaltexture
 		surfaceparm trans
@@ -6950,18 +6950,18 @@ textures/pad_liquidfx/water_calm1
 		surfaceparm water
 		cull disable
 
-{ 
-		
-		map textures/pad_liquidfx/wat01.tga
+{
+
+		map textures/pad_liquidfx/wat01
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod transform 1.5 0 1.5 1 1 2
 		tcmod scroll -.05 .001
 	}
-	
-{ 
-		map textures/pad_liquidfx/wat03.tga
+
+{
+		map textures/pad_liquidfx/wat03
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
@@ -6969,18 +6969,18 @@ textures/pad_liquidfx/water_calm1
 		tcmod scroll .025 -.001
 	}
 
-{ 
-		map textures/pad_liquidfx/wat01.tga
+{
+		map textures/pad_liquidfx/wat01
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .25 .5
 		tcmod scroll .001 .025
 	}
-	
+
 {
 		map $lightmap
 		blendFunc GL_dst_color GL_zero
-		rgbgen identity		
+		rgbgen identity
 	}
 }
 
@@ -6988,7 +6988,7 @@ textures/pad_liquidfx/water_calm1
 
 textures/pad_liquidfx/water_light6
 {
-	qer_editorimage textures/pad_liquidfx/wat06.tga
+	qer_editorimage textures/pad_liquidfx/wat06
 	qer_trans .5
 	q3map_globaltexture
 	surfaceparm trans
@@ -6998,14 +6998,14 @@ textures/pad_liquidfx/water_light6
 	cull disable
 
 	{
-		map textures/pad_liquidfx/wat06.tga
+		map textures/pad_liquidfx/wat06
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod scroll .025 .01
 	}
 	{
-		map textures/pad_liquidfx/wat06.tga
+		map textures/pad_liquidfx/wat06
 		blendFunc GL_dst_color gl_one
 		rgbgen identity
 		tcmod scale -1 -1
@@ -7022,7 +7022,7 @@ textures/pad_liquidfx/water_light6
 
 textures/pad_liquidfx/water_light5
 {
-	qer_editorimage textures/pad_liquidfx/wat05.tga
+	qer_editorimage textures/pad_liquidfx/wat05
 	qer_trans .5
 	q3map_globaltexture
 	surfaceparm trans
@@ -7032,14 +7032,14 @@ textures/pad_liquidfx/water_light5
 	cull disable
 
 	{
-		map textures/pad_liquidfx/wat05.tga
+		map textures/pad_liquidfx/wat05
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod scroll .025 .01
 	}
 	{
-		map textures/pad_liquidfx/wat05.tga
+		map textures/pad_liquidfx/wat05
 		blendFunc GL_dst_color gl_one
 		rgbgen identity
 		tcmod scale -1 -1
@@ -7056,7 +7056,7 @@ textures/pad_liquidfx/water_light5
 
 textures/pad_liquidfx/water_light4
 {
-	qer_editorimage textures/pad_liquidfx/wat04.tga
+	qer_editorimage textures/pad_liquidfx/wat04
 	qer_trans .5
 	q3map_globaltexture
 	surfaceparm trans
@@ -7066,14 +7066,14 @@ textures/pad_liquidfx/water_light4
 	cull disable
 
 	{
-		map textures/pad_liquidfx/wat04.tga
+		map textures/pad_liquidfx/wat04
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod scroll .025 .01
 	}
 	{
-		map textures/pad_liquidfx/wat04.tga
+		map textures/pad_liquidfx/wat04
 		blendFunc GL_dst_color gl_one
 		rgbgen identity
 		tcmod scale -1 -1
@@ -7089,7 +7089,7 @@ textures/pad_liquidfx/water_light4
 
 textures/pad_liquidfx/water_light3
 {
-	qer_editorimage textures/pad_liquidfx/wat03.tga
+	qer_editorimage textures/pad_liquidfx/wat03
 	qer_trans .5
 	q3map_globaltexture
 	surfaceparm trans
@@ -7099,14 +7099,14 @@ textures/pad_liquidfx/water_light3
 	cull disable
 
 	{
-		map textures/pad_liquidfx/wat03.tga
+		map textures/pad_liquidfx/wat03
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod scroll .025 .01
 	}
 	{
-		map textures/pad_liquidfx/wat03.tga
+		map textures/pad_liquidfx/wat03
 		blendFunc GL_dst_color gl_one
 		rgbgen identity
 		tcmod scale -1 -1
@@ -7122,7 +7122,7 @@ textures/pad_liquidfx/water_light3
 
 textures/pad_liquidfx/water_light2
 {
-	qer_editorimage textures/pad_liquidfx/wat02.tga
+	qer_editorimage textures/pad_liquidfx/wat02
 	qer_trans .5
 	q3map_globaltexture
 	surfaceparm trans
@@ -7132,14 +7132,14 @@ textures/pad_liquidfx/water_light2
 	cull disable
 
 	{
-		map textures/pad_liquidfx/wat02.tga
+		map textures/pad_liquidfx/wat02
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod scroll .025 .01
 	}
 	{
-		map textures/pad_liquidfx/wat02.tga
+		map textures/pad_liquidfx/wat02
 		blendFunc GL_dst_color gl_one
 		rgbgen identity
 		tcmod scale -1 -1
@@ -7155,7 +7155,7 @@ textures/pad_liquidfx/water_light2
 
 textures/pad_liquidfx/water_light1
 {
-	qer_editorimage textures/pad_liquidfx/wat01.tga
+	qer_editorimage textures/pad_liquidfx/wat01
 	qer_trans .5
 	q3map_globaltexture
 	surfaceparm trans
@@ -7165,14 +7165,14 @@ textures/pad_liquidfx/water_light1
 	cull disable
 
 	{
-		map textures/pad_liquidfx/wat01.tga
+		map textures/pad_liquidfx/wat01
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod scroll .025 .01
 	}
 	{
-		map textures/pad_liquidfx/wat01.tga
+		map textures/pad_liquidfx/wat01
 		blendFunc GL_dst_color gl_one
 		rgbgen identity
 		tcmod scale -1 -1
@@ -7187,7 +7187,7 @@ textures/pad_liquidfx/water_light1
 
 textures/pad_liquidfx/pad_rain1
 {
-qer_editorimage textures/pad_liquidfx/pad_rain.tga
+qer_editorimage textures/pad_liquidfx/pad_rain
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -7197,7 +7197,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.000043 0.000000 -1100 sawtooth 0 1 0.000000 3
 {
-clampmap textures/pad_liquidfx/pad_rain.tga
+clampmap textures/pad_liquidfx/pad_rain
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.000000 8.000000 0.000000 0.129033
 rgbGen wave sawtooth 1.000000 0.000000 0.000000 0.129033
@@ -7209,7 +7209,7 @@ blendfunc blend
 
 textures/pad_liquidfx/pad_rain2
 {
-		qer_editorimage textures/pad_liquidfx/pad_rain.tga
+		qer_editorimage textures/pad_liquidfx/pad_rain
 		surfaceparm noimpact
 		surfaceparm nolightmap
 		cull none
@@ -7220,7 +7220,7 @@ textures/pad_liquidfx/pad_rain2
 		deformvertexes move 0.000043 0.000000 -1000 sawtooth 0 1 0.200000 3
 
 	{
-		clampmap textures/pad_liquidfx/pad_rain.tga
+		clampmap textures/pad_liquidfx/pad_rain
 		tcMod rotate 0.000000
 		AlphaGen wave sawtooth 0.000000 8.000000 0.200000 0.129033
 		rgbGen wave sawtooth 1.000000 0.000000 0.200000 0.129033
@@ -7231,7 +7231,7 @@ textures/pad_liquidfx/pad_rain2
 
 textures/pad_liquidfx/pad_rain3
 {
-		qer_editorimage textures/pad_liquidfx/pad_rain.tga
+		qer_editorimage textures/pad_liquidfx/pad_rain
 		surfaceparm noimpact
 		surfaceparm nolightmap
 		cull none
@@ -7240,9 +7240,9 @@ textures/pad_liquidfx/pad_rain3
 		surfaceparm nodlight
 		deformvertexes autosprite
 		deformvertexes move 0.000043 0.000000 -1100 sawtooth 0 1 0.400000 3
-	
+
 	{
-		clampmap textures/pad_liquidfx/pad_rain.tga
+		clampmap textures/pad_liquidfx/pad_rain
 		tcMod rotate 0.000000
 		AlphaGen wave sawtooth 0.000000 8.000000 0.400000 0.129033
 		rgbGen wave sawtooth 1.000000 0.000000 0.400000 0.129033
@@ -7253,7 +7253,7 @@ textures/pad_liquidfx/pad_rain3
 
 textures/pad_liquidfx/pad_rain4
 {
-		qer_editorimage textures/pad_liquidfx/pad_rain.tga
+		qer_editorimage textures/pad_liquidfx/pad_rain
 		surfaceparm noimpact
 		surfaceparm nolightmap
 		cull none
@@ -7262,9 +7262,9 @@ textures/pad_liquidfx/pad_rain4
 		surfaceparm nodlight
 		deformvertexes autosprite
 		deformvertexes move 0.000043 0.000000 -1000 sawtooth 0 1 0.600000 3
-	
+
 	{
-		clampmap textures/pad_liquidfx/pad_rain.tga
+		clampmap textures/pad_liquidfx/pad_rain
 		tcMod rotate 0.000000
 		AlphaGen wave sawtooth 0.000000 8.000000 0.600000 0.129033
 		rgbGen wave sawtooth 1.000000 0.000000 0.600000 0.129033
@@ -7275,7 +7275,7 @@ textures/pad_liquidfx/pad_rain4
 
 textures/pad_liquidfx/pad_rain5
 {
-		qer_editorimage textures/pad_liquidfx/pad_rain.tga
+		qer_editorimage textures/pad_liquidfx/pad_rain
 		surfaceparm noimpact
 		surfaceparm nolightmap
 		cull none
@@ -7285,7 +7285,7 @@ textures/pad_liquidfx/pad_rain5
 		deformvertexes autosprite
 		deformvertexes move 0.000043 0.000000 -1100 sawtooth 0 1 0.800000 3
 	{
-		clampmap textures/pad_liquidfx/pad_rain.tga
+		clampmap textures/pad_liquidfx/pad_rain
 		tcMod rotate 0.000000
 		AlphaGen wave sawtooth 0.000000 8.000000 0.800000 0.129033
 		rgbGen wave sawtooth 1.000000 0.000000 0.800000 0.129033
@@ -7298,7 +7298,7 @@ textures/pad_liquidfx/pad_rain5
 
 textures/pad_liquidfx/water_invisible
 {
-	qer_editorimage textures/pad_liquidfx/wat01.tga
+	qer_editorimage textures/pad_liquidfx/wat01
 	qer_trans .5
 	surfaceparm trans
 	surfaceparm nonsolid
@@ -7306,7 +7306,7 @@ textures/pad_liquidfx/water_invisible
 	cull disable
 
 	{
-		map textures/pad_liquidfx/invis_effect.tga
+		map textures/pad_liquidfx/invis_effect
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 	}
@@ -7314,7 +7314,7 @@ textures/pad_liquidfx/water_invisible
 
 textures/pad_liquidfx/water_river_rough
 {
-	qer_editorimage textures/pad_liquidfx/wat05.tga
+	qer_editorimage textures/pad_liquidfx/wat05
 	qer_trans .8
 	q3map_globaltexture
 	surfaceparm nonsolid
@@ -7324,7 +7324,7 @@ textures/pad_liquidfx/water_river_rough
 	deformVertexes wave 160 sin 0 10 0 .3
 
 	{
-		map textures/pad_liquidfx/wat05.tga
+		map textures/pad_liquidfx/wat05
 		rgbgen identity
 		tcmod scale .4 .2
 		tcmod scroll .0 .08
@@ -7333,7 +7333,7 @@ textures/pad_liquidfx/water_river_rough
 
 textures/pad_liquidfx/water_shadow
 {
-	qer_editorimage textures/pad_liquidfx/wat01.tga
+	qer_editorimage textures/pad_liquidfx/wat01
 	qer_trans .4
 	q3map_globaltexture
 	surfaceparm trans
@@ -7341,14 +7341,14 @@ textures/pad_liquidfx/water_shadow
 	surfaceparm nomarks
 
 	{
-		map textures/pad_liquidfx/wat01.tga
+		map textures/pad_liquidfx/wat01
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .5 .5
 		tcmod scroll .025 .01
 	}
 	{
-		map textures/pad_liquidfx/wat01.tga
+		map textures/pad_liquidfx/wat01
 		blendFunc GL_dst_color gl_one
 		rgbgen identity
 		tcmod scale -1 -1
@@ -7363,19 +7363,19 @@ textures/pad_liquidfx/water_shadow
 
 textures/pad_liquidfx/pad_waterfall
 {
-	qer_editorimage textures/pad_liquidfx/pad_waterfall.tga
+	qer_editorimage textures/pad_liquidfx/pad_waterfall
 	surfaceparm nolightmap
 	surfaceparm trans
 	surfaceparm nonsolid
 	cull none
 
 	{
-		map textures/pad_liquidfx/pad_waterfall.tga
+		map textures/pad_liquidfx/pad_waterfall
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		tcMod scroll 0.000000 -1.2
 	}
 	{
-		map textures/pad_liquidfx/pad_waterfall.tga
+		map textures/pad_liquidfx/pad_waterfall
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		tcMod scroll 0.000000 -0.7
 	}
@@ -7384,19 +7384,19 @@ textures/pad_liquidfx/pad_waterfall
 
 textures/pad_liquidfx/pad_waterfall02_fast
 {
-      qer_editorimage textures/pad_liquidfx/pad_waterfall02.tga
+      qer_editorimage textures/pad_liquidfx/pad_waterfall02
       surfaceparm nolightmap
       surfaceparm nonsolid
       surfaceparm trans
       cull disable
 
       {
-            map textures/pad_liquidfx/pad_waterfall02.tga
+            map textures/pad_liquidfx/pad_waterfall02
             blendfunc blend
             tcMod scroll 0 -2.8
       }
       {
-            map textures/pad_liquidfx/pad_waterfall02.tga
+            map textures/pad_liquidfx/pad_waterfall02
             blendfunc blend
             tcMod scroll 0 -2
       }
@@ -7408,7 +7408,7 @@ textures/pad_liquidfx/pad_waterfall02_fast
 
 textures/pad_enteflare/targetlight
 {
-	qer_editorimage textures/pad_enteflare/targetlight.tga
+	qer_editorimage textures/pad_enteflare/targetlight
 	q3map_surfacelight 150
               q3map_flareShader flareShader
 	q3map_lightRGB 255 0 0
@@ -7418,12 +7418,12 @@ textures/pad_enteflare/targetlight
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/targetlight.tga
+		map textures/pad_enteflare/targetlight
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/target_flash.tga
+		map textures/pad_enteflare/target_flash
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -7437,7 +7437,7 @@ textures/pad_enteflare/elight
     q3map_flareShader flareShader
     surfaceparm nolightmap
     {
-        map textures/pad_enteflare/elight.tga
+        map textures/pad_enteflare/elight
     }
 }
 
@@ -7448,14 +7448,14 @@ textures/pad_enteflare/lightpoint
     q3map_flareShader flareShader
     surfaceparm nolightmap
     {
-        map textures/pad_enteflare/lightpoint.tga
+        map textures/pad_enteflare/lightpoint
     }
 }
 
 
 textures/pad_enteflare/neon01
 {
-	qer_editorimage textures/pad_enteflare/neon01.tga
+	qer_editorimage textures/pad_enteflare/neon01
 	surfaceparm nomarks
               q3map_flareShader flareShader
 	q3map_surfacelight 300
@@ -7464,12 +7464,12 @@ textures/pad_enteflare/neon01
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/neon01.tga
+		map textures/pad_enteflare/neon01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/neon01_blend.tga
+		map textures/pad_enteflare/neon01_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7486,12 +7486,12 @@ textures/pad_enteflare/light01
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light01.tga
+		map textures/pad_enteflare/light01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light01_blend.tga
+		map textures/pad_enteflare/light01_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7508,12 +7508,12 @@ textures/pad_enteflare/light02
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light02.tga
+		map textures/pad_enteflare/light02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light02_blend.tga
+		map textures/pad_enteflare/light02_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7530,12 +7530,12 @@ textures/pad_enteflare/light03
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light03.tga
+		map textures/pad_enteflare/light03
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light03_blend.tga
+		map textures/pad_enteflare/light03_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7552,12 +7552,12 @@ textures/pad_enteflare/light04
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light04.tga
+		map textures/pad_enteflare/light04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light04_blend.tga
+		map textures/pad_enteflare/light04_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7573,19 +7573,19 @@ textures/pad_enteflare/light04b
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light04b.tga
+		map textures/pad_enteflare/light04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light04b_blend.tga
+		map textures/pad_enteflare/light04b_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
 
 textures/pad_enteflare/light04_noflare
 {
-	qer_editorimage textures/pad_enteflare/light04b.tga
+	qer_editorimage textures/pad_enteflare/light04b
 	surfaceparm nomarks
 	q3map_lightRGB 0 255 255
                 q3map_surfacelight 300
@@ -7594,12 +7594,12 @@ textures/pad_enteflare/light04_noflare
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light04b.tga
+		map textures/pad_enteflare/light04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light04b_blend.tga
+		map textures/pad_enteflare/light04b_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7615,12 +7615,12 @@ textures/pad_enteflare/light05
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light05.tga
+		map textures/pad_enteflare/light05
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light05_blend.tga
+		map textures/pad_enteflare/light05_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7637,12 +7637,12 @@ textures/pad_enteflare/light06
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light06.tga
+		map textures/pad_enteflare/light06
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light06_blend.tga
+		map textures/pad_enteflare/light06_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7659,12 +7659,12 @@ textures/pad_enteflare/light07
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light07.tga
+		map textures/pad_enteflare/light07
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light07_blend.tga
+		map textures/pad_enteflare/light07_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7672,7 +7672,7 @@ textures/pad_enteflare/light07
 
 textures/pad_enteflare/light07_noflare
 {
-	qer_editorimage textures/pad_enteflare/light07.tga
+	qer_editorimage textures/pad_enteflare/light07
 	surfaceparm nomarks
 	q3map_lightRGB 255 0 0
               q3map_surfacelight 300
@@ -7681,12 +7681,12 @@ textures/pad_enteflare/light07_noflare
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light07.tga
+		map textures/pad_enteflare/light07
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/light07_blend.tga
+		map textures/pad_enteflare/light07_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7694,8 +7694,8 @@ textures/pad_enteflare/light07_noflare
 
 textures/pad_enteflare/lightlamp01
 {
-	qer_editorimage textures/pad_enteflare/lightlamp01.tga
-	q3map_lightimage textures/pad_enteflare/lightlamp01_blend.tga
+	qer_editorimage textures/pad_enteflare/lightlamp01
+	q3map_lightimage textures/pad_enteflare/lightlamp01_blend
 	surfaceparm nomarks
               q3map_flareShader flareShader
 	q3map_lightRGB 102 204 255
@@ -7705,12 +7705,12 @@ textures/pad_enteflare/lightlamp01
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/lightlamp01.tga
+		map textures/pad_enteflare/lightlamp01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-	{	
-		map textures/pad_enteflare/lightlamp01_blend.tga
+	{
+		map textures/pad_enteflare/lightlamp01_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -7718,7 +7718,7 @@ textures/pad_enteflare/lightlamp01
 
 textures/pad_enteflare/lightlamp02
 {
-	q3map_lightimage textures/pad_enteflare/lightlamp02_blend.tga
+	q3map_lightimage textures/pad_enteflare/lightlamp02_blend
 	surfaceparm nomarks
               q3map_flareShader flareShader
 	q3map_lightRGB 153 102 255
@@ -7728,22 +7728,22 @@ textures/pad_enteflare/lightlamp02
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/lightlamp02.tga
+		map textures/pad_enteflare/lightlamp02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-	{	
-		map textures/pad_enteflare/lightlamp02_blend.tga
+	{
+		map textures/pad_enteflare/lightlamp02_blend
 		blendfunc GL_ONE GL_ONE
                 rgbGen wave sin .5 0.5 1 .1
 	}
-        {	
-		map textures/pad_enteflare/lightlamp02b.tga
+        {
+		map textures/pad_enteflare/lightlamp02b
 		blendfunc GL_ONE GL_ONE
                 rgbgen wave triangle 1 5 1 3
 	}
-        {	
-		map textures/pad_enteflare/lightlamp02b.tga
+        {
+		map textures/pad_enteflare/lightlamp02b
 		blendfunc GL_ONE GL_ONE
                 tcmod scale -1 -1
                  rgbgen wave triangle 1 2 0 7
@@ -7753,7 +7753,7 @@ textures/pad_enteflare/lightlamp02
 
 textures/pad_enteflare/lightred
 {
-	q3map_lightimage textures/pad_enteflare/lightred.tga
+	q3map_lightimage textures/pad_enteflare/lightred
 	surfaceparm nomarks
               q3map_flareShader flareShader
 	q3map_lightRGB 255 0 0
@@ -7763,15 +7763,15 @@ textures/pad_enteflare/lightred
 		rgbGen identity
 	}
 	{
-		map textures/pad_enteflare/lightred.tga
+		map textures/pad_enteflare/lightred
 		blendFunc filter
 		rgbGen identity
 	}
         {
-		map textures/pad_enteflare/lightred.tga
+		map textures/pad_enteflare/lightred
 		blendFunc add
 	}
-	
+
 }
 
 
@@ -7781,7 +7781,7 @@ textures/pad_enteflare/lighty
               q3map_flareShader flareShader
 	surfaceparm nolightmap
     {
-        map textures/pad_enteflare/lighty.tga
+        map textures/pad_enteflare/lighty
     }
 }
 
@@ -7792,13 +7792,13 @@ textures/pad_enteflare/lightyy
               q3map_flareShader flareShader
 	surfaceparm nolightmap
     {
-        map textures/pad_enteflare/lightyy.tga
+        map textures/pad_enteflare/lightyy
     }
 }
 
 textures/pad_enteflare/flame1
 {
-	deformVertexes autoSprite2 
+	deformVertexes autoSprite2
 	surfaceparm trans
 	surfaceparm nomarks
 	surfaceparm nolightmap
@@ -7806,26 +7806,26 @@ textures/pad_enteflare/flame1
               q3map_flareShader flareShader
 	q3map_surfacelight 50
 	q3map_lightRGB 255 255 153
-              qer_editorimage textures/pad_enteflare/flame1.tga
-	
+              qer_editorimage textures/pad_enteflare/flame1
+
 
 	{
-		animMap 3 textures/pad_enteflare/flame1.tga textures/pad_enteflare/flame2.tga textures/pad_enteflare/flame3.tga textures/pad_enteflare/flame2.tga
+		animMap 3 textures/pad_enteflare/flame1 textures/pad_enteflare/flame2 textures/pad_enteflare/flame3 textures/pad_enteflare/flame2
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 10
-		
-	}	
+
+	}
 	{
-		animMap 3 textures/pad_enteflare/flame2.tga textures/pad_enteflare/flame3.tga textures/pad_enteflare/flame2.tga textures/pad_enteflare/flame1.tga
+		animMap 3 textures/pad_enteflare/flame2 textures/pad_enteflare/flame3 textures/pad_enteflare/flame2 textures/pad_enteflare/flame1
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave sawtooth 0 1 0 10
-	}	
+	}
 
 
 	{
-		map textures/pad_enteflare/flameball.tga
+		map textures/pad_enteflare/flameball
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+		rgbGen wave sin .6 .2 0 .6
 	}
 
 }
@@ -7839,7 +7839,7 @@ flareShader
 {
         cull none
         {
-                map textures/pad_gfx/flareb.tga
+                map textures/pad_gfx/flareb
                 blendFunc GL_ONE GL_ONE
                 rgbGen vertex
         }
@@ -7853,7 +7853,7 @@ flareShader
 sprites/star02
 {
 	{
-		map sprites/star02.tga
+		map sprites/star02
 		blendfunc blend
 		alphaGen vertex
 	}
@@ -7862,7 +7862,7 @@ sprites/star02
 sprites/star03
 {
 	{
-		map sprites/star03.tga
+		map sprites/star03
 		blendfunc blend
 		alphaGen vertex
 	}
@@ -7872,7 +7872,7 @@ sprites/star03
 lfsprites/ball
 {
 	{
-		map		lfsprites/ball.tga
+		map		lfsprites/ball
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7882,7 +7882,7 @@ lfsprites/ball
 lfsprites/cring1
 {
 	{
-		map		lfsprites/cring1.tga
+		map		lfsprites/cring1
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7892,7 +7892,7 @@ lfsprites/cring1
 lfsprites/cross1
 {
 	{
-		map		lfsprites/cross1.tga
+		map		lfsprites/cross1
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7902,7 +7902,7 @@ lfsprites/cross1
 lfsprites/cross2
 {
 	{
-		map		lfsprites/cross2.tga
+		map		lfsprites/cross2
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7912,7 +7912,7 @@ lfsprites/cross2
 lfsprites/BigDisc
 {
 	{
-		map		lfsprites/BigDisc.tga
+		map		lfsprites/BigDisc
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7922,7 +7922,7 @@ lfsprites/BigDisc
 lfsprites/disc1
 {
 	{
-		map		lfsprites/disc1.tga
+		map		lfsprites/disc1
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7932,7 +7932,7 @@ lfsprites/disc1
 lfsprites/disc2
 {
 	{
-		map		lfsprites/disc2.tga
+		map		lfsprites/disc2
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7942,7 +7942,7 @@ lfsprites/disc2
 lfsprites/disc3
 {
 	{
-		map		lfsprites/disc3.tga
+		map		lfsprites/disc3
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7952,7 +7952,7 @@ lfsprites/disc3
 lfsprites/ring1
 {
 	{
-		map		lfsprites/ring1.tga
+		map		lfsprites/ring1
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7962,7 +7962,7 @@ lfsprites/ring1
 lfsprites/ring2
 {
 	{
-		map		lfsprites/ring2.tga
+		map		lfsprites/ring2
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7972,7 +7972,7 @@ lfsprites/ring2
 lfsprites/star1
 {
 	{
-		map		lfsprites/star1.tga
+		map		lfsprites/star1
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7982,7 +7982,7 @@ lfsprites/star1
 lfsprites/star2
 {
 	{
-		map		lfsprites/star2.tga
+		map		lfsprites/star2
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -7992,7 +7992,7 @@ lfsprites/star2
 lfsprites/BigStar
 {
 	{
-		map		lfsprites/BigStar.tga
+		map		lfsprites/BigStar
 		blendfunc	add
 		rgbGen		vertex
 		alphaGen	vertex
@@ -8002,7 +8002,7 @@ lfsprites/BigStar
 lfsprites/sun1
 {
 	{
-		map		lfsprites/sun1.tga
+		map		lfsprites/sun1
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -8012,7 +8012,7 @@ lfsprites/sun1
 lfsprites/sun2
 {
 	{
-		map		lfsprites/sun2.tga
+		map		lfsprites/sun2
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -8022,7 +8022,7 @@ lfsprites/sun2
 lfsprites/sun3
 {
 	{
-		map		lfsprites/sun3.tga
+		map		lfsprites/sun3
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -8032,7 +8032,7 @@ lfsprites/sun3
 lfsprites/pentagon1
 {
 	{
-		map		lfsprites/pentagon1.tga
+		map		lfsprites/pentagon1
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -8042,7 +8042,7 @@ lfsprites/pentagon1
 lfsprites/pentagon2
 {
 	{
-		map		lfsprites/pentagon2.tga
+		map		lfsprites/pentagon2
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -8052,7 +8052,7 @@ lfsprites/pentagon2
 lfsprites/pentagon3
 {
 	{
-		map		lfsprites/pentagon3.tga
+		map		lfsprites/pentagon3
 		blendfunc	blend
 		rgbGen		vertex
 		alphaGen	vertex
@@ -8069,7 +8069,7 @@ lfsprites/pentagon3
 
 textures/pad_effects/steam_big_Zminus
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_1
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8080,7 +8080,7 @@ textures/pad_effects/steam_big_Zminus
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0 1
 		alphagen const 1
@@ -8091,7 +8091,7 @@ textures/pad_effects/steam_big_Zminus
 
 textures/pad_effects/zzsteam_big_Zminus_1
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_2
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8102,7 +8102,7 @@ textures/pad_effects/zzsteam_big_Zminus_1
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0078125 1
 		alphagen const 1
@@ -8113,7 +8113,7 @@ textures/pad_effects/zzsteam_big_Zminus_1
 
 textures/pad_effects/zzsteam_big_Zminus_2
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_3
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8124,7 +8124,7 @@ textures/pad_effects/zzsteam_big_Zminus_2
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.015625 1
 		alphagen const 1
@@ -8135,7 +8135,7 @@ textures/pad_effects/zzsteam_big_Zminus_2
 
 textures/pad_effects/zzsteam_big_Zminus_3
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_4
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8146,7 +8146,7 @@ textures/pad_effects/zzsteam_big_Zminus_3
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0234375 1
 		alphagen const 1
@@ -8157,7 +8157,7 @@ textures/pad_effects/zzsteam_big_Zminus_3
 
 textures/pad_effects/zzsteam_big_Zminus_4
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_5
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8168,7 +8168,7 @@ textures/pad_effects/zzsteam_big_Zminus_4
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.03125 1
 		alphagen const 1
@@ -8179,7 +8179,7 @@ textures/pad_effects/zzsteam_big_Zminus_4
 
 textures/pad_effects/zzsteam_big_Zminus_5
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_6
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8190,7 +8190,7 @@ textures/pad_effects/zzsteam_big_Zminus_5
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0390625 1
 		alphagen const 1
@@ -8201,7 +8201,7 @@ textures/pad_effects/zzsteam_big_Zminus_5
 
 textures/pad_effects/zzsteam_big_Zminus_6
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_7
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8212,7 +8212,7 @@ textures/pad_effects/zzsteam_big_Zminus_6
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.046875 1
 		alphagen const 1
@@ -8223,7 +8223,7 @@ textures/pad_effects/zzsteam_big_Zminus_6
 
 textures/pad_effects/zzsteam_big_Zminus_7
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_8
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8234,7 +8234,7 @@ textures/pad_effects/zzsteam_big_Zminus_7
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0546875 1
 		alphagen const 1
@@ -8245,7 +8245,7 @@ textures/pad_effects/zzsteam_big_Zminus_7
 
 textures/pad_effects/zzsteam_big_Zminus_8
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_9
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8256,7 +8256,7 @@ textures/pad_effects/zzsteam_big_Zminus_8
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0625 1
 		alphagen const 1
@@ -8267,7 +8267,7 @@ textures/pad_effects/zzsteam_big_Zminus_8
 
 textures/pad_effects/zzsteam_big_Zminus_9
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_10
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8278,7 +8278,7 @@ textures/pad_effects/zzsteam_big_Zminus_9
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0703125 1
 		alphagen const 1
@@ -8289,7 +8289,7 @@ textures/pad_effects/zzsteam_big_Zminus_9
 
 textures/pad_effects/zzsteam_big_Zminus_10
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_11
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8300,7 +8300,7 @@ textures/pad_effects/zzsteam_big_Zminus_10
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.078125 1
 		alphagen const 1
@@ -8311,7 +8311,7 @@ textures/pad_effects/zzsteam_big_Zminus_10
 
 textures/pad_effects/zzsteam_big_Zminus_11
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_12
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8322,7 +8322,7 @@ textures/pad_effects/zzsteam_big_Zminus_11
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0859375 1
 		alphagen const 1
@@ -8333,7 +8333,7 @@ textures/pad_effects/zzsteam_big_Zminus_11
 
 textures/pad_effects/zzsteam_big_Zminus_12
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_13
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8344,7 +8344,7 @@ textures/pad_effects/zzsteam_big_Zminus_12
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.09375 1
 		alphagen const 1
@@ -8355,7 +8355,7 @@ textures/pad_effects/zzsteam_big_Zminus_12
 
 textures/pad_effects/zzsteam_big_Zminus_13
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_14
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8366,7 +8366,7 @@ textures/pad_effects/zzsteam_big_Zminus_13
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.101563 1
 		alphagen const 1
@@ -8377,7 +8377,7 @@ textures/pad_effects/zzsteam_big_Zminus_13
 
 textures/pad_effects/zzsteam_big_Zminus_14
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_15
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8388,7 +8388,7 @@ textures/pad_effects/zzsteam_big_Zminus_14
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.109375 1
 		alphagen const 1
@@ -8399,7 +8399,7 @@ textures/pad_effects/zzsteam_big_Zminus_14
 
 textures/pad_effects/zzsteam_big_Zminus_15
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_16
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8410,7 +8410,7 @@ textures/pad_effects/zzsteam_big_Zminus_15
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.117188 1
 		alphagen const 1
@@ -8421,7 +8421,7 @@ textures/pad_effects/zzsteam_big_Zminus_15
 
 textures/pad_effects/zzsteam_big_Zminus_16
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_17
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8432,7 +8432,7 @@ textures/pad_effects/zzsteam_big_Zminus_16
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.125 1
 		alphagen const 1
@@ -8443,7 +8443,7 @@ textures/pad_effects/zzsteam_big_Zminus_16
 
 textures/pad_effects/zzsteam_big_Zminus_17
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_18
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8454,7 +8454,7 @@ textures/pad_effects/zzsteam_big_Zminus_17
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.132813 1
 		alphagen const 1
@@ -8465,7 +8465,7 @@ textures/pad_effects/zzsteam_big_Zminus_17
 
 textures/pad_effects/zzsteam_big_Zminus_18
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_19
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8476,7 +8476,7 @@ textures/pad_effects/zzsteam_big_Zminus_18
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.140625 1
 		alphagen const 1
@@ -8487,7 +8487,7 @@ textures/pad_effects/zzsteam_big_Zminus_18
 
 textures/pad_effects/zzsteam_big_Zminus_19
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_20
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8498,7 +8498,7 @@ textures/pad_effects/zzsteam_big_Zminus_19
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.148438 1
 		alphagen const 1
@@ -8509,7 +8509,7 @@ textures/pad_effects/zzsteam_big_Zminus_19
 
 textures/pad_effects/zzsteam_big_Zminus_20
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_21
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8520,7 +8520,7 @@ textures/pad_effects/zzsteam_big_Zminus_20
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.15625 1
 		alphagen const 1
@@ -8531,7 +8531,7 @@ textures/pad_effects/zzsteam_big_Zminus_20
 
 textures/pad_effects/zzsteam_big_Zminus_21
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_22
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8542,7 +8542,7 @@ textures/pad_effects/zzsteam_big_Zminus_21
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.164063 1
 		alphagen const 1
@@ -8553,7 +8553,7 @@ textures/pad_effects/zzsteam_big_Zminus_21
 
 textures/pad_effects/zzsteam_big_Zminus_22
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_23
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8564,7 +8564,7 @@ textures/pad_effects/zzsteam_big_Zminus_22
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.171875 1
 		alphagen const 1
@@ -8575,7 +8575,7 @@ textures/pad_effects/zzsteam_big_Zminus_22
 
 textures/pad_effects/zzsteam_big_Zminus_23
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_24
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8586,7 +8586,7 @@ textures/pad_effects/zzsteam_big_Zminus_23
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.179688 1
 		alphagen const 1
@@ -8597,7 +8597,7 @@ textures/pad_effects/zzsteam_big_Zminus_23
 
 textures/pad_effects/zzsteam_big_Zminus_24
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_25
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8608,7 +8608,7 @@ textures/pad_effects/zzsteam_big_Zminus_24
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.1875 1
 		alphagen const 1
@@ -8619,7 +8619,7 @@ textures/pad_effects/zzsteam_big_Zminus_24
 
 textures/pad_effects/zzsteam_big_Zminus_25
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_26
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8630,7 +8630,7 @@ textures/pad_effects/zzsteam_big_Zminus_25
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.195313 1
 		alphagen const 1
@@ -8641,7 +8641,7 @@ textures/pad_effects/zzsteam_big_Zminus_25
 
 textures/pad_effects/zzsteam_big_Zminus_26
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_27
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8652,7 +8652,7 @@ textures/pad_effects/zzsteam_big_Zminus_26
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.203125 1
 		alphagen const 1
@@ -8663,7 +8663,7 @@ textures/pad_effects/zzsteam_big_Zminus_26
 
 textures/pad_effects/zzsteam_big_Zminus_27
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_28
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8674,7 +8674,7 @@ textures/pad_effects/zzsteam_big_Zminus_27
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.210938 1
 		alphagen const 1
@@ -8685,7 +8685,7 @@ textures/pad_effects/zzsteam_big_Zminus_27
 
 textures/pad_effects/zzsteam_big_Zminus_28
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_29
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8696,7 +8696,7 @@ textures/pad_effects/zzsteam_big_Zminus_28
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.21875 1
 		alphagen const 1
@@ -8707,7 +8707,7 @@ textures/pad_effects/zzsteam_big_Zminus_28
 
 textures/pad_effects/zzsteam_big_Zminus_29
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_30
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8718,7 +8718,7 @@ textures/pad_effects/zzsteam_big_Zminus_29
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.226563 1
 		alphagen const 1
@@ -8729,7 +8729,7 @@ textures/pad_effects/zzsteam_big_Zminus_29
 
 textures/pad_effects/zzsteam_big_Zminus_30
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_31
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8740,7 +8740,7 @@ textures/pad_effects/zzsteam_big_Zminus_30
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.234375 1
 		alphagen const 1
@@ -8750,7 +8750,7 @@ textures/pad_effects/zzsteam_big_Zminus_30
 
 textures/pad_effects/zzsteam_big_Zminus_31
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_32
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8761,7 +8761,7 @@ textures/pad_effects/zzsteam_big_Zminus_31
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.242188 1
 		alphagen const 1
@@ -8772,7 +8772,7 @@ textures/pad_effects/zzsteam_big_Zminus_31
 
 textures/pad_effects/zzsteam_big_Zminus_32
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_33
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8783,7 +8783,7 @@ textures/pad_effects/zzsteam_big_Zminus_32
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.25 1
 		alphagen const 1
@@ -8794,7 +8794,7 @@ textures/pad_effects/zzsteam_big_Zminus_32
 
 textures/pad_effects/zzsteam_big_Zminus_33
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_34
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8805,7 +8805,7 @@ textures/pad_effects/zzsteam_big_Zminus_33
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.257813 1
 		alphagen const 1
@@ -8816,7 +8816,7 @@ textures/pad_effects/zzsteam_big_Zminus_33
 
 textures/pad_effects/zzsteam_big_Zminus_34
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_35
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8827,7 +8827,7 @@ textures/pad_effects/zzsteam_big_Zminus_34
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.265625 1
 		alphagen const 1
@@ -8838,7 +8838,7 @@ textures/pad_effects/zzsteam_big_Zminus_34
 
 textures/pad_effects/zzsteam_big_Zminus_35
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_36
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8849,7 +8849,7 @@ textures/pad_effects/zzsteam_big_Zminus_35
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.273438 1
 		alphagen const 1
@@ -8860,7 +8860,7 @@ textures/pad_effects/zzsteam_big_Zminus_35
 
 textures/pad_effects/zzsteam_big_Zminus_36
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_37
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8871,7 +8871,7 @@ textures/pad_effects/zzsteam_big_Zminus_36
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.28125 1
 		alphagen const 1
@@ -8882,7 +8882,7 @@ textures/pad_effects/zzsteam_big_Zminus_36
 
 textures/pad_effects/zzsteam_big_Zminus_37
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_38
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8893,7 +8893,7 @@ textures/pad_effects/zzsteam_big_Zminus_37
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.289063 1
 		alphagen const 1
@@ -8904,7 +8904,7 @@ textures/pad_effects/zzsteam_big_Zminus_37
 
 textures/pad_effects/zzsteam_big_Zminus_38
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_39
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8915,7 +8915,7 @@ textures/pad_effects/zzsteam_big_Zminus_38
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.296875 1
 		alphagen const 1
@@ -8926,7 +8926,7 @@ textures/pad_effects/zzsteam_big_Zminus_38
 
 textures/pad_effects/zzsteam_big_Zminus_39
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_40
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8937,7 +8937,7 @@ textures/pad_effects/zzsteam_big_Zminus_39
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.304688 1
 		alphagen const 1
@@ -8948,7 +8948,7 @@ textures/pad_effects/zzsteam_big_Zminus_39
 
 textures/pad_effects/zzsteam_big_Zminus_40
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_41
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8959,7 +8959,7 @@ textures/pad_effects/zzsteam_big_Zminus_40
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.3125 1
 		alphagen const 1
@@ -8970,7 +8970,7 @@ textures/pad_effects/zzsteam_big_Zminus_40
 
 textures/pad_effects/zzsteam_big_Zminus_41
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_42
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -8981,7 +8981,7 @@ textures/pad_effects/zzsteam_big_Zminus_41
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.320313 1
 		alphagen const 1
@@ -8992,7 +8992,7 @@ textures/pad_effects/zzsteam_big_Zminus_41
 
 textures/pad_effects/zzsteam_big_Zminus_42
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_43
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9003,7 +9003,7 @@ textures/pad_effects/zzsteam_big_Zminus_42
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.328125 1
 		alphagen const 1
@@ -9014,7 +9014,7 @@ textures/pad_effects/zzsteam_big_Zminus_42
 
 textures/pad_effects/zzsteam_big_Zminus_43
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_44
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9025,7 +9025,7 @@ textures/pad_effects/zzsteam_big_Zminus_43
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.335938 1
 		alphagen const 1
@@ -9036,7 +9036,7 @@ textures/pad_effects/zzsteam_big_Zminus_43
 
 textures/pad_effects/zzsteam_big_Zminus_44
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_45
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9047,7 +9047,7 @@ textures/pad_effects/zzsteam_big_Zminus_44
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.34375 1
 		alphagen const 1
@@ -9058,7 +9058,7 @@ textures/pad_effects/zzsteam_big_Zminus_44
 
 textures/pad_effects/zzsteam_big_Zminus_45
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_46
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9069,7 +9069,7 @@ textures/pad_effects/zzsteam_big_Zminus_45
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.351563 1
 		alphagen const 1
@@ -9080,7 +9080,7 @@ textures/pad_effects/zzsteam_big_Zminus_45
 
 textures/pad_effects/zzsteam_big_Zminus_46
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_47
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9091,7 +9091,7 @@ textures/pad_effects/zzsteam_big_Zminus_46
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.359375 1
 		alphagen const 1
@@ -9102,7 +9102,7 @@ textures/pad_effects/zzsteam_big_Zminus_46
 
 textures/pad_effects/zzsteam_big_Zminus_47
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_48
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9113,7 +9113,7 @@ textures/pad_effects/zzsteam_big_Zminus_47
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.367188 1
 		alphagen const 1
@@ -9124,7 +9124,7 @@ textures/pad_effects/zzsteam_big_Zminus_47
 
 textures/pad_effects/zzsteam_big_Zminus_48
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_49
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9135,7 +9135,7 @@ textures/pad_effects/zzsteam_big_Zminus_48
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.375 1
 		alphagen const 1
@@ -9146,7 +9146,7 @@ textures/pad_effects/zzsteam_big_Zminus_48
 
 textures/pad_effects/zzsteam_big_Zminus_49
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_50
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9157,7 +9157,7 @@ textures/pad_effects/zzsteam_big_Zminus_49
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.382813 1
 		alphagen const 1
@@ -9168,7 +9168,7 @@ textures/pad_effects/zzsteam_big_Zminus_49
 
 textures/pad_effects/zzsteam_big_Zminus_50
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_51
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9179,7 +9179,7 @@ textures/pad_effects/zzsteam_big_Zminus_50
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.390625 1
 		alphagen const 1
@@ -9190,7 +9190,7 @@ textures/pad_effects/zzsteam_big_Zminus_50
 
 textures/pad_effects/zzsteam_big_Zminus_51
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_52
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9201,7 +9201,7 @@ textures/pad_effects/zzsteam_big_Zminus_51
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.398438 1
 		alphagen const 1
@@ -9212,7 +9212,7 @@ textures/pad_effects/zzsteam_big_Zminus_51
 
 textures/pad_effects/zzsteam_big_Zminus_52
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_53
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9223,7 +9223,7 @@ textures/pad_effects/zzsteam_big_Zminus_52
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.40625 1
 		alphagen const 1
@@ -9234,7 +9234,7 @@ textures/pad_effects/zzsteam_big_Zminus_52
 
 textures/pad_effects/zzsteam_big_Zminus_53
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_54
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9245,7 +9245,7 @@ textures/pad_effects/zzsteam_big_Zminus_53
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.414063 1
 		alphagen const 1
@@ -9256,7 +9256,7 @@ textures/pad_effects/zzsteam_big_Zminus_53
 
 textures/pad_effects/zzsteam_big_Zminus_54
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_55
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9267,7 +9267,7 @@ textures/pad_effects/zzsteam_big_Zminus_54
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.421875 1
 		alphagen const 1
@@ -9278,7 +9278,7 @@ textures/pad_effects/zzsteam_big_Zminus_54
 
 textures/pad_effects/zzsteam_big_Zminus_55
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_56
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9289,7 +9289,7 @@ textures/pad_effects/zzsteam_big_Zminus_55
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.429688 1
 		alphagen const 1
@@ -9300,7 +9300,7 @@ textures/pad_effects/zzsteam_big_Zminus_55
 
 textures/pad_effects/zzsteam_big_Zminus_56
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_57
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9311,7 +9311,7 @@ textures/pad_effects/zzsteam_big_Zminus_56
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.4375 1
 		alphagen const 1
@@ -9322,7 +9322,7 @@ textures/pad_effects/zzsteam_big_Zminus_56
 
 textures/pad_effects/zzsteam_big_Zminus_57
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_58
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9333,7 +9333,7 @@ textures/pad_effects/zzsteam_big_Zminus_57
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.445313 1
 		alphagen const 1
@@ -9344,7 +9344,7 @@ textures/pad_effects/zzsteam_big_Zminus_57
 
 textures/pad_effects/zzsteam_big_Zminus_58
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_59
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9355,7 +9355,7 @@ textures/pad_effects/zzsteam_big_Zminus_58
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.453125 1
 		alphagen const 1
@@ -9366,7 +9366,7 @@ textures/pad_effects/zzsteam_big_Zminus_58
 
 textures/pad_effects/zzsteam_big_Zminus_59
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_60
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9377,7 +9377,7 @@ textures/pad_effects/zzsteam_big_Zminus_59
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.460938 1
 		alphagen const 1
@@ -9388,7 +9388,7 @@ textures/pad_effects/zzsteam_big_Zminus_59
 
 textures/pad_effects/zzsteam_big_Zminus_60
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_61
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9399,7 +9399,7 @@ textures/pad_effects/zzsteam_big_Zminus_60
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.46875 1
 		alphagen const 1
@@ -9410,7 +9410,7 @@ textures/pad_effects/zzsteam_big_Zminus_60
 
 textures/pad_effects/zzsteam_big_Zminus_61
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_62
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9421,7 +9421,7 @@ textures/pad_effects/zzsteam_big_Zminus_61
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.476563 1
 		alphagen const 1
@@ -9432,7 +9432,7 @@ textures/pad_effects/zzsteam_big_Zminus_61
 
 textures/pad_effects/zzsteam_big_Zminus_62
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_63
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9443,7 +9443,7 @@ textures/pad_effects/zzsteam_big_Zminus_62
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.484375 1
 		alphagen const 1
@@ -9454,7 +9454,7 @@ textures/pad_effects/zzsteam_big_Zminus_62
 
 textures/pad_effects/zzsteam_big_Zminus_63
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_64
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9465,7 +9465,7 @@ textures/pad_effects/zzsteam_big_Zminus_63
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.492188 1
 		alphagen const 1
@@ -9476,7 +9476,7 @@ textures/pad_effects/zzsteam_big_Zminus_63
 
 textures/pad_effects/zzsteam_big_Zminus_64
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_65
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9487,7 +9487,7 @@ textures/pad_effects/zzsteam_big_Zminus_64
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.5 1
 		alphagen const 1
@@ -9498,7 +9498,7 @@ textures/pad_effects/zzsteam_big_Zminus_64
 
 textures/pad_effects/zzsteam_big_Zminus_65
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_66
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9509,7 +9509,7 @@ textures/pad_effects/zzsteam_big_Zminus_65
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.507813 1
 		alphagen const 1
@@ -9520,7 +9520,7 @@ textures/pad_effects/zzsteam_big_Zminus_65
 
 textures/pad_effects/zzsteam_big_Zminus_66
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_67
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9531,7 +9531,7 @@ textures/pad_effects/zzsteam_big_Zminus_66
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.515625 1
 		alphagen const 1
@@ -9542,7 +9542,7 @@ textures/pad_effects/zzsteam_big_Zminus_66
 
 textures/pad_effects/zzsteam_big_Zminus_67
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_68
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9553,7 +9553,7 @@ textures/pad_effects/zzsteam_big_Zminus_67
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.523438 1
 		alphagen const 1
@@ -9564,7 +9564,7 @@ textures/pad_effects/zzsteam_big_Zminus_67
 
 textures/pad_effects/zzsteam_big_Zminus_68
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_69
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9575,7 +9575,7 @@ textures/pad_effects/zzsteam_big_Zminus_68
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.53125 1
 		alphagen const 1
@@ -9586,7 +9586,7 @@ textures/pad_effects/zzsteam_big_Zminus_68
 
 textures/pad_effects/zzsteam_big_Zminus_69
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_70
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9597,7 +9597,7 @@ textures/pad_effects/zzsteam_big_Zminus_69
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.539063 1
 		alphagen const 1
@@ -9608,7 +9608,7 @@ textures/pad_effects/zzsteam_big_Zminus_69
 
 textures/pad_effects/zzsteam_big_Zminus_70
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_71
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9619,7 +9619,7 @@ textures/pad_effects/zzsteam_big_Zminus_70
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.546875 1
 		alphagen const 1
@@ -9630,7 +9630,7 @@ textures/pad_effects/zzsteam_big_Zminus_70
 
 textures/pad_effects/zzsteam_big_Zminus_71
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_72
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9641,7 +9641,7 @@ textures/pad_effects/zzsteam_big_Zminus_71
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.554688 1
 		alphagen const 1
@@ -9652,7 +9652,7 @@ textures/pad_effects/zzsteam_big_Zminus_71
 
 textures/pad_effects/zzsteam_big_Zminus_72
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_73
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9663,7 +9663,7 @@ textures/pad_effects/zzsteam_big_Zminus_72
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.5625 1
 		alphagen const 1
@@ -9674,7 +9674,7 @@ textures/pad_effects/zzsteam_big_Zminus_72
 
 textures/pad_effects/zzsteam_big_Zminus_73
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_74
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9685,7 +9685,7 @@ textures/pad_effects/zzsteam_big_Zminus_73
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.570313 1
 		alphagen const 1
@@ -9696,7 +9696,7 @@ textures/pad_effects/zzsteam_big_Zminus_73
 
 textures/pad_effects/zzsteam_big_Zminus_74
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_75
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9707,7 +9707,7 @@ textures/pad_effects/zzsteam_big_Zminus_74
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.578125 1
 		alphagen const 1
@@ -9718,7 +9718,7 @@ textures/pad_effects/zzsteam_big_Zminus_74
 
 textures/pad_effects/zzsteam_big_Zminus_75
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_76
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9729,7 +9729,7 @@ textures/pad_effects/zzsteam_big_Zminus_75
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.585938 1
 		alphagen const 1
@@ -9740,7 +9740,7 @@ textures/pad_effects/zzsteam_big_Zminus_75
 
 textures/pad_effects/zzsteam_big_Zminus_76
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_77
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9751,7 +9751,7 @@ textures/pad_effects/zzsteam_big_Zminus_76
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.59375 1
 		alphagen const 1
@@ -9762,7 +9762,7 @@ textures/pad_effects/zzsteam_big_Zminus_76
 
 textures/pad_effects/zzsteam_big_Zminus_77
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_78
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9773,7 +9773,7 @@ textures/pad_effects/zzsteam_big_Zminus_77
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.601563 1
 		alphagen const 1
@@ -9784,7 +9784,7 @@ textures/pad_effects/zzsteam_big_Zminus_77
 
 textures/pad_effects/zzsteam_big_Zminus_78
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_79
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9795,7 +9795,7 @@ textures/pad_effects/zzsteam_big_Zminus_78
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.609375 1
 		alphagen const 1
@@ -9806,7 +9806,7 @@ textures/pad_effects/zzsteam_big_Zminus_78
 
 textures/pad_effects/zzsteam_big_Zminus_79
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_80
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9817,7 +9817,7 @@ textures/pad_effects/zzsteam_big_Zminus_79
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.617188 1
 		alphagen const 1
@@ -9828,7 +9828,7 @@ textures/pad_effects/zzsteam_big_Zminus_79
 
 textures/pad_effects/zzsteam_big_Zminus_80
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_81
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9839,7 +9839,7 @@ textures/pad_effects/zzsteam_big_Zminus_80
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.625 1
 		alphagen const 1
@@ -9850,7 +9850,7 @@ textures/pad_effects/zzsteam_big_Zminus_80
 
 textures/pad_effects/zzsteam_big_Zminus_81
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_82
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9861,7 +9861,7 @@ textures/pad_effects/zzsteam_big_Zminus_81
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.632813 1
 		alphagen const 1
@@ -9872,7 +9872,7 @@ textures/pad_effects/zzsteam_big_Zminus_81
 
 textures/pad_effects/zzsteam_big_Zminus_82
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_83
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9883,7 +9883,7 @@ textures/pad_effects/zzsteam_big_Zminus_82
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.640625 1
 		alphagen const 1
@@ -9894,7 +9894,7 @@ textures/pad_effects/zzsteam_big_Zminus_82
 
 textures/pad_effects/zzsteam_big_Zminus_83
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_84
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9905,7 +9905,7 @@ textures/pad_effects/zzsteam_big_Zminus_83
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.648438 1
 		alphagen const 1
@@ -9916,7 +9916,7 @@ textures/pad_effects/zzsteam_big_Zminus_83
 
 textures/pad_effects/zzsteam_big_Zminus_84
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_85
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9927,7 +9927,7 @@ textures/pad_effects/zzsteam_big_Zminus_84
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.65625 1
 		alphagen const 1
@@ -9938,7 +9938,7 @@ textures/pad_effects/zzsteam_big_Zminus_84
 
 textures/pad_effects/zzsteam_big_Zminus_85
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_86
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9949,7 +9949,7 @@ textures/pad_effects/zzsteam_big_Zminus_85
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.664063 1
 		alphagen const 1
@@ -9960,7 +9960,7 @@ textures/pad_effects/zzsteam_big_Zminus_85
 
 textures/pad_effects/zzsteam_big_Zminus_86
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_87
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9971,7 +9971,7 @@ textures/pad_effects/zzsteam_big_Zminus_86
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.671875 1
 		alphagen const 1
@@ -9982,7 +9982,7 @@ textures/pad_effects/zzsteam_big_Zminus_86
 
 textures/pad_effects/zzsteam_big_Zminus_87
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_88
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -9993,7 +9993,7 @@ textures/pad_effects/zzsteam_big_Zminus_87
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.679688 1
 		alphagen const 1
@@ -10004,7 +10004,7 @@ textures/pad_effects/zzsteam_big_Zminus_87
 
 textures/pad_effects/zzsteam_big_Zminus_88
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_89
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10015,7 +10015,7 @@ textures/pad_effects/zzsteam_big_Zminus_88
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.6875 1
 		alphagen const 1
@@ -10026,7 +10026,7 @@ textures/pad_effects/zzsteam_big_Zminus_88
 
 textures/pad_effects/zzsteam_big_Zminus_89
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_90
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10037,7 +10037,7 @@ textures/pad_effects/zzsteam_big_Zminus_89
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.695313 1
 		alphagen const 1
@@ -10048,7 +10048,7 @@ textures/pad_effects/zzsteam_big_Zminus_89
 
 textures/pad_effects/zzsteam_big_Zminus_90
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_91
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10059,7 +10059,7 @@ textures/pad_effects/zzsteam_big_Zminus_90
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.703125 1
 		alphagen const 1
@@ -10070,7 +10070,7 @@ textures/pad_effects/zzsteam_big_Zminus_90
 
 textures/pad_effects/zzsteam_big_Zminus_91
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_92
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10081,7 +10081,7 @@ textures/pad_effects/zzsteam_big_Zminus_91
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.710938 1
 		alphagen const 1
@@ -10092,7 +10092,7 @@ textures/pad_effects/zzsteam_big_Zminus_91
 
 textures/pad_effects/zzsteam_big_Zminus_92
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_93
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10103,7 +10103,7 @@ textures/pad_effects/zzsteam_big_Zminus_92
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.71875 1
 		alphagen const 1
@@ -10114,7 +10114,7 @@ textures/pad_effects/zzsteam_big_Zminus_92
 
 textures/pad_effects/zzsteam_big_Zminus_93
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_94
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10125,7 +10125,7 @@ textures/pad_effects/zzsteam_big_Zminus_93
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.726563 1
 		alphagen const 1
@@ -10136,7 +10136,7 @@ textures/pad_effects/zzsteam_big_Zminus_93
 
 textures/pad_effects/zzsteam_big_Zminus_94
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_95
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10147,7 +10147,7 @@ textures/pad_effects/zzsteam_big_Zminus_94
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.734375 1
 		alphagen const 1
@@ -10158,7 +10158,7 @@ textures/pad_effects/zzsteam_big_Zminus_94
 
 textures/pad_effects/zzsteam_big_Zminus_95
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_96
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10169,7 +10169,7 @@ textures/pad_effects/zzsteam_big_Zminus_95
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.742188 1
 		alphagen const 1
@@ -10180,7 +10180,7 @@ textures/pad_effects/zzsteam_big_Zminus_95
 
 textures/pad_effects/zzsteam_big_Zminus_96
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_97
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10191,7 +10191,7 @@ textures/pad_effects/zzsteam_big_Zminus_96
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.75 1
 		alphagen const 1
@@ -10202,7 +10202,7 @@ textures/pad_effects/zzsteam_big_Zminus_96
 
 textures/pad_effects/zzsteam_big_Zminus_97
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_98
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10213,7 +10213,7 @@ textures/pad_effects/zzsteam_big_Zminus_97
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.757813 1
 		alphagen const 1
@@ -10224,7 +10224,7 @@ textures/pad_effects/zzsteam_big_Zminus_97
 
 textures/pad_effects/zzsteam_big_Zminus_98
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_99
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10235,7 +10235,7 @@ textures/pad_effects/zzsteam_big_Zminus_98
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.765625 1
 		alphagen const 1
@@ -10246,7 +10246,7 @@ textures/pad_effects/zzsteam_big_Zminus_98
 
 textures/pad_effects/zzsteam_big_Zminus_99
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_100
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10257,7 +10257,7 @@ textures/pad_effects/zzsteam_big_Zminus_99
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.773438 1
 		alphagen const 1
@@ -10268,7 +10268,7 @@ textures/pad_effects/zzsteam_big_Zminus_99
 
 textures/pad_effects/zzsteam_big_Zminus_100
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_101
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10279,7 +10279,7 @@ textures/pad_effects/zzsteam_big_Zminus_100
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.78125 1
 		alphagen const 1
@@ -10290,7 +10290,7 @@ textures/pad_effects/zzsteam_big_Zminus_100
 
 textures/pad_effects/zzsteam_big_Zminus_101
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_102
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10301,7 +10301,7 @@ textures/pad_effects/zzsteam_big_Zminus_101
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.789063 1
 		alphagen const 1
@@ -10312,7 +10312,7 @@ textures/pad_effects/zzsteam_big_Zminus_101
 
 textures/pad_effects/zzsteam_big_Zminus_102
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_103
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10323,7 +10323,7 @@ textures/pad_effects/zzsteam_big_Zminus_102
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.796875 1
 		alphagen const 1
@@ -10334,7 +10334,7 @@ textures/pad_effects/zzsteam_big_Zminus_102
 
 textures/pad_effects/zzsteam_big_Zminus_103
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_104
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10345,7 +10345,7 @@ textures/pad_effects/zzsteam_big_Zminus_103
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.804688 1
 		alphagen const 1
@@ -10356,7 +10356,7 @@ textures/pad_effects/zzsteam_big_Zminus_103
 
 textures/pad_effects/zzsteam_big_Zminus_104
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_105
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10367,7 +10367,7 @@ textures/pad_effects/zzsteam_big_Zminus_104
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.8125 1
 		alphagen const 1
@@ -10378,7 +10378,7 @@ textures/pad_effects/zzsteam_big_Zminus_104
 
 textures/pad_effects/zzsteam_big_Zminus_105
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_106
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10389,7 +10389,7 @@ textures/pad_effects/zzsteam_big_Zminus_105
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.820313 1
 		alphagen const 1
@@ -10400,7 +10400,7 @@ textures/pad_effects/zzsteam_big_Zminus_105
 
 textures/pad_effects/zzsteam_big_Zminus_106
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_107
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10411,7 +10411,7 @@ textures/pad_effects/zzsteam_big_Zminus_106
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.828125 1
 		alphagen const 1
@@ -10422,7 +10422,7 @@ textures/pad_effects/zzsteam_big_Zminus_106
 
 textures/pad_effects/zzsteam_big_Zminus_107
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_108
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10433,7 +10433,7 @@ textures/pad_effects/zzsteam_big_Zminus_107
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.835938 1
 		alphagen const 1
@@ -10444,7 +10444,7 @@ textures/pad_effects/zzsteam_big_Zminus_107
 
 textures/pad_effects/zzsteam_big_Zminus_108
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_109
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10455,7 +10455,7 @@ textures/pad_effects/zzsteam_big_Zminus_108
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.84375 1
 		alphagen const 1
@@ -10466,7 +10466,7 @@ textures/pad_effects/zzsteam_big_Zminus_108
 
 textures/pad_effects/zzsteam_big_Zminus_109
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_110
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10477,7 +10477,7 @@ textures/pad_effects/zzsteam_big_Zminus_109
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.851563 1
 		alphagen const 1
@@ -10488,7 +10488,7 @@ textures/pad_effects/zzsteam_big_Zminus_109
 
 textures/pad_effects/zzsteam_big_Zminus_110
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_111
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10499,7 +10499,7 @@ textures/pad_effects/zzsteam_big_Zminus_110
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.859375 1
 		alphagen const 1
@@ -10510,7 +10510,7 @@ textures/pad_effects/zzsteam_big_Zminus_110
 
 textures/pad_effects/zzsteam_big_Zminus_111
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_112
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10521,7 +10521,7 @@ textures/pad_effects/zzsteam_big_Zminus_111
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.867188 1
 		alphagen const 1
@@ -10532,7 +10532,7 @@ textures/pad_effects/zzsteam_big_Zminus_111
 
 textures/pad_effects/zzsteam_big_Zminus_112
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_113
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10543,7 +10543,7 @@ textures/pad_effects/zzsteam_big_Zminus_112
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.875 1
 		alphagen const 1
@@ -10554,7 +10554,7 @@ textures/pad_effects/zzsteam_big_Zminus_112
 
 textures/pad_effects/zzsteam_big_Zminus_113
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_114
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10565,7 +10565,7 @@ textures/pad_effects/zzsteam_big_Zminus_113
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.882813 1
 		alphagen const 1
@@ -10576,7 +10576,7 @@ textures/pad_effects/zzsteam_big_Zminus_113
 
 textures/pad_effects/zzsteam_big_Zminus_114
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_115
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10587,7 +10587,7 @@ textures/pad_effects/zzsteam_big_Zminus_114
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.890625 1
 		alphagen const 1
@@ -10598,7 +10598,7 @@ textures/pad_effects/zzsteam_big_Zminus_114
 
 textures/pad_effects/zzsteam_big_Zminus_115
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_116
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10609,7 +10609,7 @@ textures/pad_effects/zzsteam_big_Zminus_115
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.898438 1
 		alphagen const 1
@@ -10620,7 +10620,7 @@ textures/pad_effects/zzsteam_big_Zminus_115
 
 textures/pad_effects/zzsteam_big_Zminus_116
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_117
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10631,7 +10631,7 @@ textures/pad_effects/zzsteam_big_Zminus_116
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.90625 1
 		alphagen const 1
@@ -10642,7 +10642,7 @@ textures/pad_effects/zzsteam_big_Zminus_116
 
 textures/pad_effects/zzsteam_big_Zminus_117
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_118
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10653,7 +10653,7 @@ textures/pad_effects/zzsteam_big_Zminus_117
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.914063 1
 		alphagen const 1
@@ -10664,7 +10664,7 @@ textures/pad_effects/zzsteam_big_Zminus_117
 
 textures/pad_effects/zzsteam_big_Zminus_118
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_119
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10675,7 +10675,7 @@ textures/pad_effects/zzsteam_big_Zminus_118
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.921875 1
 		alphagen const 1
@@ -10686,7 +10686,7 @@ textures/pad_effects/zzsteam_big_Zminus_118
 
 textures/pad_effects/zzsteam_big_Zminus_119
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_120
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10697,7 +10697,7 @@ textures/pad_effects/zzsteam_big_Zminus_119
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.929688 1
 		alphagen const 1
@@ -10708,7 +10708,7 @@ textures/pad_effects/zzsteam_big_Zminus_119
 
 textures/pad_effects/zzsteam_big_Zminus_120
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_121
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10719,7 +10719,7 @@ textures/pad_effects/zzsteam_big_Zminus_120
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.9375 1
 		alphagen const 1
@@ -10729,7 +10729,7 @@ textures/pad_effects/zzsteam_big_Zminus_120
 
 textures/pad_effects/zzsteam_big_Zminus_121
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_122
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10740,7 +10740,7 @@ textures/pad_effects/zzsteam_big_Zminus_121
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.945313 1
 		alphagen const 1
@@ -10751,7 +10751,7 @@ textures/pad_effects/zzsteam_big_Zminus_121
 
 textures/pad_effects/zzsteam_big_Zminus_122
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_123
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10762,7 +10762,7 @@ textures/pad_effects/zzsteam_big_Zminus_122
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.953125 1
 		alphagen const 1
@@ -10773,7 +10773,7 @@ textures/pad_effects/zzsteam_big_Zminus_122
 
 textures/pad_effects/zzsteam_big_Zminus_123
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_124
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10784,7 +10784,7 @@ textures/pad_effects/zzsteam_big_Zminus_123
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.960938 1
 		alphagen const 1
@@ -10795,7 +10795,7 @@ textures/pad_effects/zzsteam_big_Zminus_123
 
 textures/pad_effects/zzsteam_big_Zminus_124
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_125
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10806,7 +10806,7 @@ textures/pad_effects/zzsteam_big_Zminus_124
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.96875 1
 		alphagen const 1
@@ -10817,7 +10817,7 @@ textures/pad_effects/zzsteam_big_Zminus_124
 
 textures/pad_effects/zzsteam_big_Zminus_125
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_126
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10828,7 +10828,7 @@ textures/pad_effects/zzsteam_big_Zminus_125
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.976563 1
 		alphagen const 1
@@ -10839,7 +10839,7 @@ textures/pad_effects/zzsteam_big_Zminus_125
 
 textures/pad_effects/zzsteam_big_Zminus_126
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zminus_127
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10850,7 +10850,7 @@ textures/pad_effects/zzsteam_big_Zminus_126
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.984375 1
 		alphagen const 1
@@ -10861,7 +10861,7 @@ textures/pad_effects/zzsteam_big_Zminus_126
 
 textures/pad_effects/zzsteam_big_Zminus_127
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	surfaceparm nonsolid
 	surfaceparm trans
 	surfaceparm nomarks
@@ -10871,7 +10871,7 @@ textures/pad_effects/zzsteam_big_Zminus_127
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.992188 1
 		alphagen const 1
@@ -10890,7 +10890,7 @@ textures/pad_effects/zzsteam_big_Zminus_127
 
 textures/pad_effects/steam_big_Zplus
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_1
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10901,7 +10901,7 @@ textures/pad_effects/steam_big_Zplus
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0 1
 		alphagen const 1
@@ -10912,7 +10912,7 @@ textures/pad_effects/steam_big_Zplus
 
 textures/pad_effects/zzsteam_big_Zplus_1
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_2
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10923,7 +10923,7 @@ textures/pad_effects/zzsteam_big_Zplus_1
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0078125 1
 		alphagen const 1
@@ -10934,7 +10934,7 @@ textures/pad_effects/zzsteam_big_Zplus_1
 
 textures/pad_effects/zzsteam_big_Zplus_2
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_3
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10945,7 +10945,7 @@ textures/pad_effects/zzsteam_big_Zplus_2
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.015625 1
 		alphagen const 1
@@ -10956,7 +10956,7 @@ textures/pad_effects/zzsteam_big_Zplus_2
 
 textures/pad_effects/zzsteam_big_Zplus_3
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_4
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10967,7 +10967,7 @@ textures/pad_effects/zzsteam_big_Zplus_3
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0234375 1
 		alphagen const 1
@@ -10978,7 +10978,7 @@ textures/pad_effects/zzsteam_big_Zplus_3
 
 textures/pad_effects/zzsteam_big_Zplus_4
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_5
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -10989,7 +10989,7 @@ textures/pad_effects/zzsteam_big_Zplus_4
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.03125 1
 		alphagen const 1
@@ -11000,7 +11000,7 @@ textures/pad_effects/zzsteam_big_Zplus_4
 
 textures/pad_effects/zzsteam_big_Zplus_5
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_6
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11011,7 +11011,7 @@ textures/pad_effects/zzsteam_big_Zplus_5
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0390625 1
 		alphagen const 1
@@ -11022,7 +11022,7 @@ textures/pad_effects/zzsteam_big_Zplus_5
 
 textures/pad_effects/zzsteam_big_Zplus_6
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_7
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11033,7 +11033,7 @@ textures/pad_effects/zzsteam_big_Zplus_6
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.046875 1
 		alphagen const 1
@@ -11044,7 +11044,7 @@ textures/pad_effects/zzsteam_big_Zplus_6
 
 textures/pad_effects/zzsteam_big_Zplus_7
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_8
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11055,7 +11055,7 @@ textures/pad_effects/zzsteam_big_Zplus_7
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0546875 1
 		alphagen const 1
@@ -11066,7 +11066,7 @@ textures/pad_effects/zzsteam_big_Zplus_7
 
 textures/pad_effects/zzsteam_big_Zplus_8
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_9
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11077,7 +11077,7 @@ textures/pad_effects/zzsteam_big_Zplus_8
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0625 1
 		alphagen const 1
@@ -11088,7 +11088,7 @@ textures/pad_effects/zzsteam_big_Zplus_8
 
 textures/pad_effects/zzsteam_big_Zplus_9
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_10
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11099,7 +11099,7 @@ textures/pad_effects/zzsteam_big_Zplus_9
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0703125 1
 		alphagen const 1
@@ -11110,7 +11110,7 @@ textures/pad_effects/zzsteam_big_Zplus_9
 
 textures/pad_effects/zzsteam_big_Zplus_10
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_11
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11121,7 +11121,7 @@ textures/pad_effects/zzsteam_big_Zplus_10
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.078125 1
 		alphagen const 1
@@ -11132,7 +11132,7 @@ textures/pad_effects/zzsteam_big_Zplus_10
 
 textures/pad_effects/zzsteam_big_Zplus_11
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_12
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11143,7 +11143,7 @@ textures/pad_effects/zzsteam_big_Zplus_11
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.0859375 1
 		alphagen const 1
@@ -11154,7 +11154,7 @@ textures/pad_effects/zzsteam_big_Zplus_11
 
 textures/pad_effects/zzsteam_big_Zplus_12
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_13
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11165,7 +11165,7 @@ textures/pad_effects/zzsteam_big_Zplus_12
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.09375 1
 		alphagen const 1
@@ -11176,7 +11176,7 @@ textures/pad_effects/zzsteam_big_Zplus_12
 
 textures/pad_effects/zzsteam_big_Zplus_13
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_14
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11187,7 +11187,7 @@ textures/pad_effects/zzsteam_big_Zplus_13
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.101563 1
 		alphagen const 1
@@ -11198,7 +11198,7 @@ textures/pad_effects/zzsteam_big_Zplus_13
 
 textures/pad_effects/zzsteam_big_Zplus_14
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_15
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11209,7 +11209,7 @@ textures/pad_effects/zzsteam_big_Zplus_14
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.109375 1
 		alphagen const 1
@@ -11220,7 +11220,7 @@ textures/pad_effects/zzsteam_big_Zplus_14
 
 textures/pad_effects/zzsteam_big_Zplus_15
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_16
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11231,7 +11231,7 @@ textures/pad_effects/zzsteam_big_Zplus_15
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.117188 1
 		alphagen const 1
@@ -11242,7 +11242,7 @@ textures/pad_effects/zzsteam_big_Zplus_15
 
 textures/pad_effects/zzsteam_big_Zplus_16
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_17
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11253,7 +11253,7 @@ textures/pad_effects/zzsteam_big_Zplus_16
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.125 1
 		alphagen const 1
@@ -11264,7 +11264,7 @@ textures/pad_effects/zzsteam_big_Zplus_16
 
 textures/pad_effects/zzsteam_big_Zplus_17
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_18
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11275,7 +11275,7 @@ textures/pad_effects/zzsteam_big_Zplus_17
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.132813 1
 		alphagen const 1
@@ -11286,7 +11286,7 @@ textures/pad_effects/zzsteam_big_Zplus_17
 
 textures/pad_effects/zzsteam_big_Zplus_18
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_19
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11297,7 +11297,7 @@ textures/pad_effects/zzsteam_big_Zplus_18
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.140625 1
 		alphagen const 1
@@ -11308,7 +11308,7 @@ textures/pad_effects/zzsteam_big_Zplus_18
 
 textures/pad_effects/zzsteam_big_Zplus_19
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_20
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11319,7 +11319,7 @@ textures/pad_effects/zzsteam_big_Zplus_19
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.148438 1
 		alphagen const 1
@@ -11330,7 +11330,7 @@ textures/pad_effects/zzsteam_big_Zplus_19
 
 textures/pad_effects/zzsteam_big_Zplus_20
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_21
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11341,7 +11341,7 @@ textures/pad_effects/zzsteam_big_Zplus_20
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.15625 1
 		alphagen const 1
@@ -11352,7 +11352,7 @@ textures/pad_effects/zzsteam_big_Zplus_20
 
 textures/pad_effects/zzsteam_big_Zplus_21
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_22
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11363,7 +11363,7 @@ textures/pad_effects/zzsteam_big_Zplus_21
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.164063 1
 		alphagen const 1
@@ -11374,7 +11374,7 @@ textures/pad_effects/zzsteam_big_Zplus_21
 
 textures/pad_effects/zzsteam_big_Zplus_22
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_23
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11385,7 +11385,7 @@ textures/pad_effects/zzsteam_big_Zplus_22
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.171875 1
 		alphagen const 1
@@ -11396,7 +11396,7 @@ textures/pad_effects/zzsteam_big_Zplus_22
 
 textures/pad_effects/zzsteam_big_Zplus_23
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_24
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11407,7 +11407,7 @@ textures/pad_effects/zzsteam_big_Zplus_23
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.179688 1
 		alphagen const 1
@@ -11418,7 +11418,7 @@ textures/pad_effects/zzsteam_big_Zplus_23
 
 textures/pad_effects/zzsteam_big_Zplus_24
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_25
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11429,7 +11429,7 @@ textures/pad_effects/zzsteam_big_Zplus_24
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.1875 1
 		alphagen const 1
@@ -11440,7 +11440,7 @@ textures/pad_effects/zzsteam_big_Zplus_24
 
 textures/pad_effects/zzsteam_big_Zplus_25
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_26
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11451,7 +11451,7 @@ textures/pad_effects/zzsteam_big_Zplus_25
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.195313 1
 		alphagen const 1
@@ -11462,7 +11462,7 @@ textures/pad_effects/zzsteam_big_Zplus_25
 
 textures/pad_effects/zzsteam_big_Zplus_26
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_27
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11473,7 +11473,7 @@ textures/pad_effects/zzsteam_big_Zplus_26
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.203125 1
 		alphagen const 1
@@ -11484,7 +11484,7 @@ textures/pad_effects/zzsteam_big_Zplus_26
 
 textures/pad_effects/zzsteam_big_Zplus_27
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_28
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11495,7 +11495,7 @@ textures/pad_effects/zzsteam_big_Zplus_27
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.210938 1
 		alphagen const 1
@@ -11506,7 +11506,7 @@ textures/pad_effects/zzsteam_big_Zplus_27
 
 textures/pad_effects/zzsteam_big_Zplus_28
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_29
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11517,7 +11517,7 @@ textures/pad_effects/zzsteam_big_Zplus_28
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.21875 1
 		alphagen const 1
@@ -11528,7 +11528,7 @@ textures/pad_effects/zzsteam_big_Zplus_28
 
 textures/pad_effects/zzsteam_big_Zplus_29
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_30
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11539,7 +11539,7 @@ textures/pad_effects/zzsteam_big_Zplus_29
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.226563 1
 		alphagen const 1
@@ -11550,7 +11550,7 @@ textures/pad_effects/zzsteam_big_Zplus_29
 
 textures/pad_effects/zzsteam_big_Zplus_30
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_31
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11561,7 +11561,7 @@ textures/pad_effects/zzsteam_big_Zplus_30
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.234375 1
 		alphagen const 1
@@ -11571,7 +11571,7 @@ textures/pad_effects/zzsteam_big_Zplus_30
 
 textures/pad_effects/zzsteam_big_Zplus_31
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_32
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11582,7 +11582,7 @@ textures/pad_effects/zzsteam_big_Zplus_31
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.242188 1
 		alphagen const 1
@@ -11593,7 +11593,7 @@ textures/pad_effects/zzsteam_big_Zplus_31
 
 textures/pad_effects/zzsteam_big_Zplus_32
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_33
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11604,7 +11604,7 @@ textures/pad_effects/zzsteam_big_Zplus_32
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.25 1
 		alphagen const 1
@@ -11615,7 +11615,7 @@ textures/pad_effects/zzsteam_big_Zplus_32
 
 textures/pad_effects/zzsteam_big_Zplus_33
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_34
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11626,7 +11626,7 @@ textures/pad_effects/zzsteam_big_Zplus_33
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.257813 1
 		alphagen const 1
@@ -11637,7 +11637,7 @@ textures/pad_effects/zzsteam_big_Zplus_33
 
 textures/pad_effects/zzsteam_big_Zplus_34
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_35
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11648,7 +11648,7 @@ textures/pad_effects/zzsteam_big_Zplus_34
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.265625 1
 		alphagen const 1
@@ -11659,7 +11659,7 @@ textures/pad_effects/zzsteam_big_Zplus_34
 
 textures/pad_effects/zzsteam_big_Zplus_35
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_36
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11670,7 +11670,7 @@ textures/pad_effects/zzsteam_big_Zplus_35
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.273438 1
 		alphagen const 1
@@ -11681,7 +11681,7 @@ textures/pad_effects/zzsteam_big_Zplus_35
 
 textures/pad_effects/zzsteam_big_Zplus_36
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_37
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11692,7 +11692,7 @@ textures/pad_effects/zzsteam_big_Zplus_36
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.28125 1
 		alphagen const 1
@@ -11703,7 +11703,7 @@ textures/pad_effects/zzsteam_big_Zplus_36
 
 textures/pad_effects/zzsteam_big_Zplus_37
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_38
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11714,7 +11714,7 @@ textures/pad_effects/zzsteam_big_Zplus_37
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.289063 1
 		alphagen const 1
@@ -11725,7 +11725,7 @@ textures/pad_effects/zzsteam_big_Zplus_37
 
 textures/pad_effects/zzsteam_big_Zplus_38
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_39
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11736,7 +11736,7 @@ textures/pad_effects/zzsteam_big_Zplus_38
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.296875 1
 		alphagen const 1
@@ -11747,7 +11747,7 @@ textures/pad_effects/zzsteam_big_Zplus_38
 
 textures/pad_effects/zzsteam_big_Zplus_39
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_40
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11758,7 +11758,7 @@ textures/pad_effects/zzsteam_big_Zplus_39
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.304688 1
 		alphagen const 1
@@ -11769,7 +11769,7 @@ textures/pad_effects/zzsteam_big_Zplus_39
 
 textures/pad_effects/zzsteam_big_Zplus_40
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_41
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11780,7 +11780,7 @@ textures/pad_effects/zzsteam_big_Zplus_40
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.3125 1
 		alphagen const 1
@@ -11791,7 +11791,7 @@ textures/pad_effects/zzsteam_big_Zplus_40
 
 textures/pad_effects/zzsteam_big_Zplus_41
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_42
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11802,7 +11802,7 @@ textures/pad_effects/zzsteam_big_Zplus_41
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.320313 1
 		alphagen const 1
@@ -11813,7 +11813,7 @@ textures/pad_effects/zzsteam_big_Zplus_41
 
 textures/pad_effects/zzsteam_big_Zplus_42
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_43
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11824,7 +11824,7 @@ textures/pad_effects/zzsteam_big_Zplus_42
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.328125 1
 		alphagen const 1
@@ -11835,7 +11835,7 @@ textures/pad_effects/zzsteam_big_Zplus_42
 
 textures/pad_effects/zzsteam_big_Zplus_43
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_44
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11846,7 +11846,7 @@ textures/pad_effects/zzsteam_big_Zplus_43
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.335938 1
 		alphagen const 1
@@ -11857,7 +11857,7 @@ textures/pad_effects/zzsteam_big_Zplus_43
 
 textures/pad_effects/zzsteam_big_Zplus_44
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_45
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11868,7 +11868,7 @@ textures/pad_effects/zzsteam_big_Zplus_44
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.34375 1
 		alphagen const 1
@@ -11879,7 +11879,7 @@ textures/pad_effects/zzsteam_big_Zplus_44
 
 textures/pad_effects/zzsteam_big_Zplus_45
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_46
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11890,7 +11890,7 @@ textures/pad_effects/zzsteam_big_Zplus_45
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.351563 1
 		alphagen const 1
@@ -11901,7 +11901,7 @@ textures/pad_effects/zzsteam_big_Zplus_45
 
 textures/pad_effects/zzsteam_big_Zplus_46
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_47
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11912,7 +11912,7 @@ textures/pad_effects/zzsteam_big_Zplus_46
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.359375 1
 		alphagen const 1
@@ -11923,7 +11923,7 @@ textures/pad_effects/zzsteam_big_Zplus_46
 
 textures/pad_effects/zzsteam_big_Zplus_47
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_48
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11934,7 +11934,7 @@ textures/pad_effects/zzsteam_big_Zplus_47
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.367188 1
 		alphagen const 1
@@ -11945,7 +11945,7 @@ textures/pad_effects/zzsteam_big_Zplus_47
 
 textures/pad_effects/zzsteam_big_Zplus_48
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_49
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11956,7 +11956,7 @@ textures/pad_effects/zzsteam_big_Zplus_48
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.375 1
 		alphagen const 1
@@ -11967,7 +11967,7 @@ textures/pad_effects/zzsteam_big_Zplus_48
 
 textures/pad_effects/zzsteam_big_Zplus_49
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_50
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -11978,7 +11978,7 @@ textures/pad_effects/zzsteam_big_Zplus_49
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.382813 1
 		alphagen const 1
@@ -11989,7 +11989,7 @@ textures/pad_effects/zzsteam_big_Zplus_49
 
 textures/pad_effects/zzsteam_big_Zplus_50
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_51
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12000,7 +12000,7 @@ textures/pad_effects/zzsteam_big_Zplus_50
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.390625 1
 		alphagen const 1
@@ -12011,7 +12011,7 @@ textures/pad_effects/zzsteam_big_Zplus_50
 
 textures/pad_effects/zzsteam_big_Zplus_51
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_52
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12022,7 +12022,7 @@ textures/pad_effects/zzsteam_big_Zplus_51
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.398438 1
 		alphagen const 1
@@ -12033,7 +12033,7 @@ textures/pad_effects/zzsteam_big_Zplus_51
 
 textures/pad_effects/zzsteam_big_Zplus_52
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_53
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12044,7 +12044,7 @@ textures/pad_effects/zzsteam_big_Zplus_52
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.40625 1
 		alphagen const 1
@@ -12055,7 +12055,7 @@ textures/pad_effects/zzsteam_big_Zplus_52
 
 textures/pad_effects/zzsteam_big_Zplus_53
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_54
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12066,7 +12066,7 @@ textures/pad_effects/zzsteam_big_Zplus_53
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.414063 1
 		alphagen const 1
@@ -12077,7 +12077,7 @@ textures/pad_effects/zzsteam_big_Zplus_53
 
 textures/pad_effects/zzsteam_big_Zplus_54
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_55
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12088,7 +12088,7 @@ textures/pad_effects/zzsteam_big_Zplus_54
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.421875 1
 		alphagen const 1
@@ -12099,7 +12099,7 @@ textures/pad_effects/zzsteam_big_Zplus_54
 
 textures/pad_effects/zzsteam_big_Zplus_55
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_56
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12110,7 +12110,7 @@ textures/pad_effects/zzsteam_big_Zplus_55
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.429688 1
 		alphagen const 1
@@ -12121,7 +12121,7 @@ textures/pad_effects/zzsteam_big_Zplus_55
 
 textures/pad_effects/zzsteam_big_Zplus_56
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_57
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12132,7 +12132,7 @@ textures/pad_effects/zzsteam_big_Zplus_56
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.4375 1
 		alphagen const 1
@@ -12143,7 +12143,7 @@ textures/pad_effects/zzsteam_big_Zplus_56
 
 textures/pad_effects/zzsteam_big_Zplus_57
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_58
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12154,7 +12154,7 @@ textures/pad_effects/zzsteam_big_Zplus_57
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.445313 1
 		alphagen const 1
@@ -12165,7 +12165,7 @@ textures/pad_effects/zzsteam_big_Zplus_57
 
 textures/pad_effects/zzsteam_big_Zplus_58
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_59
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12176,7 +12176,7 @@ textures/pad_effects/zzsteam_big_Zplus_58
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.453125 1
 		alphagen const 1
@@ -12187,7 +12187,7 @@ textures/pad_effects/zzsteam_big_Zplus_58
 
 textures/pad_effects/zzsteam_big_Zplus_59
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_60
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12198,7 +12198,7 @@ textures/pad_effects/zzsteam_big_Zplus_59
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.460938 1
 		alphagen const 1
@@ -12209,7 +12209,7 @@ textures/pad_effects/zzsteam_big_Zplus_59
 
 textures/pad_effects/zzsteam_big_Zplus_60
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_61
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12220,7 +12220,7 @@ textures/pad_effects/zzsteam_big_Zplus_60
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.46875 1
 		alphagen const 1
@@ -12231,7 +12231,7 @@ textures/pad_effects/zzsteam_big_Zplus_60
 
 textures/pad_effects/zzsteam_big_Zplus_61
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_62
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12242,7 +12242,7 @@ textures/pad_effects/zzsteam_big_Zplus_61
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.476563 1
 		alphagen const 1
@@ -12253,7 +12253,7 @@ textures/pad_effects/zzsteam_big_Zplus_61
 
 textures/pad_effects/zzsteam_big_Zplus_62
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_63
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12264,7 +12264,7 @@ textures/pad_effects/zzsteam_big_Zplus_62
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.484375 1
 		alphagen const 1
@@ -12275,7 +12275,7 @@ textures/pad_effects/zzsteam_big_Zplus_62
 
 textures/pad_effects/zzsteam_big_Zplus_63
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_64
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12286,7 +12286,7 @@ textures/pad_effects/zzsteam_big_Zplus_63
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.492188 1
 		alphagen const 1
@@ -12297,7 +12297,7 @@ textures/pad_effects/zzsteam_big_Zplus_63
 
 textures/pad_effects/zzsteam_big_Zplus_64
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_65
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12308,7 +12308,7 @@ textures/pad_effects/zzsteam_big_Zplus_64
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.5 1
 		alphagen const 1
@@ -12319,7 +12319,7 @@ textures/pad_effects/zzsteam_big_Zplus_64
 
 textures/pad_effects/zzsteam_big_Zplus_65
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_66
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12330,7 +12330,7 @@ textures/pad_effects/zzsteam_big_Zplus_65
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.507813 1
 		alphagen const 1
@@ -12341,7 +12341,7 @@ textures/pad_effects/zzsteam_big_Zplus_65
 
 textures/pad_effects/zzsteam_big_Zplus_66
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_67
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12352,7 +12352,7 @@ textures/pad_effects/zzsteam_big_Zplus_66
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.515625 1
 		alphagen const 1
@@ -12363,7 +12363,7 @@ textures/pad_effects/zzsteam_big_Zplus_66
 
 textures/pad_effects/zzsteam_big_Zplus_67
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_68
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12374,7 +12374,7 @@ textures/pad_effects/zzsteam_big_Zplus_67
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.523438 1
 		alphagen const 1
@@ -12385,7 +12385,7 @@ textures/pad_effects/zzsteam_big_Zplus_67
 
 textures/pad_effects/zzsteam_big_Zplus_68
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_69
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12396,7 +12396,7 @@ textures/pad_effects/zzsteam_big_Zplus_68
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.53125 1
 		alphagen const 1
@@ -12407,7 +12407,7 @@ textures/pad_effects/zzsteam_big_Zplus_68
 
 textures/pad_effects/zzsteam_big_Zplus_69
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_70
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12418,7 +12418,7 @@ textures/pad_effects/zzsteam_big_Zplus_69
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.539063 1
 		alphagen const 1
@@ -12429,7 +12429,7 @@ textures/pad_effects/zzsteam_big_Zplus_69
 
 textures/pad_effects/zzsteam_big_Zplus_70
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_71
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12440,7 +12440,7 @@ textures/pad_effects/zzsteam_big_Zplus_70
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.546875 1
 		alphagen const 1
@@ -12451,7 +12451,7 @@ textures/pad_effects/zzsteam_big_Zplus_70
 
 textures/pad_effects/zzsteam_big_Zplus_71
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_72
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12462,7 +12462,7 @@ textures/pad_effects/zzsteam_big_Zplus_71
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.554688 1
 		alphagen const 1
@@ -12473,7 +12473,7 @@ textures/pad_effects/zzsteam_big_Zplus_71
 
 textures/pad_effects/zzsteam_big_Zplus_72
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_73
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12484,7 +12484,7 @@ textures/pad_effects/zzsteam_big_Zplus_72
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.5625 1
 		alphagen const 1
@@ -12495,7 +12495,7 @@ textures/pad_effects/zzsteam_big_Zplus_72
 
 textures/pad_effects/zzsteam_big_Zplus_73
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_74
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12506,7 +12506,7 @@ textures/pad_effects/zzsteam_big_Zplus_73
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.570313 1
 		alphagen const 1
@@ -12517,7 +12517,7 @@ textures/pad_effects/zzsteam_big_Zplus_73
 
 textures/pad_effects/zzsteam_big_Zplus_74
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_75
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12528,7 +12528,7 @@ textures/pad_effects/zzsteam_big_Zplus_74
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.578125 1
 		alphagen const 1
@@ -12539,7 +12539,7 @@ textures/pad_effects/zzsteam_big_Zplus_74
 
 textures/pad_effects/zzsteam_big_Zplus_75
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_76
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12550,7 +12550,7 @@ textures/pad_effects/zzsteam_big_Zplus_75
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.585938 1
 		alphagen const 1
@@ -12561,7 +12561,7 @@ textures/pad_effects/zzsteam_big_Zplus_75
 
 textures/pad_effects/zzsteam_big_Zplus_76
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_77
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12572,7 +12572,7 @@ textures/pad_effects/zzsteam_big_Zplus_76
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.59375 1
 		alphagen const 1
@@ -12583,7 +12583,7 @@ textures/pad_effects/zzsteam_big_Zplus_76
 
 textures/pad_effects/zzsteam_big_Zplus_77
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_78
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12594,7 +12594,7 @@ textures/pad_effects/zzsteam_big_Zplus_77
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.601563 1
 		alphagen const 1
@@ -12605,7 +12605,7 @@ textures/pad_effects/zzsteam_big_Zplus_77
 
 textures/pad_effects/zzsteam_big_Zplus_78
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_79
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12616,7 +12616,7 @@ textures/pad_effects/zzsteam_big_Zplus_78
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.609375 1
 		alphagen const 1
@@ -12627,7 +12627,7 @@ textures/pad_effects/zzsteam_big_Zplus_78
 
 textures/pad_effects/zzsteam_big_Zplus_79
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_80
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12638,7 +12638,7 @@ textures/pad_effects/zzsteam_big_Zplus_79
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.617188 1
 		alphagen const 1
@@ -12649,7 +12649,7 @@ textures/pad_effects/zzsteam_big_Zplus_79
 
 textures/pad_effects/zzsteam_big_Zplus_80
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_81
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12660,7 +12660,7 @@ textures/pad_effects/zzsteam_big_Zplus_80
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.625 1
 		alphagen const 1
@@ -12671,7 +12671,7 @@ textures/pad_effects/zzsteam_big_Zplus_80
 
 textures/pad_effects/zzsteam_big_Zplus_81
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_82
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12682,7 +12682,7 @@ textures/pad_effects/zzsteam_big_Zplus_81
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.632813 1
 		alphagen const 1
@@ -12693,7 +12693,7 @@ textures/pad_effects/zzsteam_big_Zplus_81
 
 textures/pad_effects/zzsteam_big_Zplus_82
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_83
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12704,7 +12704,7 @@ textures/pad_effects/zzsteam_big_Zplus_82
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.640625 1
 		alphagen const 1
@@ -12715,7 +12715,7 @@ textures/pad_effects/zzsteam_big_Zplus_82
 
 textures/pad_effects/zzsteam_big_Zplus_83
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_84
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12726,7 +12726,7 @@ textures/pad_effects/zzsteam_big_Zplus_83
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.648438 1
 		alphagen const 1
@@ -12737,7 +12737,7 @@ textures/pad_effects/zzsteam_big_Zplus_83
 
 textures/pad_effects/zzsteam_big_Zplus_84
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_85
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12748,7 +12748,7 @@ textures/pad_effects/zzsteam_big_Zplus_84
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.65625 1
 		alphagen const 1
@@ -12759,7 +12759,7 @@ textures/pad_effects/zzsteam_big_Zplus_84
 
 textures/pad_effects/zzsteam_big_Zplus_85
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_86
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12770,7 +12770,7 @@ textures/pad_effects/zzsteam_big_Zplus_85
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.664063 1
 		alphagen const 1
@@ -12781,7 +12781,7 @@ textures/pad_effects/zzsteam_big_Zplus_85
 
 textures/pad_effects/zzsteam_big_Zplus_86
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_87
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12792,7 +12792,7 @@ textures/pad_effects/zzsteam_big_Zplus_86
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.671875 1
 		alphagen const 1
@@ -12803,7 +12803,7 @@ textures/pad_effects/zzsteam_big_Zplus_86
 
 textures/pad_effects/zzsteam_big_Zplus_87
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_88
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12814,7 +12814,7 @@ textures/pad_effects/zzsteam_big_Zplus_87
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.679688 1
 		alphagen const 1
@@ -12825,7 +12825,7 @@ textures/pad_effects/zzsteam_big_Zplus_87
 
 textures/pad_effects/zzsteam_big_Zplus_88
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_89
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12836,7 +12836,7 @@ textures/pad_effects/zzsteam_big_Zplus_88
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.6875 1
 		alphagen const 1
@@ -12847,7 +12847,7 @@ textures/pad_effects/zzsteam_big_Zplus_88
 
 textures/pad_effects/zzsteam_big_Zplus_89
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_90
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12858,7 +12858,7 @@ textures/pad_effects/zzsteam_big_Zplus_89
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.695313 1
 		alphagen const 1
@@ -12869,7 +12869,7 @@ textures/pad_effects/zzsteam_big_Zplus_89
 
 textures/pad_effects/zzsteam_big_Zplus_90
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_91
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12880,7 +12880,7 @@ textures/pad_effects/zzsteam_big_Zplus_90
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.703125 1
 		alphagen const 1
@@ -12891,7 +12891,7 @@ textures/pad_effects/zzsteam_big_Zplus_90
 
 textures/pad_effects/zzsteam_big_Zplus_91
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_92
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12902,7 +12902,7 @@ textures/pad_effects/zzsteam_big_Zplus_91
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.710938 1
 		alphagen const 1
@@ -12913,7 +12913,7 @@ textures/pad_effects/zzsteam_big_Zplus_91
 
 textures/pad_effects/zzsteam_big_Zplus_92
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_93
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12924,7 +12924,7 @@ textures/pad_effects/zzsteam_big_Zplus_92
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.71875 1
 		alphagen const 1
@@ -12935,7 +12935,7 @@ textures/pad_effects/zzsteam_big_Zplus_92
 
 textures/pad_effects/zzsteam_big_Zplus_93
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_94
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12946,7 +12946,7 @@ textures/pad_effects/zzsteam_big_Zplus_93
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.726563 1
 		alphagen const 1
@@ -12957,7 +12957,7 @@ textures/pad_effects/zzsteam_big_Zplus_93
 
 textures/pad_effects/zzsteam_big_Zplus_94
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_95
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12968,7 +12968,7 @@ textures/pad_effects/zzsteam_big_Zplus_94
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.734375 1
 		alphagen const 1
@@ -12979,7 +12979,7 @@ textures/pad_effects/zzsteam_big_Zplus_94
 
 textures/pad_effects/zzsteam_big_Zplus_95
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_96
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -12990,7 +12990,7 @@ textures/pad_effects/zzsteam_big_Zplus_95
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.742188 1
 		alphagen const 1
@@ -13001,7 +13001,7 @@ textures/pad_effects/zzsteam_big_Zplus_95
 
 textures/pad_effects/zzsteam_big_Zplus_96
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_97
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13012,7 +13012,7 @@ textures/pad_effects/zzsteam_big_Zplus_96
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.75 1
 		alphagen const 1
@@ -13023,7 +13023,7 @@ textures/pad_effects/zzsteam_big_Zplus_96
 
 textures/pad_effects/zzsteam_big_Zplus_97
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_98
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13034,7 +13034,7 @@ textures/pad_effects/zzsteam_big_Zplus_97
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.757813 1
 		alphagen const 1
@@ -13045,7 +13045,7 @@ textures/pad_effects/zzsteam_big_Zplus_97
 
 textures/pad_effects/zzsteam_big_Zplus_98
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_99
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13056,7 +13056,7 @@ textures/pad_effects/zzsteam_big_Zplus_98
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.765625 1
 		alphagen const 1
@@ -13067,7 +13067,7 @@ textures/pad_effects/zzsteam_big_Zplus_98
 
 textures/pad_effects/zzsteam_big_Zplus_99
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_100
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13078,7 +13078,7 @@ textures/pad_effects/zzsteam_big_Zplus_99
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.773438 1
 		alphagen const 1
@@ -13089,7 +13089,7 @@ textures/pad_effects/zzsteam_big_Zplus_99
 
 textures/pad_effects/zzsteam_big_Zplus_100
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_101
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13100,7 +13100,7 @@ textures/pad_effects/zzsteam_big_Zplus_100
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.78125 1
 		alphagen const 1
@@ -13111,7 +13111,7 @@ textures/pad_effects/zzsteam_big_Zplus_100
 
 textures/pad_effects/zzsteam_big_Zplus_101
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_102
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13122,7 +13122,7 @@ textures/pad_effects/zzsteam_big_Zplus_101
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.789063 1
 		alphagen const 1
@@ -13133,7 +13133,7 @@ textures/pad_effects/zzsteam_big_Zplus_101
 
 textures/pad_effects/zzsteam_big_Zplus_102
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_103
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13144,7 +13144,7 @@ textures/pad_effects/zzsteam_big_Zplus_102
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.796875 1
 		alphagen const 1
@@ -13155,7 +13155,7 @@ textures/pad_effects/zzsteam_big_Zplus_102
 
 textures/pad_effects/zzsteam_big_Zplus_103
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_104
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13166,7 +13166,7 @@ textures/pad_effects/zzsteam_big_Zplus_103
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.804688 1
 		alphagen const 1
@@ -13177,7 +13177,7 @@ textures/pad_effects/zzsteam_big_Zplus_103
 
 textures/pad_effects/zzsteam_big_Zplus_104
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_105
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13188,7 +13188,7 @@ textures/pad_effects/zzsteam_big_Zplus_104
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.8125 1
 		alphagen const 1
@@ -13199,7 +13199,7 @@ textures/pad_effects/zzsteam_big_Zplus_104
 
 textures/pad_effects/zzsteam_big_Zplus_105
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_106
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13210,7 +13210,7 @@ textures/pad_effects/zzsteam_big_Zplus_105
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.820313 1
 		alphagen const 1
@@ -13221,7 +13221,7 @@ textures/pad_effects/zzsteam_big_Zplus_105
 
 textures/pad_effects/zzsteam_big_Zplus_106
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_107
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13232,7 +13232,7 @@ textures/pad_effects/zzsteam_big_Zplus_106
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.828125 1
 		alphagen const 1
@@ -13243,7 +13243,7 @@ textures/pad_effects/zzsteam_big_Zplus_106
 
 textures/pad_effects/zzsteam_big_Zplus_107
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_108
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13254,7 +13254,7 @@ textures/pad_effects/zzsteam_big_Zplus_107
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.835938 1
 		alphagen const 1
@@ -13265,7 +13265,7 @@ textures/pad_effects/zzsteam_big_Zplus_107
 
 textures/pad_effects/zzsteam_big_Zplus_108
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_109
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13276,7 +13276,7 @@ textures/pad_effects/zzsteam_big_Zplus_108
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.84375 1
 		alphagen const 1
@@ -13287,7 +13287,7 @@ textures/pad_effects/zzsteam_big_Zplus_108
 
 textures/pad_effects/zzsteam_big_Zplus_109
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_110
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13298,7 +13298,7 @@ textures/pad_effects/zzsteam_big_Zplus_109
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.851563 1
 		alphagen const 1
@@ -13309,7 +13309,7 @@ textures/pad_effects/zzsteam_big_Zplus_109
 
 textures/pad_effects/zzsteam_big_Zplus_110
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_111
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13320,7 +13320,7 @@ textures/pad_effects/zzsteam_big_Zplus_110
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.859375 1
 		alphagen const 1
@@ -13331,7 +13331,7 @@ textures/pad_effects/zzsteam_big_Zplus_110
 
 textures/pad_effects/zzsteam_big_Zplus_111
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_112
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13342,7 +13342,7 @@ textures/pad_effects/zzsteam_big_Zplus_111
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.867188 1
 		alphagen const 1
@@ -13353,7 +13353,7 @@ textures/pad_effects/zzsteam_big_Zplus_111
 
 textures/pad_effects/zzsteam_big_Zplus_112
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_113
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13364,7 +13364,7 @@ textures/pad_effects/zzsteam_big_Zplus_112
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.875 1
 		alphagen const 1
@@ -13375,7 +13375,7 @@ textures/pad_effects/zzsteam_big_Zplus_112
 
 textures/pad_effects/zzsteam_big_Zplus_113
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_114
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13386,7 +13386,7 @@ textures/pad_effects/zzsteam_big_Zplus_113
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.882813 1
 		alphagen const 1
@@ -13397,7 +13397,7 @@ textures/pad_effects/zzsteam_big_Zplus_113
 
 textures/pad_effects/zzsteam_big_Zplus_114
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_115
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13408,7 +13408,7 @@ textures/pad_effects/zzsteam_big_Zplus_114
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.890625 1
 		alphagen const 1
@@ -13419,7 +13419,7 @@ textures/pad_effects/zzsteam_big_Zplus_114
 
 textures/pad_effects/zzsteam_big_Zplus_115
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_116
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13430,7 +13430,7 @@ textures/pad_effects/zzsteam_big_Zplus_115
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.898438 1
 		alphagen const 1
@@ -13441,7 +13441,7 @@ textures/pad_effects/zzsteam_big_Zplus_115
 
 textures/pad_effects/zzsteam_big_Zplus_116
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_117
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13452,7 +13452,7 @@ textures/pad_effects/zzsteam_big_Zplus_116
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.90625 1
 		alphagen const 1
@@ -13463,7 +13463,7 @@ textures/pad_effects/zzsteam_big_Zplus_116
 
 textures/pad_effects/zzsteam_big_Zplus_117
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_118
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13474,7 +13474,7 @@ textures/pad_effects/zzsteam_big_Zplus_117
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.914063 1
 		alphagen const 1
@@ -13485,7 +13485,7 @@ textures/pad_effects/zzsteam_big_Zplus_117
 
 textures/pad_effects/zzsteam_big_Zplus_118
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_119
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13496,7 +13496,7 @@ textures/pad_effects/zzsteam_big_Zplus_118
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.921875 1
 		alphagen const 1
@@ -13507,7 +13507,7 @@ textures/pad_effects/zzsteam_big_Zplus_118
 
 textures/pad_effects/zzsteam_big_Zplus_119
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_120
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13518,7 +13518,7 @@ textures/pad_effects/zzsteam_big_Zplus_119
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.929688 1
 		alphagen const 1
@@ -13529,7 +13529,7 @@ textures/pad_effects/zzsteam_big_Zplus_119
 
 textures/pad_effects/zzsteam_big_Zplus_120
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_121
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13540,7 +13540,7 @@ textures/pad_effects/zzsteam_big_Zplus_120
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.9375 1
 		alphagen const 1
@@ -13550,7 +13550,7 @@ textures/pad_effects/zzsteam_big_Zplus_120
 
 textures/pad_effects/zzsteam_big_Zplus_121
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_122
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13561,7 +13561,7 @@ textures/pad_effects/zzsteam_big_Zplus_121
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.945313 1
 		alphagen const 1
@@ -13572,7 +13572,7 @@ textures/pad_effects/zzsteam_big_Zplus_121
 
 textures/pad_effects/zzsteam_big_Zplus_122
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_123
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13583,7 +13583,7 @@ textures/pad_effects/zzsteam_big_Zplus_122
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.953125 1
 		alphagen const 1
@@ -13594,7 +13594,7 @@ textures/pad_effects/zzsteam_big_Zplus_122
 
 textures/pad_effects/zzsteam_big_Zplus_123
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_124
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13605,7 +13605,7 @@ textures/pad_effects/zzsteam_big_Zplus_123
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.960938 1
 		alphagen const 1
@@ -13616,7 +13616,7 @@ textures/pad_effects/zzsteam_big_Zplus_123
 
 textures/pad_effects/zzsteam_big_Zplus_124
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_125
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13627,7 +13627,7 @@ textures/pad_effects/zzsteam_big_Zplus_124
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.96875 1
 		alphagen const 1
@@ -13638,7 +13638,7 @@ textures/pad_effects/zzsteam_big_Zplus_124
 
 textures/pad_effects/zzsteam_big_Zplus_125
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_126
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13649,7 +13649,7 @@ textures/pad_effects/zzsteam_big_Zplus_125
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.976563 1
 		alphagen const 1
@@ -13660,7 +13660,7 @@ textures/pad_effects/zzsteam_big_Zplus_125
 
 textures/pad_effects/zzsteam_big_Zplus_126
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	q3map_cloneshader textures/pad_effects/zzsteam_big_Zplus_127
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -13671,7 +13671,7 @@ textures/pad_effects/zzsteam_big_Zplus_126
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.984375 1
 		alphagen const 1
@@ -13682,7 +13682,7 @@ textures/pad_effects/zzsteam_big_Zplus_126
 
 textures/pad_effects/zzsteam_big_Zplus_127
 {
-	qer_editorimage textures/particles/steam.tga
+	qer_editorimage textures/particles/steam
 	surfaceparm nonsolid
 	surfaceparm trans
 	surfaceparm nomarks
@@ -13692,7 +13692,7 @@ textures/pad_effects/zzsteam_big_Zplus_127
 	deformvertexes autosprite
 	cull disable
 	{
-		clampmap textures/particles/steam.tga
+		clampmap textures/particles/steam
 		blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		rgbgen wave sawtooth 1 -2 0.992188 1
 		alphagen const 1

--- a/wop/scripts.pk3dir/scripts/pad_fridge.shader
+++ b/wop/scripts.pk3dir/scripts/pad_fridge.shader
@@ -4,360 +4,360 @@
 textures/pad_fridge/kb_poolpackblue
 {
 	{
-		map textures/pad_fridge/kb_poolpackblue.tga
+		map textures/pad_fridge/kb_poolpackblue
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_poolpackred
 {
 	{
-		map textures/pad_fridge/kb_poolpackred.tga
+		map textures/pad_fridge/kb_poolpackred
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_butter01
 {
 	{
-		map textures/pad_fridge/kb_butter01.tga
+		map textures/pad_fridge/kb_butter01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_butter02
 {
 	{
-		map textures/pad_fridge/kb_butter02.tga
+		map textures/pad_fridge/kb_butter02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_butter03
 {
 	{
-		map textures/pad_fridge/kb_butter03.tga
+		map textures/pad_fridge/kb_butter03
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_butter04
 {
 	{
-		map textures/pad_fridge/kb_butter04.tga
+		map textures/pad_fridge/kb_butter04
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_margarine01
 {
 	{
-		map textures/pad_fridge/kb_margarine01.tga
+		map textures/pad_fridge/kb_margarine01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_margarine02
 {
 	{
-		map textures/pad_fridge/kb_margarine02.tga
+		map textures/pad_fridge/kb_margarine02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_margarine03
 {
 	{
-		map textures/pad_fridge/kb_margarine03.tga
+		map textures/pad_fridge/kb_margarine03
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_margarine04
 {
 	{
-		map textures/pad_fridge/kb_margarine04.tga
+		map textures/pad_fridge/kb_margarine04
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_blackbox01
 {
 	{
-		map textures/pad_fridge/kb_blackbox01.tga
+		map textures/pad_fridge/kb_blackbox01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_blackbox02
 {
 	{
-		map textures/pad_fridge/kb_blackbox02.tga
+		map textures/pad_fridge/kb_blackbox02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_blackbox03
 {
 	{
-		map textures/pad_fridge/kb_blackbox03.tga
+		map textures/pad_fridge/kb_blackbox03
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_joghurt01
 {
 	{
-		map textures/pad_fridge/kb_joghurt01.tga
+		map textures/pad_fridge/kb_joghurt01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_joghurt02
 {
 	{
-		map textures/pad_fridge/kb_joghurt02.tga
+		map textures/pad_fridge/kb_joghurt02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_joghurt03
 {
 	{
-		map textures/pad_fridge/kb_joghurt03.tga
+		map textures/pad_fridge/kb_joghurt03
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_feta01
 {
 	{
-		map textures/pad_fridge/kb_feta01.tga
+		map textures/pad_fridge/kb_feta01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_feta02
 {
 	{
-		map textures/pad_fridge/kb_feta02.tga
+		map textures/pad_fridge/kb_feta02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
@@ -366,33 +366,33 @@ textures/pad_fridge/kb_feta02
 // ==============================================================
 textures/pad_fridge/kb_eisfachlight_2500
 {
-	qer_editorimage textures/pad_fridge/kb_eisfachlight.tga
-	q3map_lightimage textures/colors/white.tga
+	qer_editorimage textures/pad_fridge/kb_eisfachlight
+	q3map_lightimage textures/colors/white
 	q3map_surfacelight 2500
 	q3map_backsplash 15 128
 	{
-		map textures/pad_fridge/kb_eisfachlight.tga
+		map textures/pad_fridge/kb_eisfachlight
 		rgbGen identity
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_decke
 {
-	qer_editorimage textures/pad_wallin/color07.tga
-	q3map_lightimage textures/pad_wallin/color07.tga
+	qer_editorimage textures/pad_wallin/color07
+	q3map_lightimage textures/pad_wallin/color07
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nomarks
 	q3map_surfacelight 20000
 	q3map_backsplash 0 0
 	{
-		map textures/pad_wallin/color07.tga
+		map textures/pad_wallin/color07
 	}
 }
 
@@ -401,7 +401,7 @@ textures/pad_fridge/kb_decke
 // ==============================================================
 textures/pad_fridge/fog_dusty
 {
-	qer_editorimage textures/pad_gfx02b/padfog_grey.tga
+	qer_editorimage textures/pad_gfx02b/padfog_grey
 	surfaceparm fog
 	surfaceparm nolightmap
 	surfaceparm nonsolid
@@ -414,16 +414,16 @@ textures/pad_fridge/fog_dusty
 // ==============================================================
 textures/pad_fridge/kb_milch
 {
-	qer_editorimage textures/pad_fridge/kb_milch.tga
+	qer_editorimage textures/pad_fridge/kb_milch
 	surfaceparm nonsolid
 	surfaceparm trans
 	surfaceparm water
 	cull disable
 	qer_trans 0.5
 	q3map_globaltexture
-	//        surfaceparm nolightmap 
+	//        surfaceparm nolightmap
 	{
-		map textures/pad_fridge/kb_milch.tga
+		map textures/pad_fridge/kb_milch
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.2 0.05 1 0.05
@@ -431,34 +431,34 @@ textures/pad_fridge/kb_milch
 		tcMod scroll 0.005 0.005
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_fridge/kb_milchfall
 {
-	qer_editorimage textures/pad_fridge/kb_milch.tga
+	qer_editorimage textures/pad_fridge/kb_milch
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm trans
 	surfaceparm water
 	cull disable
-	deformVertexes wave 128 triangle 1 3 0.1 0.8 
+	deformVertexes wave 128 triangle 1 3 0.1 0.8
 	tessSize 32
 	qer_trans 0.5
 	q3map_globaltexture
 	{
-		map textures/pad_fridge/kb_milch.tga
+		map textures/pad_fridge/kb_milch
 		blendfunc add
 		tcMod scale 1 1
 		tcMod turb 0.1 0.08 0.5 0.1
 		tcMod scroll 0.8 0.25
 	}
 	{
-		map textures/pad_fridge/kb_milch.tga
+		map textures/pad_fridge/kb_milch
 		blendfunc filter
 		tcMod scale 0.5 0.5
 		tcMod turb 0.1 0.075 0.5 0.05
@@ -471,29 +471,29 @@ textures/pad_fridge/kb_milchfall
 // ==============================================================
 textures/pad_fridge/kb_eisfach
 {
-	qer_editorimage textures/pad_fridge/kb_eisfach.tga
+	qer_editorimage textures/pad_fridge/kb_eisfach
 	surfaceparm snowsteps
 	{
-		map textures/pad_fridge/kb_sparkle.tga
+		map textures/pad_fridge/kb_sparkle
 		rgbGen vertex
 		tcMod scale 2 2
 		tcGen environment
 	}
 	{
-		map $whiteimage 
+		map $whiteimage
 		blendfunc add
 		rgbGen const ( 0.8 0.8 0.8 )
 	}
 	{
-		map textures/pad_fridge/kb_eisfach.tga
+		map textures/pad_fridge/kb_eisfach
 		rgbGen identity
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
@@ -501,26 +501,26 @@ textures/pad_fridge/kb_eisfach
 // 	DECALS
 // ==============================================================
 textures/pad_fridge/kb_klecks
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_fridge/kb_klecks.tga
+		map textures/pad_fridge/kb_klecks
                	blendFunc blend
 		rgbGen vertex
 	}
 }
 
 textures/pad_fridge/wop_icelogo
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_fridge/wop_icelogo.tga
+		map textures/pad_fridge/wop_icelogo
                	blendFunc blend
 		rgbGen vertex
 	}
@@ -537,7 +537,7 @@ textures/pad_fridge/kb_groundw
 		rgbGen identity
 	}
 	{
-		map textures/pad_fridge/kb_groundw.tga
+		map textures/pad_fridge/kb_groundw
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}

--- a/wop/scripts.pk3dir/scripts/pad_gamemodels.shader
+++ b/wop/scripts.pk3dir/scripts/pad_gamemodels.shader
@@ -3,85 +3,85 @@
 // =================
 
 //23:19 06/04/2003//pad health station v2 SLoB
-//2 main textures - pad_hs_base.tga, pad_hs_crossring.tga
+//2 main textures - pad_hs_base, pad_hs_crossring
 //
 models/mapobjects/pad_healthstation/pad_hs_dome
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_healthstation/pad_hs_base.tga
-	
-	
+	qer_editorimage models/mapobjects/pad_healthstation/pad_hs_base
+
+
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_base.tga
+		map models/mapobjects/pad_healthstation/pad_hs_base
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_baselight.tga
+		map models/mapobjects/pad_healthstation/pad_hs_baselight
 		blendfunc add
 	}
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_baselight.tga
+		map models/mapobjects/pad_healthstation/pad_hs_baselight
 		rgbGen wave sin .5 .5 0 .35
 		blendFunc add
 	}
 }
 
 models/mapobjects/pad_healthstation/pad_hs_fin
-{   	                 
+{
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_healthstation/pad_hs_base.tga
+	qer_editorimage models/mapobjects/pad_healthstation/pad_hs_base
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_base.tga
+		map models/mapobjects/pad_healthstation/pad_hs_base
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_baselight.tga
+		map models/mapobjects/pad_healthstation/pad_hs_baselight
 		blendFunc add
-		
+
 	}
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_baselight.tga
+		map models/mapobjects/pad_healthstation/pad_hs_baselight
 		blendFunc add
 		rgbGen wave sin .5 .5 0 .35
-		
+
 	}
-	
+
 }
 
 models/mapobjects/pad_healthstation/pad_hs_ring
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_healthstation/pad_hs_base.tga
+	qer_editorimage models/mapobjects/pad_healthstation/pad_hs_base
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_base.tga
+		map models/mapobjects/pad_healthstation/pad_hs_base
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_baselight.tga
+		map models/mapobjects/pad_healthstation/pad_hs_baselight
 		blendFunc add
-		
+
 	}
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_baselight.tga
+		map models/mapobjects/pad_healthstation/pad_hs_baselight
 		rgbGen wave sin .5 .5 0 .35
 		blendFunc add
 	}
@@ -94,23 +94,23 @@ models/mapobjects/pad_healthstation/pad_hs_crossring
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	qer_editorimage models/mapobjects/pad_healthstation/pad_hs_crossring.tga
-	cull disable 
+	qer_editorimage models/mapobjects/pad_healthstation/pad_hs_crossring
+	cull disable
 	{
-		map models/mapobjects/pad_healthstation/pad_hs_crossring.tga
+		map models/mapobjects/pad_healthstation/pad_hs_crossring
 		rgbGen lightingdiffuse
 	}
 	{
-	        map models/mapobjects/pad_healthstation/red02.tga
-		blendfunc GL_ONE GL_ONE                   
+	        map models/mapobjects/pad_healthstation/red02
+		blendfunc GL_ONE GL_ONE
                 tcMod turb 0 .2 0 .2
                	tcmod scale .4 .4
                 tcMod scroll .09 -.1.1
                 rgbGen lightingdiffuse
-        }	
+        }
         {
-                map models/mapobjects/pad_healthstation/red.tga
-		blendfunc GL_ONE GL_ONE                   
+                map models/mapobjects/pad_healthstation/red
+		blendfunc GL_ONE GL_ONE
                 tcMod turb 0 .1 0 .3
                 tcmod scale .2 .2
                 tcMod scroll .1 .09
@@ -123,7 +123,7 @@ station/ring
 {
 	cull disable
 	{
-		map models/mapobjects/pad_healthstation/ringy.tga
+		map models/mapobjects/pad_healthstation/ringy
 		tcGen environment
 		tcMod turb 0 0.15 0 0.3
                 tcmod rotate 333
@@ -142,14 +142,14 @@ models/ctl/foil
 {
 	cull disable
 	{
-		map models/ctl/foil.tga
+		map models/ctl/foil
 		blendfunc add
 		rgbGen identity
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
-		tcGen environment 
+		tcGen environment
 	}
 }
 
@@ -157,13 +157,13 @@ models/ctl/r_lollipop
 {
 	cull disable
 	{
-		map models/ctl/r_lollipop.tga
+		map models/ctl/r_lollipop
 		rgbGen identity
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
-		tcGen environment 
+		tcGen environment
 	}
 }
 
@@ -171,17 +171,17 @@ models/ctl/r_sticker_ribbon
 {
 	cull disable
 	{
-		map models/ctl/r_chromic.tga
+		map models/ctl/r_chromic
 		rgbGen identity
 		alphaFunc GE128
 	}
 	{
-		map models/ctl/r_chromic.tga
-		tcGen environment 
+		map models/ctl/r_chromic
+		tcGen environment
 		depthFunc equal
 	}
 	{
-		map models/ctl/r_sticker_ribbon.tga
+		map models/ctl/r_sticker_ribbon
 		depthFunc equal
 		alphaFunc GE128
 	}
@@ -191,13 +191,13 @@ models/ctl/b_lollipop
 {
 	cull disable
 	{
-		map models/ctl/b_lollipop.tga
+		map models/ctl/b_lollipop
 		rgbGen identity
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
-		tcGen environment 
+		tcGen environment
 	}
 }
 
@@ -205,17 +205,17 @@ models/ctl/b_sticker_ribbon
 {
 	cull disable
 	{
-		map models/ctl/b_chromic.tga
+		map models/ctl/b_chromic
 		rgbGen identity
 		alphaFunc GE128
 	}
 	{
-		map models/ctl/b_chromic.tga
-		tcGen environment 
+		map models/ctl/b_chromic
+		tcGen environment
 		depthFunc equal
 	}
 	{
-		map models/ctl/b_sticker_ribbon.tga
+		map models/ctl/b_sticker_ribbon
 		depthFunc equal
 		alphaFunc GE128
 	}
@@ -229,8 +229,8 @@ models/special/ballon
 {
 	nomipmaps
 	{
-		map models/special/ballon.tga
-		rgbGen entity  
+		map models/special/ballon
+		rgbGen entity
         }
 	{
 		map $lightmap
@@ -238,30 +238,30 @@ models/special/ballon
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
-		blendfunc GL_ONE GL_ONE 
+		map textures/pad_gfx02/tinpad3
+		blendfunc GL_ONE GL_ONE
 		tcGen environment
         rgbGen entity //lightingDiffuse //vertex //identity //makes effect darker
 	}
 }
 
 models/special/box
-{	
+{
 	nopicmip
 	nomipmaps
-	qer_editorimage models/special/box.tga
+	qer_editorimage models/special/box
 	{
-		map models/special/box.tga
+		map models/special/box
 		rgbGen lightingdiffuse
 	}
 
 }
 
 models/special/bow
-{	
+{
 	cull none
 	{
-		map textures/pad_gfx02/padmaprail4.tga
+		map textures/pad_gfx02/padmaprail4
 		tcGen environment
 		rgbGen lightingdiffuse
 	}
@@ -272,10 +272,10 @@ models/special/bow
 // =================
 
 models/iceblock
-{	
-	cull none	
+{
+	cull none
 	{
-        map models/iceblock.tga
+        map models/iceblock
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
     }
@@ -292,58 +292,58 @@ models/mapobjects/pad_teleporter/pad_teleporter_blue
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_blgr
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_bl_glow.tga
-		blendFunc add			
+		map models/mapobjects/pad_teleporter/pad_teleporter_bl_glow
+		blendFunc add
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_bl_glow.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_bl_glow
 		blendFunc add
-		rgbGen wave sin .5 .5 0 .35	
-		
+		rgbGen wave sin .5 .5 0 .35
+
 	}
-	
+
 }
 
 models/mapobjects/pad_teleporter/pad_teleporter_orange
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_blgr
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_or_glow.tga
-		blendFunc add			
+		map models/mapobjects/pad_teleporter/pad_teleporter_or_glow
+		blendFunc add
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_or_glow.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_or_glow
 		blendFunc add
-		rgbGen wave sin .5 .5 0 .35	
-		
+		rgbGen wave sin .5 .5 0 .35
+
 	}
 }
 
@@ -351,28 +351,28 @@ models/mapobjects/pad_teleporter/pad_teleporter_yellow
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_blgr
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_ye_glow.tga
-		blendFunc add			
+		map models/mapobjects/pad_teleporter/pad_teleporter_ye_glow
+		blendFunc add
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_ye_glow.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_ye_glow
 		blendFunc add
-		rgbGen wave sin .5 .5 0 .35	
-		
+		rgbGen wave sin .5 .5 0 .35
+
 	}
 }
 
@@ -380,28 +380,28 @@ models/mapobjects/pad_teleporter/pad_teleporter_pink
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_blgr
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_pi_glow.tga
-		blendFunc add			
+		map models/mapobjects/pad_teleporter/pad_teleporter_pi_glow
+		blendFunc add
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_pi_glow.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_pi_glow
 		blendFunc add
-		rgbGen wave sin .5 .5 0 .35	
-		
+		rgbGen wave sin .5 .5 0 .35
+
 	}
 }
 
@@ -409,28 +409,28 @@ models/mapobjects/pad_teleporter/pad_teleporter_purple
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+	qer_editorimage models/mapobjects/pad_teleporter/pad_teleporter_blgr
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_blgr.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_blgr
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_pu_glow.tga
-		blendFunc add			
+		map models/mapobjects/pad_teleporter/pad_teleporter_pu_glow
+		blendFunc add
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_teleporter_pu_glow.tga
+		map models/mapobjects/pad_teleporter/pad_teleporter_pu_glow
 		blendFunc add
-		rgbGen wave sin .5 .5 0 .35	
-		
+		rgbGen wave sin .5 .5 0 .35
+
 	}
 }
 
@@ -438,34 +438,34 @@ models/mapobjects/pad_teleporter/pad_baseglow
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_teleporter/padlogo.tga
+	qer_editorimage models/mapobjects/pad_teleporter/padlogo
 	{
-		map models/mapobjects/pad_teleporter/padlogo.tga
+		map models/mapobjects/pad_teleporter/padlogo
 		rgbGen lightingDiffuse
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_baseglow.tga
+		map models/mapobjects/pad_teleporter/pad_baseglow
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_teleporter/padlogo.tga
+		map models/mapobjects/pad_teleporter/padlogo
 		blendFunc add
 		rgbGen wave sin .5 .5 0 .35
-		
+
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_baseglow.tga
+		map models/mapobjects/pad_teleporter/pad_baseglow
 		blendFunc add
 		rgbGen wave sin .5 .5 0 .35
-		
+
 	}
 }
 
@@ -476,20 +476,20 @@ models/mapobjects/pad_teleporter/padsphere_orange
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_teleporter/padsphereor.tga
+	q3map_lightimage models/mapobjects/pad_teleporter/padsphereor
 	q3map_surfacelight 200
 
-	cull disable 
+	cull disable
     	{
-		map models/mapobjects/pad_teleporter/padsphereor.tga
+		map models/mapobjects/pad_teleporter/padsphereor
                	blendfunc GL_ONE GL_ONE
-		tcMod scale 2 2	
+		tcMod scale 2 2
                	tcMod scroll .2 .2
 		rgbGen lightingdiffuse
        }
 
 	{
-               	map textures/pad_gfx02/padmapsphere01.jpg
+               	map textures/pad_gfx02/padmapsphere01
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll .1 -.1
@@ -497,7 +497,7 @@ models/mapobjects/pad_teleporter/padsphere_orange
        	}
 
 	{
-               	map textures/pad_gfx02/padmapsphere02.jpg
+               	map textures/pad_gfx02/padmapsphere02
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll -.1 .1
@@ -515,20 +515,20 @@ models/mapobjects/pad_teleporter/padsphere_blue
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_teleporter/padspherebl.tga
+	q3map_lightimage models/mapobjects/pad_teleporter/padspherebl
 	q3map_surfacelight 200
 
-	cull disable 
+	cull disable
     	{
-		map models/mapobjects/pad_teleporter/padspherebl.tga
+		map models/mapobjects/pad_teleporter/padspherebl
                	blendfunc GL_ONE GL_ONE
-		tcMod scale 2 2	
+		tcMod scale 2 2
                	tcMod scroll .2 .2
 		rgbGen lightingdiffuse
        }
 
 	{
-               	map textures/pad_gfx02/padmapspherebl01.jpg
+               	map textures/pad_gfx02/padmapspherebl01
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll .1 -.1
@@ -536,7 +536,7 @@ models/mapobjects/pad_teleporter/padsphere_blue
        	}
 
 	{
-               	map textures/pad_gfx02/padmapspherebl02.jpg
+               	map textures/pad_gfx02/padmapspherebl02
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll -.1 .1
@@ -554,20 +554,20 @@ models/mapobjects/pad_teleporter/padsphere_purple
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_teleporter/padspherepu.tga
+	q3map_lightimage models/mapobjects/pad_teleporter/padspherepu
 	q3map_surfacelight 200
 
-	cull disable 
+	cull disable
     	{
-		map models/mapobjects/pad_teleporter/padspherepu.tga
+		map models/mapobjects/pad_teleporter/padspherepu
                	blendfunc GL_ONE GL_ONE
-		tcMod scale 2 2	
+		tcMod scale 2 2
                	tcMod scroll .2 .2
 		rgbGen lightingdiffuse
        }
 
 	{
-               	map textures/pad_gfx02/padmapspherepu01.jpg
+               	map textures/pad_gfx02/padmapspherepu01
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll .1 -.1
@@ -575,7 +575,7 @@ models/mapobjects/pad_teleporter/padsphere_purple
        	}
 
 	{
-               	map textures/pad_gfx02/padmapspherepu02.jpg
+               	map textures/pad_gfx02/padmapspherepu02
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll -.1 .1
@@ -593,20 +593,20 @@ models/mapobjects/pad_teleporter/padsphere_pink
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_teleporter/padspherepi.tga
+	q3map_lightimage models/mapobjects/pad_teleporter/padspherepi
 	q3map_surfacelight 200
 
-	cull disable 
+	cull disable
     	{
-		map models/mapobjects/pad_teleporter/padspherepi.tga
+		map models/mapobjects/pad_teleporter/padspherepi
                	blendfunc GL_ONE GL_ONE
-		tcMod scale 2 2	
+		tcMod scale 2 2
                	tcMod scroll .2 .2
 		rgbGen lightingdiffuse
        }
 
 	{
-               	map textures/pad_gfx02/padmapspherepi01.jpg
+               	map textures/pad_gfx02/padmapspherepi01
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll .1 -.1
@@ -614,7 +614,7 @@ models/mapobjects/pad_teleporter/padsphere_pink
        	}
 
 	{
-               	map textures/pad_gfx02/padmapspherepi02.jpg
+               	map textures/pad_gfx02/padmapspherepi02
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll -.1 .1
@@ -632,20 +632,20 @@ models/mapobjects/pad_teleporter/padsphere_yellow
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_teleporter/padsphereyel.tga
+	q3map_lightimage models/mapobjects/pad_teleporter/padsphereyel
 	q3map_surfacelight 200
 
-	cull disable 
+	cull disable
     	{
-		map models/mapobjects/pad_teleporter/padsphereyel.tga
+		map models/mapobjects/pad_teleporter/padsphereyel
                	blendfunc GL_ONE GL_ONE
-		tcMod scale 2 2	
+		tcMod scale 2 2
                	tcMod scroll .2 .2
 		rgbGen lightingdiffuse
        }
 
 	{
-               	map textures/pad_gfx02/padmapsphereyel01.jpg
+               	map textures/pad_gfx02/padmapsphereyel01
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll .1 -.1
@@ -653,7 +653,7 @@ models/mapobjects/pad_teleporter/padsphere_yellow
        	}
 
 	{
-               	map textures/pad_gfx02/padmapsphereyel02.jpg
+               	map textures/pad_gfx02/padmapsphereyel02
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll -.1 .1
@@ -666,15 +666,15 @@ models/mapobjects/pad_teleporter/padsphere_yellow
 models/mapobjects/pad_teleporter/pad_base
 {
 	nopicmip
-	nomipmaps 
-	qer_editorimage models/mapobjects/pad_teleporter/pad_base.tga
+	nomipmaps
+	qer_editorimage models/mapobjects/pad_teleporter/pad_base
 	{
-		map models/mapobjects/pad_teleporter/pad_base.tga
+		map models/mapobjects/pad_teleporter/pad_base
 		alphaFunc ge128
 		rgbGen lightingDiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -696,64 +696,64 @@ models/mapobjects/pad_teleporter/pad_base
 
 //4 blue versions with blue glow
 models/mapobjects/pad_weaponmarker/pad_wepm_blue_bg
-{	
+{
 	nopicmip
-	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_blue_bg.tga
+	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_blue_bg
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_blue_bg.tga
-		
-		
+		map models/mapobjects/pad_weaponmarker/pad_wepm_blue_bg
+
+
 	}
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_blueglow.tga
+		map models/mapobjects/pad_weaponmarker/pad_wepm_blueglow
 		rgbGen wave sin .05 .9 0 .4
 		blendFunc add
 	}
 }
 
 models/mapobjects/pad_weaponmarker/pad_wepm_black_bg
-{	
+{
 	nopicmip
-	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_black_bg.tga
+	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_black_bg
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_black_bg.tga
-		
-		
+		map models/mapobjects/pad_weaponmarker/pad_wepm_black_bg
+
+
 	}
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_blueglow.tga
+		map models/mapobjects/pad_weaponmarker/pad_wepm_blueglow
 		rgbGen wave sin .05 .9 0 .4
 		blendFunc add
 	}
 }
 
 models/mapobjects/pad_weaponmarker/pad_wepm_orange_bg
-{	
+{
 	nopicmip
-	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_orange_bg.tga
+	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_orange_bg
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_orange_bg.tga
-		
-		
+		map models/mapobjects/pad_weaponmarker/pad_wepm_orange_bg
+
+
 	}
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_blueglow.tga
+		map models/mapobjects/pad_weaponmarker/pad_wepm_blueglow
 		rgbGen wave sin .05 .9 0 .4
 		blendFunc add
 	}
 }
 
 models/mapobjects/pad_weaponmarker/pad_wepm_green_bg
-{	
+{
 	nopicmip
-	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_green_bg.tga
+	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_green_bg
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_green_bg.tga
-		
-		
+		map models/mapobjects/pad_weaponmarker/pad_wepm_green_bg
+
+
 	}
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_pinkglow.tga
+		map models/mapobjects/pad_weaponmarker/pad_wepm_pinkglow
 		rgbGen wave sin .05 .9 0 .4
 		blendFunc add
 	}
@@ -761,16 +761,16 @@ models/mapobjects/pad_weaponmarker/pad_wepm_green_bg
 
 //1 green version with green glow
 models/mapobjects/pad_weaponmarker/pad_wepm_green_gg
-{	
+{
 	nopicmip
-	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_green_gg.tga
+	qer_editorimage models/mapobjects/pad_weaponmarker/pad_wepm_green_gg
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_green_gg.tga
-		
-		
+		map models/mapobjects/pad_weaponmarker/pad_wepm_green_gg
+
+
 	}
 	{
-		map models/mapobjects/pad_weaponmarker/pad_wepm_greenglow.tga
+		map models/mapobjects/pad_weaponmarker/pad_wepm_greenglow
 		rgbGen wave sin .05 .9 0 .4
 		blendFunc add
 	}
@@ -783,25 +783,25 @@ models/mapobjects/pad_weaponmarker/pad_wepm_bluecone
 {
 	nopicmip
 	cull none
-	qer_editorimage models/mapobjects/pad_weaponmarker/beam_blue.tga
+	qer_editorimage models/mapobjects/pad_weaponmarker/beam_blue
 	{
-		map models/mapobjects/pad_weaponmarker/beam_blue.tga
+		map models/mapobjects/pad_weaponmarker/beam_blue
                 tcMod Scroll .3 0
                 blendFunc add
         }
-     
+
 }
 
 models/mapobjects/pad_weaponmarker/pad_wepm_greencone
 {
 	nopicmip
 	cull none
-	qer_editorimage models/mapobjects/pad_weaponmarker/beam_green.tga
+	qer_editorimage models/mapobjects/pad_weaponmarker/beam_green
 	{
-		map models/mapobjects/pad_weaponmarker/beam_green.tga
+		map models/mapobjects/pad_weaponmarker/beam_green
                 tcMod Scroll .3 0
                 blendFunc add
         }
-     
+
 }
 

--- a/wop/scripts.pk3dir/scripts/pad_garden.shader
+++ b/wop/scripts.pk3dir/scripts/pad_garden.shader
@@ -67,14 +67,14 @@ qer_trans 0.75
 
 textures/pad_garden/vines2
 {
-        qer_editorimage textures/pad_garden/vines2.tga
+        qer_editorimage textures/pad_garden/vines2
     	surfaceparm trans
 	surfaceparm alphashadow
    	surfaceparm nonsolid
 	cull none
         nopicmip
 	{
-		map textures/pad_garden/vines2.tga
+		map textures/pad_garden/vines2
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -88,37 +88,37 @@ textures/pad_garden/vines2
 	}
 }
 
-textures/pad_garden/schilf02 
-{ 
-        qer_editorimage textures/pad_garden/schilf02.tga 
-      //q3map_lightimage textures/pad_garden/schilf02.tga 
-        qer_trans 0.5 
-        q3map_globaltexture 
-        surfaceparm trans 
-        surfaceparm nonsolid 
-        surfaceparm water 
-        cull disable 
-        
+textures/pad_garden/schilf02
+{
+        qer_editorimage textures/pad_garden/schilf02
+      //q3map_lightimage textures/pad_garden/schilf02
+        qer_trans 0.5
+        q3map_globaltexture
+        surfaceparm trans
+        surfaceparm nonsolid
+        surfaceparm water
+        cull disable
 
-        { 
-               map textures/pad_garden/schilf02.tga 
-               tcMod turb 0.2 0.1 1 0.05 
-               tcMod scale 0.5 0.5 
-               tcMod scroll 0.01 0.01 
+
+        {
+               map textures/pad_garden/schilf02
+               tcMod turb 0.2 0.1 1 0.05
+               tcMod scale 0.5 0.5
+               tcMod scroll 0.01 0.01
 	       blendFunc filter
 	       rgbGen identity
 
-        } 
+        }
 
-        { 
-               map textures/pad_garden/schilf03.tga 
-               tcMod turb 0.2 0.1 1 0.05 
-               tcMod scale -0.5 -0.5 
-               tcMod scroll .025 -.001 
+        {
+               map textures/pad_garden/schilf03
+               tcMod turb 0.2 0.1 1 0.05
+               tcMod scale -0.5 -0.5
+               tcMod scroll .025 -.001
 	       blendFunc filter
 	       rgbGen identity
 
-        } 
+        }
 
 	{
 		map $lightmap
@@ -131,12 +131,12 @@ textures/pad_garden/schilf02
 
 textures/pad_garden/tuereglass
 {
-        surfaceparm trans	
+        surfaceparm trans
 	cull none
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_garden/tuereglass.tga
+		map textures/pad_garden/tuereglass
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -146,18 +146,18 @@ textures/pad_garden/tuereglass
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_garden/tuerglasdark
 {
-        surfaceparm trans	
+        surfaceparm trans
 	cull none
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_garden/tuerglasdark.tga
+		map textures/pad_garden/tuerglasdark
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -167,18 +167,18 @@ textures/pad_garden/tuerglasdark
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_garden/fensterglass
 {
-        surfaceparm trans	
+        surfaceparm trans
 	cull none
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_garden/fensterglass.tga
+		map textures/pad_garden/fensterglass
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -188,18 +188,18 @@ textures/pad_garden/fensterglass
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_garden/fensterglasdark
 {
-        surfaceparm trans	
+        surfaceparm trans
 	cull none
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_garden/fensterglasdark.tga
+		map textures/pad_garden/fensterglasdark
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -209,13 +209,13 @@ textures/pad_garden/fensterglasdark
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_garden/firedrops01
 {
-qer_editorimage textures/pad_garden/firedrops.tga
+qer_editorimage textures/pad_garden/firedrops
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -225,7 +225,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.000043 0.000000 -1100 sawtooth 0 1 0.000000 3
 {
-clampmap textures/pad_garden/firedrops.tga
+clampmap textures/pad_garden/firedrops
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.000000 8.000000 0.000000 0.129033
 rgbGen wave sawtooth 1.000000 0.000000 0.000000 0.129033
@@ -237,7 +237,7 @@ blendfunc blend
 
 textures/pad_garden/firedrops02
 {
-		qer_editorimage textures/pad_garden/firedrops.tga
+		qer_editorimage textures/pad_garden/firedrops
 		surfaceparm noimpact
 		surfaceparm nolightmap
 		cull none
@@ -247,7 +247,7 @@ textures/pad_garden/firedrops02
 		deformvertexes autosprite
 		deformvertexes move 0.000043 0.000000 -1100 sawtooth 0 1 0.800000 3
 	{
-		clampmap textures/pad_garden/firedrops.tga
+		clampmap textures/pad_garden/firedrops
 		tcMod rotate 0.000000
 		AlphaGen wave sawtooth 0.000000 8.000000 0.800000 0.129033
 		rgbGen wave sawtooth 1.000000 0.000000 0.800000 0.129033
@@ -261,14 +261,14 @@ textures/pad_garden/padflagred
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_garden/padflagred.tga
+                map textures/pad_garden/padflagred
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -288,14 +288,14 @@ textures/pad_garden/padflagblue
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_garden/padflagblue.tga
+                map textures/pad_garden/padflagblue
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -312,18 +312,18 @@ textures/pad_garden/padflagblue
 
 textures/pad_garden/fort-pad
 {
-        qer_editorimage textures/pad_garden/fort-pad.tga
+        qer_editorimage textures/pad_garden/fort-pad
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-              q3map_lightimage textures/pad_garden/brightyell.tga
+              q3map_lightimage textures/pad_garden/brightyell
 	q3map_sun	1.000000 0.913939 0.701350 390 220 40
 	q3map_surfacelight 250
 
         skyparms env/fort-pad512 - -
 //       {
-//		map textures/pad_garden/fort-pad.tga
+//		map textures/pad_garden/fort-pad
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -333,18 +333,18 @@ textures/pad_garden/fort-pad
 
 textures/pad_garden/polter_geist
 {
-        qer_editorimage textures/pad_garden/polter_geist.tga
+        qer_editorimage textures/pad_garden/polter_geist
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-              q3map_lightimage textures/pad_garden/darkblue.tga
+              q3map_lightimage textures/pad_garden/darkblue
 	q3map_sun	0.404654 0.474220 1.000000 330 220 50
 	q3map_surfacelight 160
 
         skyparms env/pf-garden512 - -
 //       {
-//		map textures/pad_garden/polter_geist.tga
+//		map textures/pad_garden/polter_geist
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -357,7 +357,7 @@ textures/pad_garden/nachtfenster
     q3map_surfacelight 1000
     surfaceparm nolightmap
     {
-        map textures/pad_garden/nachtfenster.tga
+        map textures/pad_garden/nachtfenster
     }
 }
 
@@ -373,12 +373,12 @@ textures/pad_garden/redpoints01
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/redpoints01.tga
+		map textures/pad_garden/redpoints01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/redpoints01_blend.tga
+		map textures/pad_garden/redpoints01_blend
 		rgbGen wave sin 0.5 0.5 1 1
 		blendfunc GL_ONE GL_ONE
 	}
@@ -394,12 +394,12 @@ textures/pad_garden/redpoints02
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/redpoints02.tga
+		map textures/pad_garden/redpoints02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/redpoints02_blend.tga
+		map textures/pad_garden/redpoints02_blend
 		rgbGen wave sin 0.7 0.7 1 1
 		blendfunc GL_ONE GL_ONE
 	}
@@ -407,13 +407,13 @@ textures/pad_garden/redpoints02
 
 
 textures/pad_garden/kreidemotiv01
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_garden/kreidemotiv01.tga
+		map textures/pad_garden/kreidemotiv01
                		blendFunc add
 		rgbGen vertex
 	}
@@ -421,13 +421,13 @@ textures/pad_garden/kreidemotiv01
 
 
 textures/pad_garden/kreidemotiv02
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_garden/kreidemotiv02.tga
+		map textures/pad_garden/kreidemotiv02
                		blendFunc add
 		rgbGen vertex
 	}
@@ -435,13 +435,13 @@ textures/pad_garden/kreidemotiv02
 
 
 textures/pad_garden/kreidemotiv03
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_garden/kreidemotiv03.tga
+		map textures/pad_garden/kreidemotiv03
                		blendFunc add
 		rgbGen vertex
 	}
@@ -450,7 +450,7 @@ textures/pad_garden/kreidemotiv03
 
 textures/pad_garden/bubbles2_1
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -460,7 +460,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.093287 -41.198784 141.500214 sawtooth 0 1 1.000725 0.195925
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 20.229958
 AlphaGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
 rgbGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
@@ -471,7 +471,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_2
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -481,7 +481,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.769913 -21.519264 169.001572 sawtooth 0 1 0.622631 0.252309
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 2.200842
 AlphaGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
 rgbGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
@@ -492,7 +492,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_3
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -502,7 +502,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.625161 -6.980746 87.586830 sawtooth 0 1 1.213530 0.445164
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 19.405041
 AlphaGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
 rgbGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
@@ -513,7 +513,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_4
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -523,7 +523,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.668365 -12.663155 109.066895 sawtooth 0 1 1.085688 0.300365
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 11.414990
 AlphaGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
 rgbGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
@@ -534,7 +534,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_5
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -544,7 +544,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.763139 -30.482132 151.611313 sawtooth 0 1 0.288759 0.189146
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 1.619465
 AlphaGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
 rgbGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
@@ -555,7 +555,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_6
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -565,7 +565,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.834942 -10.679131 100.490509 sawtooth 0 1 1.237915 0.365962
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate -2.907956
 AlphaGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
 rgbGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
@@ -576,7 +576,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_7
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -586,7 +586,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.454388 -41.883984 127.730408 sawtooth 0 1 0.402287 0.207241
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 3.890042
 AlphaGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
 rgbGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
@@ -597,7 +597,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_8
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -607,7 +607,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.112141 -36.627399 116.117142 sawtooth 0 1 0.784623 0.218790
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 24.587999
 AlphaGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
 rgbGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
@@ -618,7 +618,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_9
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -628,7 +628,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 13.988351 -11.087501 103.268707 sawtooth 0 1 1.044519 0.235235
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 12.468795
 AlphaGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
 rgbGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
@@ -639,7 +639,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_10
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -649,7 +649,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 10.265741 7.714635 131.291351 sawtooth 0 1 0.524331 0.144779
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 12.796563
 AlphaGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
 rgbGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
@@ -660,7 +660,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_11
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -670,7 +670,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 25.100649 4.780672 156.159500 sawtooth 0 1 0.907308 0.255448
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 16.214331
 AlphaGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
 rgbGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
@@ -681,7 +681,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_12
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -691,7 +691,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 12.983425 -1.691125 95.949432 sawtooth 0 1 0.845538 0.495670
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate -2.724845
 AlphaGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
 rgbGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
@@ -700,233 +700,233 @@ blendfunc add
 }
 }
 
-textures/pad_garden/wellen3_1 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
-surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.758238 0.386510 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 13.147161 
-AlphaGen wave sawtooth 1.083261 -1.083261 0.758238 0.386510 
-rgbGen wave sawtooth 0.651039 -0.651039 0.758238 0.386510 
-tcMod stretch sawtooth 0.496692 0.396280 0.758238 0.386510 
-blendfunc add 
-} 
-} 
-
-textures/pad_garden/wellen3_2 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
-surfaceparm nolightmap 
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.550810 0.215062 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 12.292642 
-AlphaGen wave sawtooth 1.012714 -1.012714 0.550810 0.215062 
-rgbGen wave sawtooth 0.747148 -0.747148 0.550810 0.215062 
-tcMod stretch sawtooth 0.488470 0.418503 0.550810 0.215062 
-blendfunc add 
-} 
-} 
-
-textures/pad_garden/wellen3_3 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_1
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
 nomipmaps
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.093259 0.268482 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 7.173833 
-AlphaGen wave sawtooth 0.962444 -0.962444 1.093259 0.268482 
-rgbGen wave sawtooth 0.716947 -0.716947 1.093259 0.268482 
-tcMod stretch sawtooth 0.399271 0.423142 1.093259 0.268482 
-blendfunc add 
-} 
-} 
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.758238 0.386510
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 13.147161
+AlphaGen wave sawtooth 1.083261 -1.083261 0.758238 0.386510
+rgbGen wave sawtooth 0.651039 -0.651039 0.758238 0.386510
+tcMod stretch sawtooth 0.496692 0.396280 0.758238 0.386510
+blendfunc add
+}
+}
 
-textures/pad_garden/wellen3_4 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_2
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.669686 0.210215 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 21.939421 
-AlphaGen wave sawtooth 1.023920 -1.023920 0.669686 0.210215 
-rgbGen wave sawtooth 0.638075 -0.638075 0.669686 0.210215 
-tcMod stretch sawtooth 0.391726 0.652324 0.669686 0.210215 
-blendfunc add 
-} 
-} 
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.550810 0.215062
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 12.292642
+AlphaGen wave sawtooth 1.012714 -1.012714 0.550810 0.215062
+rgbGen wave sawtooth 0.747148 -0.747148 0.550810 0.215062
+tcMod stretch sawtooth 0.488470 0.418503 0.550810 0.215062
+blendfunc add
+}
+}
 
-textures/pad_garden/wellen3_5 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_3
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.228907 0.215789 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 15.530046 
-AlphaGen wave sawtooth 0.950432 -0.950432 1.228907 0.215789 
-rgbGen wave sawtooth 0.785540 -0.785540 1.228907 0.215789 
-tcMod stretch sawtooth 0.325874 0.732252 1.228907 0.215789 
-blendfunc add 
-} 
-} 
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.093259 0.268482
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 7.173833
+AlphaGen wave sawtooth 0.962444 -0.962444 1.093259 0.268482
+rgbGen wave sawtooth 0.716947 -0.716947 1.093259 0.268482
+tcMod stretch sawtooth 0.399271 0.423142 1.093259 0.268482
+blendfunc add
+}
+}
 
-textures/pad_garden/wellen3_6 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_4
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.527409 0.303915 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 8.849666 
-AlphaGen wave sawtooth 1.098447 -1.098447 0.527409 0.303915 
-rgbGen wave sawtooth 0.905087 -0.905087 0.527409 0.303915 
-tcMod stretch sawtooth 0.395859 0.421647 0.527409 0.303915 
-blendfunc add 
-} 
-} 
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.669686 0.210215
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 21.939421
+AlphaGen wave sawtooth 1.023920 -1.023920 0.669686 0.210215
+rgbGen wave sawtooth 0.638075 -0.638075 0.669686 0.210215
+tcMod stretch sawtooth 0.391726 0.652324 0.669686 0.210215
+blendfunc add
+}
+}
 
-textures/pad_garden/wellen3_7 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
-surfaceparm nolightmap 
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.650606 0.368229 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 10.157323 
-AlphaGen wave sawtooth 0.910831 -0.910831 0.650606 0.368229 
-rgbGen wave sawtooth 0.628663 -0.628663 0.650606 0.368229 
-tcMod stretch sawtooth 0.396371 0.581820 0.650606 0.368229 
-blendfunc add 
-} 
-} 
-
-textures/pad_garden/wellen3_8 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_5
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.134458 0.217227 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 9.057192 
-AlphaGen wave sawtooth 1.037141 -1.037141 1.134458 0.217227 
-rgbGen wave sawtooth 0.722733 -0.722733 1.134458 0.217227 
-tcMod stretch sawtooth 0.388113 0.698187 1.134458 0.217227 
-blendfunc add 
-} 
-} 
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.228907 0.215789
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 15.530046
+AlphaGen wave sawtooth 0.950432 -0.950432 1.228907 0.215789
+rgbGen wave sawtooth 0.785540 -0.785540 1.228907 0.215789
+tcMod stretch sawtooth 0.325874 0.732252 1.228907 0.215789
+blendfunc add
+}
+}
+
+textures/pad_garden/wellen3_6
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
+surfaceparm nolightmap
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.527409 0.303915
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 8.849666
+AlphaGen wave sawtooth 1.098447 -1.098447 0.527409 0.303915
+rgbGen wave sawtooth 0.905087 -0.905087 0.527409 0.303915
+tcMod stretch sawtooth 0.395859 0.421647 0.527409 0.303915
+blendfunc add
+}
+}
+
+textures/pad_garden/wellen3_7
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
+surfaceparm nolightmap
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.650606 0.368229
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 10.157323
+AlphaGen wave sawtooth 0.910831 -0.910831 0.650606 0.368229
+rgbGen wave sawtooth 0.628663 -0.628663 0.650606 0.368229
+tcMod stretch sawtooth 0.396371 0.581820 0.650606 0.368229
+blendfunc add
+}
+}
+
+textures/pad_garden/wellen3_8
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
+surfaceparm nolightmap
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.134458 0.217227
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 9.057192
+AlphaGen wave sawtooth 1.037141 -1.037141 1.134458 0.217227
+rgbGen wave sawtooth 0.722733 -0.722733 1.134458 0.217227
+tcMod stretch sawtooth 0.388113 0.698187 1.134458 0.217227
+blendfunc add
+}
+}
 
 
-textures/pad_garden/wave0 
-{ 
-qer_editorimage textures/pad_garden/wave0.tga 
-surfaceparm noimpact 
-surfaceparm nolightmap 
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.765160 0.500000 
-{ 
-clampmap textures/pad_garden/wave1.tga 
-tcMod rotate 5.752586 
-AlphaGen wave sawtooth 1.000000 -0.421894 0.765160 0.500000 
-rgbGen wave sawtooth 1.000000 -0.720054 0.765160 0.500000 
-tcMod stretch sawtooth 0 0 0 0 
-blendfunc add 
-} 
-{ 
-clampmap textures/pad_garden/wave2.tga 
-tcMod rotate 5.752586 
-AlphaGen wave sawtooth 1.000000 -0.421894 0.765160 0.500000 
-rgbGen wave sawtooth 1.000000 -0.720054 0.765160 0.500000 
-tcMod stretch sawtooth 0.177834 0.822166 0.765160 0.500000 
-blendfunc add 
-} 
-} 
+textures/pad_garden/wave0
+{
+qer_editorimage textures/pad_garden/wave0
+surfaceparm noimpact
+surfaceparm nolightmap
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.765160 0.500000
+{
+clampmap textures/pad_garden/wave1
+tcMod rotate 5.752586
+AlphaGen wave sawtooth 1.000000 -0.421894 0.765160 0.500000
+rgbGen wave sawtooth 1.000000 -0.720054 0.765160 0.500000
+tcMod stretch sawtooth 0 0 0 0
+blendfunc add
+}
+{
+clampmap textures/pad_garden/wave2
+tcMod rotate 5.752586
+AlphaGen wave sawtooth 1.000000 -0.421894 0.765160 0.500000
+rgbGen wave sawtooth 1.000000 -0.720054 0.765160 0.500000
+tcMod stretch sawtooth 0.177834 0.822166 0.765160 0.500000
+blendfunc add
+}
+}
 
-textures/pad_garden/waterfall2 
-{ 
-qer_editorimage textures/pad_garden/waterstream.tga 
-q3map_globaltexture 
-surfaceparm nonsolid 
-surfaceparm nolightmap 
-surfaceparm trans 
-surfaceparm noimpact 
-surfaceparm water 
-tessSize 32 
-//deformVertexes move 2 1 0 sin 0 1 0.2 0.2 
-//deformVertexes move .6 3.3 0 sin 0 1 0 0.4 
-//deformVertexes wave 32 sin 0 10 0 .2 
-cull disable 
-{ 
-map textures/pad_garden/waterstream.tga 
-blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR 
-tcMod scale 0.4 0.55 
-tcMod turb .1 .08 .25 .08 
-tcMod scroll 0.005 -1 
-} 
-{ 
-map textures/pad_garden/waterstream.tga 
-blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR 
-tcMod scale 0.5 0.45 
-tcMod turb .1 .05 .25 .08 
-tcMod scroll 0.008 -0.6 
-} 
-} 
+textures/pad_garden/waterfall2
+{
+qer_editorimage textures/pad_garden/waterstream
+q3map_globaltexture
+surfaceparm nonsolid
+surfaceparm nolightmap
+surfaceparm trans
+surfaceparm noimpact
+surfaceparm water
+tessSize 32
+//deformVertexes move 2 1 0 sin 0 1 0.2 0.2
+//deformVertexes move .6 3.3 0 sin 0 1 0 0.4
+//deformVertexes wave 32 sin 0 10 0 .2
+cull disable
+{
+map textures/pad_garden/waterstream
+blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
+tcMod scale 0.4 0.55
+tcMod turb .1 .08 .25 .08
+tcMod scroll 0.005 -1
+}
+{
+map textures/pad_garden/waterstream
+blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
+tcMod scale 0.5 0.45
+tcMod turb .1 .05 .25 .08
+tcMod scroll 0.008 -0.6
+}
+}
 
 
 
@@ -935,13 +935,13 @@ textures/pad_garden/gardensand02
 q3map_nonplanar
 q3map_shadeangle 60 l
 surfaceparm sandsteps
-qer_editorimage textures/pad_garden/gardensand02.tga
+qer_editorimage textures/pad_garden/gardensand02
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/gardensand02.tga
+map textures/pad_garden/gardensand02
 blendFunc filter
 }
 }
@@ -951,13 +951,13 @@ textures/pad_garden/sand003a
 q3map_nonplanar
 q3map_shadeangle 60 l
 surfaceparm sandsteps
-qer_editorimage textures/pad_garden/sand003a.tga
+qer_editorimage textures/pad_garden/sand003a
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/sand003a.tga
+map textures/pad_garden/sand003a
 blendFunc filter
 }
 }
@@ -966,14 +966,14 @@ textures/pad_garden/algen
 {
 q3map_nonplanar
 q3map_shadeangle 60 l
-qer_editorimage textures/pad_garden/algen.tga
+qer_editorimage textures/pad_garden/algen
 surfaceparm sandsteps
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/algen.tga
+map textures/pad_garden/algen
 blendFunc filter
 }
 }
@@ -983,14 +983,14 @@ textures/pad_garden/ashes_256
 {
 q3map_nonplanar
 q3map_shadeangle 60 l
-qer_editorimage textures/pad_garden/ashes_256.tga
+qer_editorimage textures/pad_garden/ashes_256
 surfaceparm sandsteps
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/ashes_256.tga
+map textures/pad_garden/ashes_256
 blendFunc filter
 }
 }
@@ -1000,13 +1000,13 @@ textures/pad_garden/nail
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_garden/nail.tga
+                map textures/pad_garden/nail
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -1026,13 +1026,13 @@ textures/pad_garden/kaktus002
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_garden/kaktus002.tga
+                map textures/pad_garden/kaktus002
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -1051,7 +1051,7 @@ textures/pad_garden/kaktus002
 
 textures/pad_garden/grasground
 {
-qer_editorimage textures/pad_garden/grasground.tga
+qer_editorimage textures/pad_garden/grasground
 surfaceparm sandsteps
 
 q3map_nonplanar
@@ -1064,11 +1064,11 @@ q3map_alphaMod dotproduct2 ( 0.0 0.0 0.75 )
 q3map_lightmapSampleSize 16
 
 {
-map textures/pad_garden/sandground.tga // Primary
+map textures/pad_garden/sandground // Primary
 rgbGen identity
 }
 {
-map textures/pad_garden/grasground.tga // Secondary
+map textures/pad_garden/grasground // Secondary
 blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 //alphaFunc GE128
 rgbGen identity
@@ -1084,7 +1084,7 @@ rgbGen identity
 
 textures/pad_garden/seerosenblatt_move
 {
-	qer_editorimage textures/pad_garden/seerosenblatt.tga
+	qer_editorimage textures/pad_garden/seerosenblatt
 	deformVertexes wave 194 sin 0 2 0 .2
 	deformVertexes wave 30 sin 0 1 0 .3
 	deformVertexes wave 194 sin 0 1 0 .1
@@ -1094,7 +1094,7 @@ textures/pad_garden/seerosenblatt_move
 	cull none
 
 	{
-		map textures/pad_garden/seerosenblatt.tga
+		map textures/pad_garden/seerosenblatt
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1116,11 +1116,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/fussmatte01.tga
+map textures/pad_garden/fussmatte01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/liegestoff02
 {
@@ -1130,11 +1130,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/liegestoff02.tga
+map textures/pad_garden/liegestoff02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/lochgitter02
 {
@@ -1144,11 +1144,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/lochgitter02.tga
+map textures/pad_garden/lochgitter02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/lochgitter03
 {
@@ -1158,11 +1158,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/lochgitter03.tga
+map textures/pad_garden/lochgitter03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/lochgitter04
 {
@@ -1172,11 +1172,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/lochgitter04.tga
+map textures/pad_garden/lochgitter04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/lochgitter05
 {
@@ -1186,11 +1186,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/lochgitter05.tga
+map textures/pad_garden/lochgitter05
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/rostblack
 {
@@ -1200,11 +1200,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostblack.tga
+map textures/pad_garden/rostblack
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/rostborderbig
 {
@@ -1214,11 +1214,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostborderbig.tga
+map textures/pad_garden/rostborderbig
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/rostbordersmall
 {
@@ -1228,7 +1228,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostbordersmall.tga
+map textures/pad_garden/rostbordersmall
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1243,7 +1243,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostdoorsmall.tga
+map textures/pad_garden/rostdoorsmall
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1257,7 +1257,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/faltblech.tga
+map textures/pad_garden/faltblech
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1265,14 +1265,14 @@ rgbGen identity
 
 textures/pad_garden/purpleflow
 {
-        qer_editorimage textures/pad_garden/purpleflow.tga
+        qer_editorimage textures/pad_garden/purpleflow
     	surfaceparm trans
 	surfaceparm alphashadow
    	surfaceparm nonsolid
 	cull none
         nopicmip
 	{
-		map textures/pad_garden/purpleflow.tga
+		map textures/pad_garden/purpleflow
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1289,19 +1289,19 @@ textures/pad_garden/purpleflow
 
 textures/pad_garden/rocket
 {
-	qer_editorimage textures/pad_garden/rocket.tga
+	qer_editorimage textures/pad_garden/rocket
 	{
-		map textures/pad_garden/rocket.tga
+		map textures/pad_garden/rocket
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1315,7 +1315,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/metalwhite001big.tga
+map textures/pad_garden/metalwhite001big
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1330,7 +1330,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/birdfloor_big.tga
+map textures/pad_garden/birdfloor_big
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1345,7 +1345,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/teichbrett2_512.tga
+map textures/pad_garden/teichbrett2_512
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1360,7 +1360,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostsoft.tga
+map textures/pad_garden/rostsoft
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1374,7 +1374,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostrough.tga
+map textures/pad_garden/rostrough
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1388,7 +1388,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostred.tga
+map textures/pad_garden/rostred
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1402,7 +1402,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostblack.tga
+map textures/pad_garden/rostblack
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1417,7 +1417,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/sunchairwood.tga
+map textures/pad_garden/sunchairwood
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1432,7 +1432,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/liegestoff02.tga
+map textures/pad_garden/liegestoff02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1448,7 +1448,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/toyblock01.tga
+map textures/pad_garden/toyblock01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1462,7 +1462,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/toyblock02.tga
+map textures/pad_garden/toyblock02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1476,7 +1476,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/toyblock03.tga
+map textures/pad_garden/toyblock03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1490,7 +1490,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/toyblock04.tga
+map textures/pad_garden/toyblock04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1502,28 +1502,28 @@ textures/pad_garden/big_flameblue256
 		surfaceparm trans
 		surfaceparm nomarks
 		surfaceparm nonsolid
-		qer_editorimage textures/pad_garden/bflame1.tga
+		qer_editorimage textures/pad_garden/bflame1
 		q3map_surfacelight 200
 		surfaceparm nolightmap
 		cull none
 
 	{
-		animMap 10 textures/pad_garden/bflame1.tga textures/pad_garden/bflame2.tga textures/pad_garden/bflame3.tga textures/pad_garden/bflame4.tga textures/pad_garden/bflame5.tga textures/pad_garden/bflame6.tga textures/pad_garden/bflame7.tga textures/pad_garden/bflame8.tga
+		animMap 10 textures/pad_garden/bflame1 textures/pad_garden/bflame2 textures/pad_garden/bflame3 textures/pad_garden/bflame4 textures/pad_garden/bflame5 textures/pad_garden/bflame6 textures/pad_garden/bflame7 textures/pad_garden/bflame8
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 10
-		
-	}	
+
+	}
 	{
-		animMap 10 textures/pad_garden/bflame2.tga textures/pad_garden/bflame3.tga textures/pad_garden/bflame4.tga textures/pad_garden/bflame5.tga textures/pad_garden/bflame6.tga textures/pad_garden/bflame7.tga textures/pad_garden/bflame8.tga textures/pad_garden/bflame1.tga
+		animMap 10 textures/pad_garden/bflame2 textures/pad_garden/bflame3 textures/pad_garden/bflame4 textures/pad_garden/bflame5 textures/pad_garden/bflame6 textures/pad_garden/bflame7 textures/pad_garden/bflame8 textures/pad_garden/bflame1
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave sawtooth 0 1 0 10
-	}	
+	}
 
 
 	{
-		map textures/pad_garden/bflameball.tga
+		map textures/pad_garden/bflameball
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+		rgbGen wave sin .6 .2 0 .6
 	}
 
 }
@@ -1535,28 +1535,28 @@ textures/pad_garden/red_flame256
 		surfaceparm trans
 		surfaceparm nomarks
 		surfaceparm nonsolid
-		qer_editorimage textures/pad_garden/sflame1.tga
+		qer_editorimage textures/pad_garden/sflame1
 		q3map_surfacelight 200
 		surfaceparm nolightmap
 		cull none
 
 	{
-		animMap 10 textures/pad_garden/sflame1.tga textures/pad_garden/sflame2.tga textures/pad_garden/sflame3.tga textures/pad_garden/sflame4.tga textures/pad_garden/sflame5.tga textures/pad_garden/sflame6.tga textures/pad_garden/sflame7.tga textures/pad_garden/sflame8.tga
+		animMap 10 textures/pad_garden/sflame1 textures/pad_garden/sflame2 textures/pad_garden/sflame3 textures/pad_garden/sflame4 textures/pad_garden/sflame5 textures/pad_garden/sflame6 textures/pad_garden/sflame7 textures/pad_garden/sflame8
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 10
-		
-	}	
+
+	}
 	{
-		animMap 10 textures/pad_garden/sflame2.tga textures/pad_garden/sflame3.tga textures/pad_garden/sflame4.tga textures/pad_garden/sflame5.tga textures/pad_garden/sflame6.tga textures/pad_garden/sflame7.tga textures/pad_garden/sflame8.tga textures/pad_garden/sflame1.tga
+		animMap 10 textures/pad_garden/sflame2 textures/pad_garden/sflame3 textures/pad_garden/sflame4 textures/pad_garden/sflame5 textures/pad_garden/sflame6 textures/pad_garden/sflame7 textures/pad_garden/sflame8 textures/pad_garden/sflame1
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave sawtooth 0 1 0 10
-	}	
+	}
 
 
 	{
-		map textures/pad_garden/sflameball.tga
+		map textures/pad_garden/sflameball
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+		rgbGen wave sin .6 .2 0 .6
 	}
 
 }
@@ -1564,7 +1564,7 @@ textures/pad_garden/red_flame256
 
 textures/pad_garden/poolfog_green
 {
-		qer_editorimage textures/pad_gfx02b/padfog_green.tga
+		qer_editorimage textures/pad_gfx02b/padfog_green
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -1576,19 +1576,19 @@ textures/pad_garden/poolfog_green
 
 textures/pad_garden/ship00
 {
-	qer_editorimage textures/pad_garden/ship00.tga
+	qer_editorimage textures/pad_garden/ship00
 	{
-		map textures/pad_garden/ship00.tga
+		map textures/pad_garden/ship00
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1597,19 +1597,19 @@ textures/pad_garden/ship00
 
 textures/pad_garden/ship02
 {
-	qer_editorimage textures/pad_garden/ship02.tga
+	qer_editorimage textures/pad_garden/ship02
 	{
-		map textures/pad_garden/ship02.tga
+		map textures/pad_garden/ship02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1619,19 +1619,19 @@ textures/pad_garden/ship02
 textures/pad_garden/ship04
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_garden/ship04.tga
+	qer_editorimage textures/pad_garden/ship04
 	{
-		map textures/pad_garden/ship04.tga
+		map textures/pad_garden/ship04
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1640,19 +1640,19 @@ textures/pad_garden/ship04
 
 textures/pad_garden/ship05
 {
-	qer_editorimage textures/pad_garden/ship05.tga
+	qer_editorimage textures/pad_garden/ship05
 	{
-		map textures/pad_garden/ship05.tga
+		map textures/pad_garden/ship05
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1662,19 +1662,19 @@ textures/pad_garden/ship05
 textures/pad_garden/ship06
 {
 
-	qer_editorimage textures/pad_garden/ship06.tga
+	qer_editorimage textures/pad_garden/ship06
 	{
-		map textures/pad_garden/ship06.tga
+		map textures/pad_garden/ship06
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1683,19 +1683,19 @@ textures/pad_garden/ship06
 
 textures/pad_garden/ship07
 {
-	qer_editorimage textures/pad_garden/ship07.tga
+	qer_editorimage textures/pad_garden/ship07
 	{
-		map textures/pad_garden/ship07.tga
+		map textures/pad_garden/ship07
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1704,19 +1704,19 @@ textures/pad_garden/ship07
 
 textures/pad_garden/ship08
 {
-	qer_editorimage textures/pad_garden/ship08.tga
+	qer_editorimage textures/pad_garden/ship08
 	{
-		map textures/pad_garden/ship08.tga
+		map textures/pad_garden/ship08
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1725,19 +1725,19 @@ textures/pad_garden/ship08
 
 textures/pad_garden/ship10
 {
-	qer_editorimage textures/pad_garden/ship10.tga
+	qer_editorimage textures/pad_garden/ship10
 	{
-		map textures/pad_garden/ship10.tga
+		map textures/pad_garden/ship10
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1746,19 +1746,19 @@ textures/pad_garden/ship10
 
 textures/pad_garden/radio002
 {
-	qer_editorimage textures/pad_garden/radio002.tga
+	qer_editorimage textures/pad_garden/radio002
 	{
-		map textures/pad_garden/radio002.tga
+		map textures/pad_garden/radio002
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1767,19 +1767,19 @@ textures/pad_garden/radio002
 
 textures/pad_garden/radio003
 {
-	qer_editorimage textures/pad_garden/radio003.tga
+	qer_editorimage textures/pad_garden/radio003
 	{
-		map textures/pad_garden/radio003.tga
+		map textures/pad_garden/radio003
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1788,19 +1788,19 @@ textures/pad_garden/radio003
 
 textures/pad_garden/radio004
 {
-	qer_editorimage textures/pad_garden/radio004.tga
+	qer_editorimage textures/pad_garden/radio004
 	{
-		map textures/pad_garden/radio004.tga
+		map textures/pad_garden/radio004
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1809,19 +1809,19 @@ textures/pad_garden/radio004
 
 textures/pad_garden/radio005
 {
-	qer_editorimage textures/pad_garden/radio005.tga
+	qer_editorimage textures/pad_garden/radio005
 	{
-		map textures/pad_garden/radio005.tga
+		map textures/pad_garden/radio005
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1829,14 +1829,14 @@ textures/pad_garden/radio005
 
 textures/pad_garden/borderfloor_a
 {
-          qer_editorimage textures/pad_garden/borderfloor_a.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_garden/borderfloor_a
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/borderfloor_a.tga
+		map textures/pad_garden/borderfloor_a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1845,14 +1845,14 @@ textures/pad_garden/borderfloor_a
 
 textures/pad_garden/rostdoorcurve
 {
-          qer_editorimage textures/pad_garden/rostdoorsmall.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_garden/rostdoorsmall
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/rostdoorsmall.tga
+		map textures/pad_garden/rostdoorsmall
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1860,14 +1860,14 @@ textures/pad_garden/rostdoorcurve
 
 textures/pad_metal/testlvlcurve
 {
-          qer_editorimage textures/pad_metal/testlvlbase.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_metal/testlvlbase
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_metal/testlvlbase.tga
+		map textures/pad_metal/testlvlbase
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1875,14 +1875,14 @@ textures/pad_metal/testlvlcurve
 
 textures/pad_floorin/metalfloorcurve
 {
-          qer_editorimage textures/pad_floorin/metalfloor001.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_floorin/metalfloor001
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_floorin/metalfloor001.tga
+		map textures/pad_floorin/metalfloor001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1891,14 +1891,14 @@ textures/pad_floorin/metalfloorcurve
 
 textures/pad_wallout/wall_stonecurve
 {
-          qer_editorimage textures/pad_wallout/wall_stone043.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wallout/wall_stone043
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wallout/wall_stone043.tga
+		map textures/pad_wallout/wall_stone043
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}

--- a/wop/scripts.pk3dir/scripts/pad_gfx.shader
+++ b/wop/scripts.pk3dir/scripts/pad_gfx.shader
@@ -7,18 +7,18 @@ textures/pad_gfx/blobfx
 	surfaceparm nonsolid
 	cull twosided
 
-	deformVertexes wave 30 sin 0 5 0 0.2 
-	deformVertexes wave 100 sin 0 4 0 0.1 
+	deformVertexes wave 30 sin 0 5 0 0.2
+	deformVertexes wave 100 sin 0 4 0 0.1
 	tessSize 48
 	qer_trans 0.5
 	{
-		map textures/pad_gfx/blobfx.tga
+		map textures/pad_gfx/blobfx
 		tcGen environment
                 tcMod turb 0 0.35 0 0.25
                 tcmod scroll -0.6 -0.8
 	}
 	{
-		map textures/pad_gfx/blobfx.tga
+		map textures/pad_gfx/blobfx
 		tcGen environment
                 tcMod turb 0 0.25 0 0.5
                 tcmod scroll 1 1
@@ -31,14 +31,14 @@ textures/pad_gfx/blobfx
 //=======================================================
 textures/pad_gfx/glass_bright
 {
-	qer_editorimage textures/pad_gfx/glass_bright.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass_bright
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass_bright.tga
+		map textures/pad_gfx/glass_bright
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -48,19 +48,19 @@ textures/pad_gfx/glass_bright
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 textures/pad_gfx/glass_normal
 {
-	qer_editorimage textures/pad_gfx/glass_normal.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass_normal
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass_normal.tga
+		map textures/pad_gfx/glass_normal
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -70,19 +70,19 @@ textures/pad_gfx/glass_normal
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 textures/pad_gfx/glass_dark
 {
-	qer_editorimage textures/pad_gfx/glass_dark.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass_dark
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass_dark.tga
+		map textures/pad_gfx/glass_dark
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -92,20 +92,20 @@ textures/pad_gfx/glass_dark
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_gfx/glass_blue
 {
-	qer_editorimage textures/pad_gfx/glass_blue.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass_blue
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass_blue.tga
+		map textures/pad_gfx/glass_blue
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -115,20 +115,20 @@ textures/pad_gfx/glass_blue
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_gfx/glass_red
 {
-	qer_editorimage textures/pad_gfx/glass_red.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass_red
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass_red.tga
+		map textures/pad_gfx/glass_red
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -138,20 +138,20 @@ textures/pad_gfx/glass_red
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_gfx/glass_green
 {
-	qer_editorimage textures/pad_gfx/glass_green.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass_green
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass_green.tga
+		map textures/pad_gfx/glass_green
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -161,20 +161,20 @@ textures/pad_gfx/glass_green
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_gfx/glass2_bright
 {
-	qer_editorimage textures/pad_gfx/glass2_bright.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass2_bright
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass2_bright.tga
+		map textures/pad_gfx/glass2_bright
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -184,19 +184,19 @@ textures/pad_gfx/glass2_bright
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 textures/pad_gfx/glass2_normal
 {
-	qer_editorimage textures/pad_gfx/glass2_normal.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass2_normal
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass2_normal.tga
+		map textures/pad_gfx/glass2_normal
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -206,19 +206,19 @@ textures/pad_gfx/glass2_normal
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 textures/pad_gfx/glass2_dark
 {
-	qer_editorimage textures/pad_gfx/glass2_dark.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass2_dark
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass2_dark.tga
+		map textures/pad_gfx/glass2_dark
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -228,20 +228,20 @@ textures/pad_gfx/glass2_dark
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_gfx/glass2_blue
 {
-	qer_editorimage textures/pad_gfx/glass2_blue.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass2_blue
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass2_blue.tga
+		map textures/pad_gfx/glass2_blue
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -251,20 +251,20 @@ textures/pad_gfx/glass2_blue
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_gfx/glass2_red
 {
-	qer_editorimage textures/pad_gfx/glass2_red.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass2_red
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass2_red.tga
+		map textures/pad_gfx/glass2_red
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -274,20 +274,20 @@ textures/pad_gfx/glass2_red
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_gfx/glass2_green
 {
-	qer_editorimage textures/pad_gfx/glass2_green.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_gfx/glass2_green
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_gfx/glass2_green.tga
+		map textures/pad_gfx/glass2_green
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -297,7 +297,7 @@ textures/pad_gfx/glass2_green
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 //=======================================================
@@ -311,7 +311,7 @@ textures/pad_gfx/flare
     surfaceparm nolightmap
     cull none
           {
-            clampmap textures/pad_gfx/flare.tga
+            clampmap textures/pad_gfx/flare
             blendFunc GL_ONE GL_ONE
           }
 }
@@ -323,13 +323,13 @@ textures/pad_gfx/flare
 
 textures/pad_gfx/lack
 {
-	qer_editorimage textures/pad_gfx/lack.tga
+	qer_editorimage textures/pad_gfx/lack
 	{
-		map textures/pad_gfx/lack.tga
+		map textures/pad_gfx/lack
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         	tcGen environment
                 blendfunc add
                 rgbGen identity
@@ -347,13 +347,13 @@ textures/pad_gfx/lack
 
 textures/pad_gfx/window
 {
-	qer_editorimage textures/pad_gfx/window.tga
+	qer_editorimage textures/pad_gfx/window
 	{
-		map textures/pad_gfx/window.tga
+		map textures/pad_gfx/window
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         	tcGen environment
                 blendfunc add
                 rgbGen identity
@@ -368,13 +368,13 @@ textures/pad_gfx/window
 
 textures/pad_gfx/lack_blue
 {
-	qer_editorimage textures/pad_gfx/lack_blue.tga
+	qer_editorimage textures/pad_gfx/lack_blue
 	{
-		map textures/pad_gfx/lack_blue.tga
+		map textures/pad_gfx/lack_blue
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         	tcGen environment
                 blendfunc add
                 rgbGen identity
@@ -389,13 +389,13 @@ textures/pad_gfx/lack_blue
 
 textures/pad_gfx/lack_green
 {
-	qer_editorimage textures/pad_gfx/lack_green.tga
+	qer_editorimage textures/pad_gfx/lack_green
 	{
-		map textures/pad_gfx/lack_green.tga
+		map textures/pad_gfx/lack_green
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         	tcGen environment
                 blendfunc add
                 rgbGen identity
@@ -410,13 +410,13 @@ textures/pad_gfx/lack_green
 
 textures/pad_gfx/lack_red
 {
-	qer_editorimage textures/pad_gfx/lack_red.tga
+	qer_editorimage textures/pad_gfx/lack_red
 	{
-		map textures/pad_gfx/lack_red.tga
+		map textures/pad_gfx/lack_red
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         	tcGen environment
                 blendfunc add
                 rgbGen identity
@@ -434,7 +434,7 @@ textures/pad_gfx/lack_red
 
 textures/pad_gfx/snow
 {
-	qer_editorimage textures/pad_gfx/snow.tga
+	qer_editorimage textures/pad_gfx/snow
 	deformVertexes autosprite2
 	surfaceparm nolightmap
 	surfaceparm nomarks
@@ -443,12 +443,12 @@ textures/pad_gfx/snow
 	cull disable
 	qer_trans 0.5
 	{
-		map textures/pad_gfx/snow.tga
+		map textures/pad_gfx/snow
 		blendFunc add
 		rgbGen identity
 		tcMod scroll 0.1 -0.6
 		tcMod turb 0.1 0.25 0 -0.1
-	} 
+	}
 }
 
 //=======================================================
@@ -457,8 +457,8 @@ textures/pad_gfx/snow
 
 textures/pad_gfx/water_static
 {
-	qer_editorimage textures/pad_gfx/water_01.tga
-	q3map_lightimage textures/pad_gfx/water_02.tga
+	qer_editorimage textures/pad_gfx/water_01
+	q3map_lightimage textures/pad_gfx/water_02
 	surfaceparm nodrop
 	surfaceparm noimpact
 	//surfaceparm nolightmap
@@ -471,10 +471,10 @@ textures/pad_gfx/water_static
 	cull disable
 	qer_trans 0.5
 	q3map_globaltexture
-	
+
 
 	{
-		map textures/pad_gfx/water_01.tga
+		map textures/pad_gfx/water_01
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.2 0.1 1 0.05
@@ -486,8 +486,8 @@ textures/pad_gfx/water_static
 
 textures/pad_gfx/water
 {
-	qer_editorimage textures/pad_gfx/water_02.tga
-	q3map_lightimage textures/pad_gfx/water_02.tga
+	qer_editorimage textures/pad_gfx/water_02
+	q3map_lightimage textures/pad_gfx/water_02
 	surfaceparm nodrop
 	surfaceparm noimpact
 	// surfaceparm nolightmap
@@ -495,13 +495,13 @@ textures/pad_gfx/water
 	surfaceparm nonsolid
 	surfaceparm trans
 	cull disable
-	deformVertexes wave 30 sin 0 4 0 0.2 
-	deformVertexes wave 100 sin 0 4 0 0.7 
+	deformVertexes wave 30 sin 0 4 0 0.2
+	deformVertexes wave 100 sin 0 4 0 0.7
 	tessSize 48
 	qer_trans 0.5
-	
+
 	{
-		map textures/liquids/pool2.tga
+		map textures/liquids/pool2
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.4 0.3 1 0.05
@@ -512,13 +512,13 @@ textures/pad_gfx/water
 
 textures/pad_gfx/schaum_static
 {
-	cull disable	 
-        surfaceparm nomarks 
-        surfaceparm trans 
-        sort additive	
+	cull disable
+        surfaceparm nomarks
+        surfaceparm trans
+        sort additive
 	qer_trans 0.5
 	{
-		map textures/pad_gfx/schaum_static.tga
+		map textures/pad_gfx/schaum_static
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.1 0.05 0 0.5
@@ -527,15 +527,15 @@ textures/pad_gfx/schaum_static
 
 textures/pad_gfx/schaum1
 {
-	qer_editorimage textures/pad_gfx/schaum.tga
+	qer_editorimage textures/pad_gfx/schaum
 	deformVertexes autosprite
-	cull disable	 
-        surfaceparm nomarks 
-        surfaceparm trans 
-        sort additive	
+	cull disable
+        surfaceparm nomarks
+        surfaceparm trans
+        sort additive
 	qer_trans 0.5
 	{
-		map textures/pad_gfx/schaum.tga
+		map textures/pad_gfx/schaum
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.1 0.05 0 0.95
@@ -543,7 +543,7 @@ textures/pad_gfx/schaum1
 
 	}
 	{
-		map textures/pad_gfx/schaum.tga
+		map textures/pad_gfx/schaum
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.8 0.08 1 -0.64
@@ -554,15 +554,15 @@ textures/pad_gfx/schaum1
 
 textures/pad_gfx/schaum2
 {
-	qer_editorimage textures/pad_gfx/schaum.tga
+	qer_editorimage textures/pad_gfx/schaum
 	deformVertexes autosprite
-	cull disable	 
-        surfaceparm nomarks 
-        surfaceparm trans 
-        sort additive	
+	cull disable
+        surfaceparm nomarks
+        surfaceparm trans
+        sort additive
 	qer_trans 0.5
 	{
-		map textures/pad_gfx/schaum.tga
+		map textures/pad_gfx/schaum
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.1 0.07 0 -0.9
@@ -570,7 +570,7 @@ textures/pad_gfx/schaum2
 		tcmod scale 0.75 0.75
 	}
 	{
-		map textures/pad_gfx/schaum.tga
+		map textures/pad_gfx/schaum
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.8 0.03 1 -1
@@ -582,15 +582,15 @@ textures/pad_gfx/schaum2
 
 textures/pad_gfx/schaum3
 {
-	qer_editorimage textures/pad_gfx/schaum.tga
+	qer_editorimage textures/pad_gfx/schaum
 	deformVertexes autosprite
-	cull disable	 
-        surfaceparm nomarks 
-        surfaceparm trans 
-        sort additive	
+	cull disable
+        surfaceparm nomarks
+        surfaceparm trans
+        sort additive
 	qer_trans 0.5
 	{
-		map textures/pad_gfx/schaum.tga
+		map textures/pad_gfx/schaum
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.1 0.06 0 -0.4
@@ -598,7 +598,7 @@ textures/pad_gfx/schaum3
 		tcmod scale 0.75 0.75
 	}
 	{
-		map textures/pad_gfx/schaum.tga
+		map textures/pad_gfx/schaum
 		blendfunc add
 		rgbGen identity
 		tcMod turb 0.8 0.04 1 -0.8
@@ -614,7 +614,7 @@ textures/pad_gfx/schaum3
 
 textures/pad_gfx02/flow01
 {
-        qer_editorimage textures/pad_gfx02/flow01.tga
+        qer_editorimage textures/pad_gfx02/flow01
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -622,7 +622,7 @@ textures/pad_gfx02/flow01
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/flow01.tga
+		map textures/pad_gfx02/flow01
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -639,7 +639,7 @@ textures/pad_gfx02/flow01
 
 textures/pad_gfx02/flow02
 {
-        qer_editorimage textures/pad_gfx02/flow02.tga
+        qer_editorimage textures/pad_gfx02/flow02
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -647,7 +647,7 @@ textures/pad_gfx02/flow02
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/flow02.tga
+		map textures/pad_gfx02/flow02
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -664,7 +664,7 @@ textures/pad_gfx02/flow02
 
 textures/pad_gfx02/flow04
 {
-        qer_editorimage textures/pad_gfx02/flow04.tga
+        qer_editorimage textures/pad_gfx02/flow04
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -672,7 +672,7 @@ textures/pad_gfx02/flow04
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/flow04.tga
+		map textures/pad_gfx02/flow04
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -689,7 +689,7 @@ textures/pad_gfx02/flow04
 
 textures/pad_gfx02/cact03
 {
-        qer_editorimage textures/pad_gfx02/cact03.tga
+        qer_editorimage textures/pad_gfx02/cact03
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -697,7 +697,7 @@ textures/pad_gfx02/cact03
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/cact03.tga
+		map textures/pad_gfx02/cact03
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -714,7 +714,7 @@ textures/pad_gfx02/cact03
 
 textures/pad_gfx02/busch
 {
-        qer_editorimage textures/pad_gfx02/busch.tga
+        qer_editorimage textures/pad_gfx02/busch
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -722,7 +722,7 @@ textures/pad_gfx02/busch
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/busch.tga
+		map textures/pad_gfx02/busch
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -740,7 +740,7 @@ textures/pad_gfx02/busch
 
 textures/pad_gfx02/sun
 {
-        qer_editorimage textures/pad_gfx02/sun.tga
+        qer_editorimage textures/pad_gfx02/sun
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -748,7 +748,7 @@ textures/pad_gfx02/sun
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/sun.tga
+		map textures/pad_gfx02/sun
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -765,7 +765,7 @@ textures/pad_gfx02/sun
 
 textures/pad_gfx02/blatt01
 {
-        qer_editorimage textures/pad_gfx02/blatt01.tga
+        qer_editorimage textures/pad_gfx02/blatt01
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -773,7 +773,7 @@ textures/pad_gfx02/blatt01
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/blatt01.tga
+		map textures/pad_gfx02/blatt01
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -798,7 +798,7 @@ textures/pad_gfx02/lighty02
     q3map_surfacelight 3000
     surfaceparm nolightmap
     {
-        map textures/pad_gfx02/lighty02.tga
+        map textures/pad_gfx02/lighty02
     }
 }
 
@@ -808,7 +808,7 @@ textures/pad_gfx02/lighty03
     q3map_surfacelight 2500
     surfaceparm nolightmap
     {
-        map textures/pad_gfx02/lighty03.tga
+        map textures/pad_gfx02/lighty03
     }
 }
 
@@ -818,7 +818,7 @@ textures/pad_gfx02/lighty
     q3map_surfacelight 2000
     surfaceparm nolightmap
     {
-        map textures/pad_gfx02/lighty.tga
+        map textures/pad_gfx02/lighty
     }
 }
 
@@ -828,7 +828,7 @@ textures/pad_gfx02/light_blue
     q3map_surfacelight 2000
     surfaceparm nolightmap
     {
-        map textures/pad_gfx02/light_blue.tga
+        map textures/pad_gfx02/light_blue
     }
 }
 
@@ -838,7 +838,7 @@ textures/pad_gfx02/light_green
     q3map_surfacelight 2000
     surfaceparm nolightmap
     {
-        map textures/pad_gfx02/light_green.tga
+        map textures/pad_gfx02/light_green
     }
 }
 
@@ -848,7 +848,7 @@ textures/pad_gfx02/light_green2
     q3map_surfacelight 1400
     surfaceparm nolightmap
     {
-        map textures/pad_gfx02/light_green2.tga
+        map textures/pad_gfx02/light_green2
     }
 }
 
@@ -859,7 +859,7 @@ textures/pad_gfx02/light_white
     q3map_surfacelight 2000
     surfaceparm nolightmap
     {
-        map textures/pad_gfx02/light_white.tga
+        map textures/pad_gfx02/light_white
     }
 }
 
@@ -871,7 +871,7 @@ textures/pad_gfx02/light_white
 
 textures/pad_gfx02/padp
 {
-        qer_editorimage textures/pad_gfx02/padp.tga
+        qer_editorimage textures/pad_gfx02/padp
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -879,7 +879,7 @@ textures/pad_gfx02/padp
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/padp.tga
+		map textures/pad_gfx02/padp
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -896,7 +896,7 @@ textures/pad_gfx02/padp
 
 textures/pad_gfx02/teller
 {
-        qer_editorimage textures/pad_gfx02/teller.tga
+        qer_editorimage textures/pad_gfx02/teller
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -904,7 +904,7 @@ textures/pad_gfx02/teller
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/teller.tga
+		map textures/pad_gfx02/teller
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -922,7 +922,7 @@ textures/pad_gfx02/teller
 
 textures/pad_gfx02/rollo
 {
-        qer_editorimage textures/pad_gfx02/rollo.tga
+        qer_editorimage textures/pad_gfx02/rollo
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -930,7 +930,7 @@ textures/pad_gfx02/rollo
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/rollo.tga
+		map textures/pad_gfx02/rollo
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -947,7 +947,7 @@ textures/pad_gfx02/rollo
 
 textures/pad_gfx02/rolloB
 {
-        qer_editorimage textures/pad_gfx02/rolloB.tga
+        qer_editorimage textures/pad_gfx02/rolloB
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -955,7 +955,7 @@ textures/pad_gfx02/rolloB
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/rolloB.tga
+		map textures/pad_gfx02/rolloB
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -972,7 +972,7 @@ textures/pad_gfx02/rolloB
 
 textures/pad_gfx02/rollo2B
 {
-        qer_editorimage textures/pad_gfx02/rollo2B.tga
+        qer_editorimage textures/pad_gfx02/rollo2B
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -980,7 +980,7 @@ textures/pad_gfx02/rollo2B
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/rollo2B.tga
+		map textures/pad_gfx02/rollo2B
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -999,7 +999,7 @@ textures/pad_gfx02/rollo2B
 
 textures/pad_gfx02/faden05
 {
-        qer_editorimage textures/pad_gfx02/faden05.tga
+        qer_editorimage textures/pad_gfx02/faden05
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -1007,7 +1007,7 @@ textures/pad_gfx02/faden05
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/faden05.tga
+		map textures/pad_gfx02/faden05
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1019,7 +1019,7 @@ textures/pad_gfx02/faden05
 		blendFunc GL_DST_COLOR GL_ZERO
 		depthFunc equal
 	}
-}   
+}
 
 
 
@@ -1031,7 +1031,7 @@ textures/pad_gfx02/faden05
 
 textures/pad_gfx02/gitter01
 {
-        qer_editorimage textures/pad_gfx02/git01.tga
+        qer_editorimage textures/pad_gfx02/git01
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -1039,7 +1039,7 @@ textures/pad_gfx02/gitter01
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/git01.tga
+		map textures/pad_gfx02/git01
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1051,11 +1051,11 @@ textures/pad_gfx02/gitter01
 		blendFunc GL_DST_COLOR GL_ZERO
 		depthFunc equal
 	}
-}   
+}
 
 textures/pad_gfx02/gitter03
 {
-        qer_editorimage textures/pad_gfx02/git03.tga
+        qer_editorimage textures/pad_gfx02/git03
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -1063,7 +1063,7 @@ textures/pad_gfx02/gitter03
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/git03.tga
+		map textures/pad_gfx02/git03
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1075,12 +1075,12 @@ textures/pad_gfx02/gitter03
 		blendFunc GL_DST_COLOR GL_ZERO
 		depthFunc equal
 	}
-}   
+}
 
 
 textures/pad_gfx02/gitter04
 {
-        qer_editorimage textures/pad_gfx02/git04.tga
+        qer_editorimage textures/pad_gfx02/git04
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -1088,7 +1088,7 @@ textures/pad_gfx02/gitter04
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/git04.tga
+		map textures/pad_gfx02/git04
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1100,13 +1100,13 @@ textures/pad_gfx02/gitter04
 		blendFunc GL_DST_COLOR GL_ZERO
 		depthFunc equal
 	}
-}   
-   
+}
+
 
 
 textures/pad_gfx02/zaun02
 {
-        qer_editorimage textures/pad_gfx02/zaun02.tga
+        qer_editorimage textures/pad_gfx02/zaun02
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -1114,7 +1114,7 @@ textures/pad_gfx02/zaun02
 	cull none
         nopicmip
 	{
-		map textures/pad_gfx02/zaun02.tga
+		map textures/pad_gfx02/zaun02
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1126,7 +1126,7 @@ textures/pad_gfx02/zaun02
 		blendFunc GL_DST_COLOR GL_ZERO
 		depthFunc equal
 	}
-}   
+}
 
 
 //=======================================================
@@ -1135,13 +1135,13 @@ textures/pad_gfx02/zaun02
 
 textures/pad_gfx02/plas01
 {
-	qer_editorimage textures/pad_gfx02/plas01.tga
+	qer_editorimage textures/pad_gfx02/plas01
 	{
-		map textures/pad_gfx02/plas01.tga
+		map textures/pad_gfx02/plas01
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
         	tcGen environment
                 blendfunc add
                 rgbGen identity
@@ -1156,13 +1156,13 @@ textures/pad_gfx02/plas01
 
 textures/pad_gfx02/plas02
 {
-	qer_editorimage textures/pad_gfx02/plas02.tga
+	qer_editorimage textures/pad_gfx02/plas02
 	{
-		map textures/pad_gfx02/plas02.tga
+		map textures/pad_gfx02/plas02
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
         	tcGen environment
                 blendfunc add
                 rgbGen identity
@@ -1176,13 +1176,13 @@ textures/pad_gfx02/plas02
 
 textures/pad_gfx02/plas07
 {
-	qer_editorimage textures/pad_gfx02/plas07.tga
+	qer_editorimage textures/pad_gfx02/plas07
 	{
-		map textures/pad_gfx02/plas07.tga
+		map textures/pad_gfx02/plas07
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
         	tcGen environment
                 blendfunc add
                 rgbGen identity
@@ -1203,25 +1203,25 @@ textures/pad_gfx02/col01
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/col01.tga
+		map textures/pad_gfx02/col01
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/col01.tga
+		map textures/pad_gfx02/col01
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}   
+}
 
 
 textures/pad_gfx02/col02
@@ -1232,25 +1232,25 @@ textures/pad_gfx02/col02
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/col02.tga
+		map textures/pad_gfx02/col02
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/col02.tga
+		map textures/pad_gfx02/col02
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}   
+}
 
 
 textures/pad_gfx02/col03
@@ -1261,25 +1261,25 @@ textures/pad_gfx02/col03
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/col03.tga
+		map textures/pad_gfx02/col03
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/col03.tga
+		map textures/pad_gfx02/col03
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}   
+}
 
 
 textures/pad_gfx02/col04
@@ -1290,25 +1290,25 @@ textures/pad_gfx02/col04
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/col04.tga
+		map textures/pad_gfx02/col04
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/col04.tga
+		map textures/pad_gfx02/col04
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}   
+}
 
 
 
@@ -1324,25 +1324,25 @@ textures/pad_gfx02/metal01
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal01.tga
+		map textures/pad_gfx02/metal01
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal01.tga
+		map textures/pad_gfx02/metal01
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}       
+}
 
 
 textures/pad_gfx02/metal02
@@ -1353,25 +1353,25 @@ textures/pad_gfx02/metal02
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal02.tga
+		map textures/pad_gfx02/metal02
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal02.tga
+		map textures/pad_gfx02/metal02
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}    
+}
 
 
 textures/pad_gfx02/metal03
@@ -1382,25 +1382,25 @@ textures/pad_gfx02/metal03
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal03.tga
+		map textures/pad_gfx02/metal03
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal03.tga
+		map textures/pad_gfx02/metal03
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}      
+}
 
 
 
@@ -1412,25 +1412,25 @@ textures/pad_gfx02/metal04
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal04.tga
+		map textures/pad_gfx02/metal04
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal04.tga
+		map textures/pad_gfx02/metal04
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}   
+}
 
 
 
@@ -1443,28 +1443,28 @@ textures/pad_gfx02/metal05
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal05.tga
+		map textures/pad_gfx02/metal05
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal05.tga
+		map textures/pad_gfx02/metal05
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}    
+}
 
 
-          
+
 
 textures/pad_gfx02/metal06
 {
@@ -1474,25 +1474,25 @@ textures/pad_gfx02/metal06
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal06.tga
+		map textures/pad_gfx02/metal06
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal06.tga
+		map textures/pad_gfx02/metal06
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}     
+}
 
 
 textures/pad_gfx02/metal06b
@@ -1503,25 +1503,25 @@ textures/pad_gfx02/metal06b
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal06b.tga
+		map textures/pad_gfx02/metal06b
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal06b.tga
+		map textures/pad_gfx02/metal06b
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}     
+}
 
 
 
@@ -1534,25 +1534,25 @@ textures/pad_gfx02/metal08
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal08.tga
+		map textures/pad_gfx02/metal08
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal08.tga
+		map textures/pad_gfx02/metal08
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}   
+}
 
 
 textures/pad_gfx02/metal09
@@ -1563,25 +1563,25 @@ textures/pad_gfx02/metal09
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal09.tga
+		map textures/pad_gfx02/metal09
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal09.tga
+		map textures/pad_gfx02/metal09
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}         
+}
 
 
 
@@ -1593,25 +1593,25 @@ textures/pad_gfx02/metal10
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal10.tga
+		map textures/pad_gfx02/metal10
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal10.tga
+		map textures/pad_gfx02/metal10
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}     
+}
 
 
 textures/pad_gfx02/metal11
@@ -1622,20 +1622,20 @@ textures/pad_gfx02/metal11
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal11.tga
+		map textures/pad_gfx02/metal11
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal11.tga
+		map textures/pad_gfx02/metal11
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
@@ -1646,30 +1646,30 @@ textures/pad_gfx02/metal11
 //=======================================================
 //Water
 //=======================================================
-        
+
 textures/pad_gfx02/wat01
 	{
-		qer_editorimage textures/pad_gfx02/wat01.tga
+		qer_editorimage textures/pad_gfx02/wat01
 		qer_trans .5
 		q3map_globaltexture
 		surfaceparm trans
 		surfaceparm nonsolid
 		surfaceparm water
-	
+
 		cull disable
-		deformVertexes wave 64 sin .5 .5 0 .5	
-		
-		{ 
-			map textures/pad_gfx02/wat02.tga
+		deformVertexes wave 64 sin .5 .5 0 .5
+
+		{
+			map textures/pad_gfx02/wat02
 			blendFunc GL_dst_color GL_one
 			rgbgen identity
 			tcmod scale .5 .5
 			tcmod transform 1.5 0 1.5 1 1 2
 			tcmod scroll -.05 .001
 		}
-	
-		{ 
-			map textures/pad_gfx02/wat03.tga
+
+		{
+			map textures/pad_gfx02/wat03
 			blendFunc GL_dst_color GL_one
 			rgbgen identity
 			tcmod scale .5 .5
@@ -1677,49 +1677,49 @@ textures/pad_gfx02/wat01
 			tcmod scroll .025 -.001
 		}
 
-		{ 
-			map textures/pad_gfx02/wat01.tga
+		{
+			map textures/pad_gfx02/wat01
 			blendFunc GL_dst_color GL_one
 			rgbgen identity
 			tcmod scale .25 .5
 			tcmod scroll .001 .025
 		}
-	
+
 		{
 			map $lightmap
 			blendFunc GL_dst_color GL_zero
-			rgbgen identity		
+			rgbgen identity
 		}
-	
 
-	}        
+
+	}
 
 
 
 textures/pad_gfx02/wat04
 
 {
-		qer_editorimage textures/pad_gfx02/wat04.tga
+		qer_editorimage textures/pad_gfx02/wat04
 		qer_trans .5
 		q3map_globaltexture
 		surfaceparm trans
 		surfaceparm nonsolid
 		surfaceparm water
-	
+
 		cull disable
-		deformVertexes wave 64 sin .5 .5 0 .5	
-		
-		{ 
-			map textures/pad_gfx02/wat05.tga
+		deformVertexes wave 64 sin .5 .5 0 .5
+
+		{
+			map textures/pad_gfx02/wat05
 			blendFunc GL_dst_color GL_one
 			rgbgen identity
 			tcmod scale .5 .5
 			tcmod transform 1.5 0 1.5 1 1 2
 			tcmod scroll -.05 .001
 		}
-	
-		{ 
-			map textures/pad_gfx02/wat06.tga
+
+		{
+			map textures/pad_gfx02/wat06
 			blendFunc GL_dst_color GL_one
 			rgbgen identity
 			tcmod scale .5 .5
@@ -1727,22 +1727,22 @@ textures/pad_gfx02/wat04
 			tcmod scroll .025 -.001
 		}
 
-		{ 
-			map textures/pad_gfx02/wat04.tga
+		{
+			map textures/pad_gfx02/wat04
 			blendFunc GL_dst_color GL_one
 			rgbgen identity
 			tcmod scale .25 .5
 			tcmod scroll .001 .025
 		}
-	
+
 		{
 			map $lightmap
 			blendFunc GL_dst_color GL_zero
-			rgbgen identity		
+			rgbgen identity
 		}
-	
 
-	}                                                                                                                                                                              
+
+	}
 
 //=======================================================
 //webs
@@ -1757,7 +1757,7 @@ textures/pad_gfx02b/cweb_m01drk
     cull disable
     deformVertexes wave 10 sin 0 2 0 0.2
     {
-        map textures/pad_gfx02b/cweb_m01drk.tga
+        map textures/pad_gfx02b/cweb_m01drk
         blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
         rgbGen vertex
     }
@@ -1775,7 +1775,7 @@ textures/pad_gfx02b/cweb_m01a
     cull disable
     deformVertexes wave 10 sin 0 2 0 0.2
     {
-        map textures/pad_gfx02b/cweb_m01a.tga
+        map textures/pad_gfx02b/cweb_m01a
         blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
         rgbGen vertex
     }
@@ -1792,13 +1792,13 @@ textures/pad_gfx02b/latern
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_gfx02b/latern.tga
+                map textures/pad_gfx02b/latern
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -1821,23 +1821,23 @@ textures/pad_gfx02b/latern
 
 textures/pad_gfx02b/desk04
 {
-	q3map_lightimage textures/pad_gfx02b/desk04.tga
+	q3map_lightimage textures/pad_gfx02b/desk04
 	q3map_surfacelight 70
 
         {
-		map textures/pad_gfx02b/desk04.tga
+		map textures/pad_gfx02b/desk04
 		rgbGen identity
 	}
-	
+
         {
-		map textures/pad_gfx02b/comp_line02.tga
+		map textures/pad_gfx02b/comp_line02
 		blendfunc add
 		rgbGen identity
 		tcmod scroll 0 1
 	}
 
         {
-		map textures/pad_gfx02b/compsnowb.tga
+		map textures/pad_gfx02b/compsnowb
 	        blendfunc add
                 rgbGen identity
 		tcmod scroll 3 3
@@ -1860,14 +1860,14 @@ textures/pad_gfx02b/desk04
 
 textures/pad_gfx02b/git001b
 {
-     qer_editorimage textures/pad_gfx02b/git001b.tga   
+     qer_editorimage textures/pad_gfx02b/git001b
      cull none
      surfaceparm alphashadow
-     surfaceparm playerclip	
+     surfaceparm playerclip
      surfaceparm nomarks
      nopicmip
      {
-                map textures/pad_gfx02b/git001b.tga
+                map textures/pad_gfx02b/git001b
                 blendFunc GL_ONE GL_ZERO
                 alphaFunc GE128
 		depthWrite
@@ -1887,13 +1887,13 @@ textures/pad_gfx02b/git001d
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_gfx02b/git001d.tga
+                map textures/pad_gfx02b/git001d
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -1914,13 +1914,13 @@ textures/pad_gfx02b/git005
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_gfx02b/git005.tga
+                map textures/pad_gfx02b/git005
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -1939,16 +1939,16 @@ textures/pad_gfx02b/git005
 
 
 textures/pad_gfx02b/watblack
-{	
-	qer_editorimage textures/pad_gfx02b/watblack.tga
-	q3map_lightimage textures/pad_gfx02b/watblack.tga
+{
+	qer_editorimage textures/pad_gfx02b/watblack
+	q3map_lightimage textures/pad_gfx02b/watblack
 	q3map_globaltexture
 	qer_trans .5
 
 	surfaceparm noimpact
 	surfaceparm slime
 	surfaceparm nolightmap
-	surfaceparm trans		
+	surfaceparm trans
 
 	q3map_surfacelight 20
 	tessSize 32
@@ -1957,35 +1957,35 @@ textures/pad_gfx02b/watblack
 	deformVertexes wave 100 sin 0 1 .2 .3
 
 	{
-		map textures/pad_gfx02b/watblackb.tga
+		map textures/pad_gfx02b/watblackb
 		tcMod turb .3 .2 1 .05
 		tcMod scroll .025 .025
 	}
-	
+
 	{
-		map textures/pad_gfx02b/watblack.tga
+		map textures/pad_gfx02b/watblack
 		blendfunc GL_ONE GL_ONE
 		tcMod turb .2 .1 1 .05
 		tcMod scale .5 .5
 		tcMod scroll .02 .02
 	}
-	
+
 
 }
 
 
 
 textures/pad_gfx02b/watyell
-{	
-	qer_editorimage textures/pad_gfx02b/watyell.tga
-	q3map_lightimage textures/pad_gfx02b/watyell.tga
+{
+	qer_editorimage textures/pad_gfx02b/watyell
+	q3map_lightimage textures/pad_gfx02b/watyell
 	q3map_globaltexture
 	qer_trans .5
 
 	surfaceparm noimpact
 	surfaceparm slime
 	surfaceparm nolightmap
-	surfaceparm trans		
+	surfaceparm trans
 
 	q3map_surfacelight 20
 	tessSize 32
@@ -1994,19 +1994,19 @@ textures/pad_gfx02b/watyell
 	deformVertexes wave 100 sin 0 1 .2 .3
 
 	{
-		map textures/pad_gfx02b/watyellow.tga
+		map textures/pad_gfx02b/watyellow
 		tcMod turb .3 .2 1 .05
 		tcMod scroll .025 .025
 	}
-	
+
 	{
-		map textures/pad_gfx02b/watyell.tga
+		map textures/pad_gfx02b/watyell
 		blendfunc GL_ONE GL_ONE
 		tcMod turb .2 .1 1 .05
 		tcMod scale .5 .5
 		tcMod scroll .02 .02
 	}
-	
+
 
 }
 
@@ -2014,134 +2014,134 @@ textures/pad_gfx02b/watyell
 
 textures/pad_gfx02b/beam_yellow
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
+        surfaceparm trans
+        surfaceparm nomarks
         surfaceparm nonsolid
 	surfaceparm nolightmap
 	cull none
 	surfaceparm nomipmaps
         //nopicmip
 	{
-		map textures/pad_gfx02b/beam_yellow.tga
+		map textures/pad_gfx02b/beam_yellow
                 tcMod Scroll .4 0
                 blendFunc add
         }
-     
+
 }
 
 
 textures/pad_gfx02b/beam_red
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
+        surfaceparm trans
+        surfaceparm nomarks
         surfaceparm nonsolid
 	surfaceparm nolightmap
 	cull none
 	surfaceparm nomipmaps
         //nopicmip
 	{
-		map textures/pad_gfx02b/beam_red.tga
+		map textures/pad_gfx02b/beam_red
                 tcMod Scroll .4 0
                 blendFunc add
         }
-     
+
 }
 
 
 textures/pad_gfx02b/beam_blue
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
+        surfaceparm trans
+        surfaceparm nomarks
         surfaceparm nonsolid
 	surfaceparm nolightmap
 	cull none
 	surfaceparm nomipmaps
         //nopicmip
 	{
-		map textures/pad_gfx02b/beam_blue.tga
+		map textures/pad_gfx02b/beam_blue
                 tcMod Scroll .4 0
                 blendFunc add
         }
-     
+
 }
 
 
 textures/pad_gfx02b/beam_grey
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
+        surfaceparm trans
+        surfaceparm nomarks
         surfaceparm nonsolid
 	surfaceparm nolightmap
 	cull none
 	surfaceparm nomipmaps
         //nopicmip
 	{
-		map textures/pad_gfx02b/beam_grey.tga
+		map textures/pad_gfx02b/beam_grey
                 tcMod Scroll .4 0
                 blendFunc add
         }
-     
+
 }
 
 
 textures/pad_gfx02b/beam_purple
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
+        surfaceparm trans
+        surfaceparm nomarks
         surfaceparm nonsolid
 	surfaceparm nolightmap
 	cull none
 	surfaceparm nomipmaps
         //nopicmip
 	{
-		map textures/pad_gfx02b/beam_purple.tga
+		map textures/pad_gfx02b/beam_purple
                 tcMod Scroll .4 0
                 blendFunc add
         }
-     
+
 }
 
 
 textures/pad_gfx02b/beam_brown
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
+        surfaceparm trans
+        surfaceparm nomarks
         surfaceparm nonsolid
 	surfaceparm nolightmap
 	cull none
 	surfaceparm nomipmaps
         //nopicmip
 	{
-		map textures/pad_gfx02b/beam_brown.tga
+		map textures/pad_gfx02b/beam_brown
                 tcMod Scroll .4 0
                 blendFunc add
         }
-     
+
 }
 
 
 textures/pad_gfx02b/beam_green
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
+        surfaceparm trans
+        surfaceparm nomarks
         surfaceparm nonsolid
 	surfaceparm nolightmap
 	cull none
 	surfaceparm nomipmaps
         //nopicmip
 	{
-		map textures/pad_gfx02b/beam_green.tga
+		map textures/pad_gfx02b/beam_green
                 tcMod Scroll .4 0
                 blendFunc add
         }
-     
+
 }
 
 
 
 textures/pad_gfx02b/hotlava1
 {
-	qer_editorimage textures/pad_gfx02b/hotlava2d.tga
+	qer_editorimage textures/pad_gfx02b/hotlava2d
 	q3map_globaltexture
 	surfaceparm trans
 	surfaceparm nonsolid
@@ -2150,13 +2150,13 @@ textures/pad_gfx02b/hotlava1
 	surfaceparm nolightmap
 	q3map_surfacelight 200
 	cull disable
-	
+
 	tesssize 128
 	cull disable
 	deformVertexes wave 100 sin 3 2 .1 0.1
-	
+
 	{
-		map textures/pad_gfx02b/hotlava2d.tga
+		map textures/pad_gfx02b/hotlava2d
 		tcMod turb 0 .2 0 .1
 	}
 }
@@ -2165,7 +2165,7 @@ textures/pad_gfx02b/hotlava1
 
 textures/pad_gfx02b/greenlava
 {
-	qer_editorimage textures/pad_gfx02b/greenlava.tga
+	qer_editorimage textures/pad_gfx02b/greenlava
 	q3map_globaltexture
 	surfaceparm trans
 	surfaceparm nonsolid
@@ -2174,13 +2174,13 @@ textures/pad_gfx02b/greenlava
 	surfaceparm nolightmap
 	q3map_surfacelight 200
 	cull disable
-	
+
 	tesssize 128
 	cull disable
 	deformVertexes wave 100 sin 3 2 .1 0.1
-	
+
 	{
-		map textures/pad_gfx02b/greenlava.tga
+		map textures/pad_gfx02b/greenlava
 		tcMod turb 0 .2 0 .1
 	}
 }
@@ -2190,8 +2190,8 @@ textures/pad_gfx02b/greenlava
 
 textures/pad_gfx02b/hotlava2
 {
-	
-	qer_editorimage textures/pad_gfx02b/hotlava2.tga
+
+	qer_editorimage textures/pad_gfx02b/hotlava2
 	q3map_globaltexture
 	surfaceparm trans
 	surfaceparm nonsolid
@@ -2200,13 +2200,13 @@ textures/pad_gfx02b/hotlava2
 	surfaceparm nolightmap
 	q3map_surfacelight 300
 	cull disable
-	
+
 	tesssize 128
 	cull disable
 	deformVertexes wave 100 sin 3 2 .1 0.1
-	
+
         {
-		map textures/pad_gfx02b/hotmatsch.tga
+		map textures/pad_gfx02b/hotmatsch
                 tcmod scale .2 .2
                 tcmod scroll .04 .03
                 tcMod turb 0 .1 0 .01
@@ -2214,7 +2214,7 @@ textures/pad_gfx02b/hotlava2
                 rgbGen identity
 	}
 	{
-		map textures/pad_gfx02b/hotlava2.tga
+		map textures/pad_gfx02b/hotlava2
                 blendfunc blend
 		tcMod turb 0 .2 0 .1
 	}
@@ -2223,16 +2223,16 @@ textures/pad_gfx02b/hotlava2
 
 
 textures/pad_gfx02b/hotlava3
-{	
-	qer_editorimage textures/pad_gfx02b/hotlava2d.tga
-	q3map_lightimage textures/pad_gfx02b/hotmatsch.tga
+{
+	qer_editorimage textures/pad_gfx02b/hotlava2d
+	q3map_lightimage textures/pad_gfx02b/hotmatsch
 	q3map_globaltexture
 	qer_trans .5
 
 	surfaceparm noimpact
 	surfaceparm lava
 	surfaceparm nolightmap
-	surfaceparm trans		
+	surfaceparm trans
 
 	q3map_surfacelight 20
 	tessSize 128
@@ -2241,19 +2241,19 @@ textures/pad_gfx02b/hotlava3
 	deformVertexes wave 100 sin 0 1 .2 .3
 
 	{
-		map textures/pad_gfx02b/hotlava2d.tga
+		map textures/pad_gfx02b/hotlava2d
 		tcMod turb .3 .2 1 .05
 		tcMod scroll .025 .025
 	}
-	
+
 	{
-		map textures/pad_gfx02b/hotmatsch.tga
+		map textures/pad_gfx02b/hotmatsch
 		blendfunc GL_ONE GL_ONE
 		tcMod turb .2 .1 1 .05
 		tcMod scale .5 .5
 		tcMod scroll .02 .02
 	}
-	
+
 
 }
 
@@ -2261,7 +2261,7 @@ textures/pad_gfx02b/hotlava3
 
 textures/pad_gfx02b/padfog_yel
 {
-		qer_editorimage textures/pad_gfx02b/padfog_yel.tga
+		qer_editorimage textures/pad_gfx02b/padfog_yel
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -2273,7 +2273,7 @@ textures/pad_gfx02b/padfog_yel
 
 textures/pad_gfx02b/padfog_yel02
 {
-		qer_editorimage textures/pad_gfx02b/padfog_yel.tga
+		qer_editorimage textures/pad_gfx02b/padfog_yel
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -2285,7 +2285,7 @@ textures/pad_gfx02b/padfog_yel02
 
 textures/pad_gfx02b/padfog_red
 {
-		qer_editorimage textures/pad_gfx02b/padfog_red.tga
+		qer_editorimage textures/pad_gfx02b/padfog_red
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -2297,8 +2297,8 @@ textures/pad_gfx02b/padfog_red
 
 textures/pad_gfx02b/padfog_red02
 {
-	q3map_lightimage textures/pad_gfx02b/hotmatsch.tga	
-	qer_editorimage textures/pad_gfx02b/padfog_red02.tga
+	q3map_lightimage textures/pad_gfx02b/hotmatsch
+	qer_editorimage textures/pad_gfx02b/padfog_red02
 	q3map_surfacelight 30
 	q3map_lightsubdivide 32
 
@@ -2314,7 +2314,7 @@ textures/pad_gfx02b/padfog_red02
 
 textures/pad_gfx02b/padfog_red03
 {
-		qer_editorimage textures/pad_gfx02b/padfog_red.tga
+		qer_editorimage textures/pad_gfx02b/padfog_red
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -2327,7 +2327,7 @@ textures/pad_gfx02b/padfog_red03
 
 textures/pad_gfx02b/padfog_green
 {
-		qer_editorimage textures/pad_gfx02b/padfog_green.tga
+		qer_editorimage textures/pad_gfx02b/padfog_green
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -2339,7 +2339,7 @@ textures/pad_gfx02b/padfog_green
 
 textures/pad_gfx02b/padfog_green02
 {
-		qer_editorimage textures/pad_gfx02b/padfog_green.tga
+		qer_editorimage textures/pad_gfx02b/padfog_green
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -2351,7 +2351,7 @@ textures/pad_gfx02b/padfog_green02
 
 textures/pad_gfx02b/padfog_grey
 {
-		qer_editorimage textures/pad_gfx02b/padfog_grey.tga
+		qer_editorimage textures/pad_gfx02b/padfog_grey
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -2364,7 +2364,7 @@ textures/pad_gfx02b/padfog_grey
 
 textures/pad_gfx02b/padfog_blue
 {
-		qer_editorimage textures/pad_gfx02b/padfog_blue.tga
+		qer_editorimage textures/pad_gfx02b/padfog_blue
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -2377,7 +2377,7 @@ textures/pad_gfx02b/padfog_blue
 
 textures/pad_gfx02b/padfog_grey02
 {
-		qer_editorimage textures/pad_gfx02b/padfog_grey.tga
+		qer_editorimage textures/pad_gfx02b/padfog_grey
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -2398,7 +2398,7 @@ textures/pad_gfx02b/padmove05
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02b/padmove05.tga
+		map textures/pad_gfx02b/padmove05
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2410,14 +2410,14 @@ textures/pad_gfx02b/padflagred02
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_gfx02b/padflagred02.tga
+                map textures/pad_gfx02b/padflagred02
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -2437,14 +2437,14 @@ textures/pad_gfx02b/padflagblue02
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_gfx02b/padflagblue02.tga
+                map textures/pad_gfx02b/padflagblue02
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -2465,14 +2465,14 @@ textures/pad_gfx02b/old_padflagred
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_gfx02b/old_padflagred.tga
+                map textures/pad_gfx02b/old_padflagred
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -2493,14 +2493,14 @@ textures/pad_gfx02b/old_padflaggreen
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_gfx02b/old_padflaggreen.tga
+                map textures/pad_gfx02b/old_padflaggreen
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -2520,14 +2520,14 @@ textures/pad_gfx02b/old_padflagblack
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_gfx02b/old_padflagblack.tga
+                map textures/pad_gfx02b/old_padflagblack
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -2545,7 +2545,7 @@ textures/pad_gfx02b/old_padflagblack
 
 textures/pad_metal/targetlight
 {
-	qer_editorimage textures/pad_metal/targetlight.tga
+	qer_editorimage textures/pad_metal/targetlight
 	q3map_surfacelight 200
               q3map_flareShader flareShader
 //	light 1
@@ -2555,12 +2555,12 @@ textures/pad_metal/targetlight
 		rgbGen identity
 	}
 	{
-		map textures/pad_metal/targetlight.tga
+		map textures/pad_metal/targetlight
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_metal/target_flash.tga
+		map textures/pad_metal/target_flash
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -2570,7 +2570,7 @@ textures/pad_metal/targetlight
 
 textures/pad_flowerfx/grass4_move
 {
-	qer_editorimage textures/pad_flowerfx/pad_leaf4.tga
+	qer_editorimage textures/pad_flowerfx/pad_leaf4
 	deformVertexes wave 194 sin 0 2 0 .2
 	deformVertexes wave 30 sin 0 1 0 .3
 	deformVertexes wave 194 sin 0 1 0 .1
@@ -2579,7 +2579,7 @@ textures/pad_flowerfx/grass4_move
 	cull none
 
 	{
-		map textures/pad_flowerfx/pad_leaf4.tga
+		map textures/pad_flowerfx/pad_leaf4
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -2596,7 +2596,7 @@ textures/pad_flowerfx/grass4_move
 
 textures/pad_flowerfx/grass2_move
 {
-	qer_editorimage textures/pad_flowerfx/pad_leaf2.tga
+	qer_editorimage textures/pad_flowerfx/pad_leaf2
 	deformVertexes wave 194 sin 0 2 0 .2
 	deformVertexes wave 30 sin 0 1 0 .3
 	deformVertexes wave 194 sin 0 1 0 .1
@@ -2605,7 +2605,7 @@ textures/pad_flowerfx/grass2_move
 	cull none
 
 	{
-		map textures/pad_flowerfx/pad_leaf2.tga
+		map textures/pad_flowerfx/pad_leaf2
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -2622,7 +2622,7 @@ textures/pad_flowerfx/grass2_move
 
 textures/pad_flowerfx/leaf04_move
 {
-	qer_editorimage textures/pad_flowerfx/blatt.tga
+	qer_editorimage textures/pad_flowerfx/blatt
 	deformVertexes wave 194 sin 0 2 0 .2
 	deformVertexes wave 30 sin 0 1 0 .3
 	deformVertexes wave 194 sin 0 1 0 .1
@@ -2631,7 +2631,7 @@ textures/pad_flowerfx/leaf04_move
 	cull none
 
 	{
-		map textures/pad_flowerfx/blatt.tga
+		map textures/pad_flowerfx/blatt
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -2648,12 +2648,12 @@ textures/pad_flowerfx/leaf04_move
 
 textures/pad_flowerfx/sprite_leaf2
 {
-	qer_editorimage textures/pad_flowerfx/pad_leaf2.tga
+	qer_editorimage textures/pad_flowerfx/pad_leaf2
 	cull disable
 	deformvertexes autosprite
 
 {
-	map textures/pad_flowerfx/pad_leaf2.tga
+	map textures/pad_flowerfx/pad_leaf2
 	blendFunc blend
       alphaFunc GE128
 	depthWrite
@@ -2668,18 +2668,18 @@ textures/pad_flowerfx/sprite_leaf2
 
 textures/pad_petesky/utopiaatoll
 {
-        qer_editorimage textures/pad_petesky/utopiaatoll.tga
+        qer_editorimage textures/pad_petesky/utopiaatoll
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/orange01.tga
+        q3map_lightimage textures/pad_petesky/orange01
 	q3map_sun	0.266383 0.274632 0.358662 100 50 55
 	q3map_surfacelight 200
 
         skyparms env/utopiaatoll512 - -
 //       {
-//		map textures/pad_petesky/utopiaatoll.tga
+//		map textures/pad_petesky/utopiaatoll
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -2689,18 +2689,18 @@ textures/pad_petesky/utopiaatoll
 
 textures/pad_petesky/urban-terror
 {
-        qer_editorimage textures/pad_petesky/urban-terror.tga
+        qer_editorimage textures/pad_petesky/urban-terror
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/orange2.tga
+        q3map_lightimage textures/pad_petesky/orange2
 	q3map_sun	1.000000 0.718471 0.616587 200 60 225
 	q3map_surfacelight 200
 
         skyparms env/urban-terror512 - -
 //       {
-//		map textures/pad_petesky/urban-terror.tga
+//		map textures/pad_petesky/urban-terror
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -2710,18 +2710,18 @@ textures/pad_petesky/urban-terror
 
 textures/pad_petesky/poltergeist
 {
-        qer_editorimage textures/pad_petesky/poltergeist.tga
+        qer_editorimage textures/pad_petesky/poltergeist
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/blue01.tga
+        q3map_lightimage textures/pad_petesky/blue01
 	q3map_sun	0.434981 0.749839 1.000000 260 340 50
 	q3map_surfacelight 400
 
         skyparms env/pf-poltergeist512 - -
 //       {
-//		map textures/pad_petesky/poltergeist.tga
+//		map textures/pad_petesky/poltergeist
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -2731,18 +2731,18 @@ textures/pad_petesky/poltergeist
 
 textures/pad_petesky/pf-tornado-alley
 {
-        qer_editorimage textures/pad_petesky/pf-tornado-alley.tga
+        qer_editorimage textures/pad_petesky/pf-tornado-alley
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/grey.tga
+        q3map_lightimage textures/pad_petesky/grey
 	q3map_sun	0.266383 0.274632 0.358662 100 50 55
 	q3map_surfacelight 200
 
         skyparms env/pf-tornado-alley512 - -
 //       {
-//		map textures/pad_petesky/pf-tornado-alley.tga
+//		map textures/pad_petesky/pf-tornado-alley
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -2752,12 +2752,12 @@ textures/pad_petesky/pf-tornado-alley
 
 textures/pad_petesky/morning_alley
 {
-             qer_editorimage textures/pad_petesky/morning_alley.tga
+             qer_editorimage textures/pad_petesky/morning_alley
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-              q3map_lightimage textures/pad_petesky/orange2.tga
+              q3map_lightimage textures/pad_petesky/orange2
 	q3map_sun	1.000000 0.862213 0.247457 330 340 50
 	q3map_surfacelight 400
 
@@ -2768,18 +2768,18 @@ textures/pad_petesky/morning_alley
 
 textures/pad_petesky/sep
 {
-        qer_editorimage textures/pad_petesky/sep.tga
+        qer_editorimage textures/pad_petesky/sep
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/orange.tga
+        q3map_lightimage textures/pad_petesky/orange
 	q3map_sun	0.266383 0.274632 0.358662 94 48 75
 	q3map_surfacelight 280
 
         skyparms env/sep512 - -
 //       {
-//		map textures/pad_petesky/sep.tga
+//		map textures/pad_petesky/sep
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -2789,18 +2789,18 @@ textures/pad_petesky/sep
 
 textures/pad_petesky/morning-madness
 {
-        qer_editorimage textures/pad_petesky/morning-madness.tga
+        qer_editorimage textures/pad_petesky/morning-madness
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/orange2.tga
+        q3map_lightimage textures/pad_petesky/orange2
 	q3map_sun	0.266383 0.274632 0.358662 100 50 55
 	q3map_surfacelight 200
 
         skyparms env/pc-morning-madness512 - -
 //       {
-//		map textures/pad_petesky/morning-madness.tga
+//		map textures/pad_petesky/morning-madness
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -2810,18 +2810,18 @@ textures/pad_petesky/morning-madness
 
 textures/pad_petesky/sist
 {
-        qer_editorimage textures/pad_petesky/sist.tga
+        qer_editorimage textures/pad_petesky/sist
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/orange01.tga
+        q3map_lightimage textures/pad_petesky/orange01
 	q3map_sun	0.266383 0.274632 0.358662 100 50 55
 	q3map_surfacelight 200
 
         skyparms env/sist512 - -
 //       {
-//		map textures/pad_petesky/sist.tga
+//		map textures/pad_petesky/sist
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2

--- a/wop/scripts.pk3dir/scripts/pad_glowmaps.shader
+++ b/wop/scripts.pk3dir/scripts/pad_glowmaps.shader
@@ -3,19 +3,19 @@ textures/pad_glowsky/padbox
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm sky
-        q3map_lightimage textures/pad_glowsky/padbox_white.tga
+        q3map_lightimage textures/pad_glowsky/padbox_white
 	q3map_sun	1 1 1 100 -58 58
 	q3map_surfacelight 90
 
         skyparms env/padboxglow - -
        {
-		map textures/pad_glowsky/sky.tga
+		map textures/pad_glowsky/sky
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll 0.01 0.02
 		tcMod scale 1 2
 	}
        {
-		map textures/pad_glowsky/sky2.tga
+		map textures/pad_glowsky/sky2
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll -0.02 -0.01
 		tcMod scale 1 2
@@ -27,18 +27,18 @@ textures/pad_glowsky/padbox
 
 textures/pad_glowsky/utopiaatoll
 {
-        qer_editorimage textures/pad_glowsky/utopiaatoll.tga
+        qer_editorimage textures/pad_glowsky/utopiaatoll
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_glowsky/orange01.tga
+        q3map_lightimage textures/pad_glowsky/orange01
 	q3map_sun	0.266383 0.274632 0.358662 150 60 85
 	q3map_surfacelight 200
 
         skyparms env/utopiaatoll512 - -
 //       {
-//		map textures/pad_glowsky/utopiaatoll.tga
+//		map textures/pad_glowsky/utopiaatoll
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -47,18 +47,18 @@ textures/pad_glowsky/utopiaatoll
 
 textures/pad_petesky/wolfl
 {
-        qer_editorimage textures/pad_petesky/wolf.tga
+        qer_editorimage textures/pad_petesky/wolf
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/grey.tga
+        q3map_lightimage textures/pad_petesky/grey
 //	q3map_sun	0.266383 0.274632 0.358662 150 60 85
 	q3map_surfacelight 20
 
         skyparms env/wolf-pack512 - -
 //       {
-//		map textures/pad_petesky/wolfl.tga
+//		map textures/pad_petesky/wolfl
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -67,18 +67,18 @@ textures/pad_petesky/wolfl
 
 textures/pad_glowsky/urban-terror
 {
-        qer_editorimage textures/pad_glowsky/urban-terror.tga
+        qer_editorimage textures/pad_glowsky/urban-terror
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_glowsky/orange03.tga
+        q3map_lightimage textures/pad_glowsky/orange03
 	q3map_sun	0.266383 0.274632 0.358662 90 90 90
 	q3map_surfacelight 20
 
         skyparms env/urban-terror512 - -
 //       {
-//		map textures/pad_glowsky/urban-terror.tga
+//		map textures/pad_glowsky/urban-terror
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -87,18 +87,18 @@ textures/pad_glowsky/urban-terror
 
 textures/pad_glowsky/sandtrap
 {
-        qer_editorimage textures/pad_glowsky/sandtrap.tga
+        qer_editorimage textures/pad_glowsky/sandtrap
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_glowsky/blue.tga
+        q3map_lightimage textures/pad_glowsky/blue
 	q3map_sun	0.266383 0.274632 0.358662 100 50 55
 	q3map_surfacelight 2
 
         skyparms env/sandtrap512 - -
 //       {
-//		map textures/pad_glowsky/sandtrap.tga
+//		map textures/pad_glowsky/sandtrap
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -110,14 +110,14 @@ textures/pad_glowsky/sandtrap
 
 textures/pad_glowsky/gglass03
 {
-	qer_editorimage textures/pad_glowsky/gglass03.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_glowsky/gglass03
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_glowsky/gglass03.tga
+		map textures/pad_glowsky/gglass03
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -126,20 +126,20 @@ textures/pad_glowsky/gglass03
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_glowsky/gglass01
 {
-	qer_editorimage textures/pad_glowsky/gglass01.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_glowsky/gglass01
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_glowsky/gglass01.tga
+		map textures/pad_glowsky/gglass01
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -148,20 +148,20 @@ textures/pad_glowsky/gglass01
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_glowsky/gglass02
 {
-	qer_editorimage textures/pad_glowsky/gglass02.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_glowsky/gglass02
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_glowsky/gglass02.tga
+		map textures/pad_glowsky/gglass02
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -170,23 +170,23 @@ textures/pad_glowsky/gglass02
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 textures/pad_backyard/pf-tornado-alley
 {
-        qer_editorimage textures/pad_backyard/pf-tornado-alley.tga
+        qer_editorimage textures/pad_backyard/pf-tornado-alley
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_backyard/grey.tga
+        q3map_lightimage textures/pad_backyard/grey
 	q3map_sun	0.266383 0.274632 0.358662 100 230 70
 	q3map_surfacelight 175
 
         skyparms env/pf-tornado-alley512 - -
 //       {
-//		map textures/pad_backyard/pf-tornado-alley.tga
+//		map textures/pad_backyard/pf-tornado-alley
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -196,12 +196,12 @@ textures/pad_backyard/pf-tornado-alley
 
 textures/pad_glowsky/glass
 {
-   qer_editorimage   textures/pad_glowsky/glass.tga
+   qer_editorimage   textures/pad_glowsky/glass
               surfaceparm trans
    q3map_nolightmap
    q3map_onlyvertexlighting
     {
-        map textures/pad_glowsky/glass.tga
+        map textures/pad_glowsky/glass
         blendFunc GL_ONE GL_ONE
     }
 }
@@ -209,57 +209,57 @@ textures/pad_glowsky/glass
 
 textures/glowstar/glas
 {
-	qer_editorimage textures/colors/greygreen.tga
+	qer_editorimage textures/colors/greygreen
 	cull back
 	{
-		map textures/colors/greygreen.tga
+		map textures/colors/greygreen
 		blendfunc add
 	}
 	{
-		map textures/pad_gfx/env2.tga
+		map textures/pad_gfx/env2
 		blendfunc filter
-		tcGen environment 
+		tcGen environment
 	}
 }
 
 textures/glowstar/greenglas
 {
-	qer_editorimage textures/colors/greygreen.tga
+	qer_editorimage textures/colors/greygreen
 	cull back
 	{
-		map textures/colors/greygreen.tga
+		map textures/colors/greygreen
 		blendfunc add
 	}
 	{
-		map textures/pad_gfx/env2.tga
+		map textures/pad_gfx/env2
 		blendfunc filter
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map textures/colors/greygreen.tga
+		map textures/colors/greygreen
 		blendfunc filter
 	}
 }
 
 textures/glowstar/milchglas
 {
-	qer_editorimage textures/colors/greygreen.tga
+	qer_editorimage textures/colors/greygreen
 	cull back
 	{
-		map textures/colors/greygreen.tga
+		map textures/colors/greygreen
 		blendfunc add
 	}
 	{
-		map textures/pad_gfx/env2.tga
+		map textures/pad_gfx/env2
 		blendfunc filter
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map textures/colors/greygreen.tga
+		map textures/colors/greygreen
 		blendfunc filter
 	}
 	{
-		map textures/colors/greygreen.tga
+		map textures/colors/greygreen
 		blendfunc blend
 	}
 }
@@ -273,28 +273,28 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_glow/liege.tga
+map textures/pad_glow/liege
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-}  
+}
 
 
 textures/pad_glow/marble01
 {
-	qer_editorimage textures/pad_glow/marble01.tga
-	
+	qer_editorimage textures/pad_glow/marble01
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_glow/marble01.tga
+		map textures/pad_glow/marble01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -303,19 +303,19 @@ textures/pad_glow/marble01
 
 textures/pad_glow/marble04
 {
-	qer_editorimage textures/pad_glow/marble04.tga
-	
+	qer_editorimage textures/pad_glow/marble04
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_glow/marble04.tga
+		map textures/pad_glow/marble04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -324,19 +324,19 @@ textures/pad_glow/marble04
 
 textures/pad_glow/marble06
 {
-	qer_editorimage textures/pad_glow/marble06.tga
-	
+	qer_editorimage textures/pad_glow/marble06
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_glow/marble06.tga
+		map textures/pad_glow/marble06
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -346,19 +346,19 @@ textures/pad_glow/marble06
 
 textures/pad_glow/marble07
 {
-	qer_editorimage textures/pad_glow/marble07.tga
-	
+	qer_editorimage textures/pad_glow/marble07
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_glow/marble07.tga
+		map textures/pad_glow/marble07
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -368,19 +368,19 @@ textures/pad_glow/marble07
 
 textures/pad_glow/marble08
 {
-	qer_editorimage textures/pad_glow/marble08.tga
-	
+	qer_editorimage textures/pad_glow/marble08
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_glow/marble08.tga
+		map textures/pad_glow/marble08
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -390,19 +390,19 @@ textures/pad_glow/marble08
 
 textures/pad_glow/marble21
 {
-	qer_editorimage textures/pad_glow/marble21.tga
-	
+	qer_editorimage textures/pad_glow/marble21
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_glow/marble21.tga
+		map textures/pad_glow/marble21
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -412,19 +412,19 @@ textures/pad_glow/marble21
 
 textures/pad_glow/marble27
 {
-	qer_editorimage textures/pad_glow/marble27.tga
-	
+	qer_editorimage textures/pad_glow/marble27
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_glow/marble27.tga
+		map textures/pad_glow/marble27
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -434,15 +434,15 @@ textures/pad_glow/marble27
 
 textures/pad_cabin/Moni
 {
-	q3map_lightimage textures/pad_cabin/Moni.tga
+	q3map_lightimage textures/pad_cabin/Moni
 	q3map_surfacelight 20
 
         {
-		map textures/pad_cabin/Moni.tga
+		map textures/pad_cabin/Moni
 		rgbGen identity
 	}
-	
-       
+
+
 	{
 		map $lightmap
 		tcgen environment
@@ -460,11 +460,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/Holz00y.tga
+map textures/pad_backyard/Holz00y
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_backyard/Holz00z
 {
@@ -474,11 +474,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/Holz00y.tga
+map textures/pad_backyard/Holz00y
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_backyard/planke02
 {
@@ -488,11 +488,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/planke02.tga
+map textures/pad_backyard/planke02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_backyard/wood0a
 {
@@ -502,11 +502,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0a.tga
+map textures/pad_backyard/wood0a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_backyard/wood0b
 {
@@ -516,11 +516,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0b.tga
+map textures/pad_backyard/wood0b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 
@@ -532,11 +532,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0c.tga
+map textures/pad_backyard/wood0c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_backyard/wood0d
@@ -547,7 +547,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0d.tga
+map textures/pad_backyard/wood0d
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -562,11 +562,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0e.tga
+map textures/pad_backyard/wood0e
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-}  
+}
 
 
 textures/pad_backyard/wood0f
@@ -577,11 +577,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0f.tga
+map textures/pad_backyard/wood0f
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_backyard/wood0g
@@ -592,11 +592,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0g.tga
+map textures/pad_backyard/wood0g
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_backyard/wood0h
@@ -607,11 +607,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0h.tga
+map textures/pad_backyard/wood0h
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_backyard/wood0i
@@ -622,11 +622,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0i.tga
+map textures/pad_backyard/wood0i
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_backyard/wood0j
@@ -637,11 +637,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood0j.tga
+map textures/pad_backyard/wood0j
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 
@@ -653,11 +653,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood01.tga
+map textures/pad_backyard/wood01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_backyard/wood02
@@ -668,11 +668,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/wood02.tga
+map textures/pad_backyard/wood02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 
@@ -684,11 +684,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/glow_rost01.tga
+map textures/pad_backyard/glow_rost01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_backyard/metal02
@@ -699,11 +699,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/metal02.tga
+map textures/pad_backyard/metal02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_backyard/metal04
 {
@@ -713,11 +713,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/metal04.tga
+map textures/pad_backyard/metal04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_backyard/metal06
 {
@@ -727,7 +727,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/metal06.tga
+map textures/pad_backyard/metal06
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -741,11 +741,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/Metal01.tga
+map textures/pad_backyard/Metal01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-}  
+}
 
 textures/pad_backyard/Metal2
 {
@@ -755,11 +755,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/Metal2.tga
+map textures/pad_backyard/Metal2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_backyard/rau
 {
@@ -769,12 +769,12 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_backyard/rau.tga
+map textures/pad_backyard/rau
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
- 
+}
+
 
 
 textures/pad_cabin/darkrost
@@ -785,11 +785,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/darkrost.tga
+map textures/pad_cabin/darkrost
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_cabin/metal
@@ -800,11 +800,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/metal.tga
+map textures/pad_cabin/metal
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_cabin/metal1
 {
@@ -814,7 +814,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/metal1.tga
+map textures/pad_cabin/metal1
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -828,11 +828,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/metall.tga
+map textures/pad_cabin/metall
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-}  
+}
 
 
 textures/pad_cabin/rost001
@@ -843,7 +843,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/rost001.tga
+map textures/pad_cabin/rost001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -857,7 +857,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/fensterbank.tga
+map textures/pad_cabin/fensterbank
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -871,11 +871,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/wood0a.tga
+map textures/pad_cabin/wood0a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-}    
+}
 
 textures/pad_cabin/wood0b
 {
@@ -885,11 +885,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/wood0b.tga
+map textures/pad_cabin/wood0b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-}   
+}
 
 textures/pad_cabin/wood0c
 {
@@ -899,11 +899,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/wood0c.tga
+map textures/pad_cabin/wood0c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-}  
+}
 
 textures/pad_cabin/wood0d
 {
@@ -913,11 +913,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_cabin/wood0d.tga
+map textures/pad_cabin/wood0d
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-}    
+}
 
 textures/pad_glow/wallcol016
 {
@@ -927,11 +927,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_glow/wallcol016.tga
+map textures/pad_glow/wallcol016
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_glow/wallcol017
 {
@@ -941,23 +941,23 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_glow/wallcol017.tga
+map textures/pad_glow/wallcol017
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_glowsky/glowscreen
 {
-	q3map_lightimage textures/pad_glowsky/glowscreen.tga
+	q3map_lightimage textures/pad_glowsky/glowscreen
 	q3map_surfacelight 20
 
         {
-		map textures/pad_glowsky/glowscreen.tga
+		map textures/pad_glowsky/glowscreen
 		rgbGen identity
 	}
-	
-       
+
+
 	{
 		map $lightmap
 		tcgen environment
@@ -970,19 +970,19 @@ textures/pad_glowsky/glowscreen
 
 textures/pad_glow/metal_old
 {
-	qer_editorimage textures/pad_glow/metal_old.tga
-	
+	qer_editorimage textures/pad_glow/metal_old
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_glow/metal_old.tga
+		map textures/pad_glow/metal_old
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity

--- a/wop/scripts.pk3dir/scripts/pad_harm.shader
+++ b/wop/scripts.pk3dir/scripts/pad_harm.shader
@@ -10,7 +10,7 @@ textures/pad_gfx/harmvorhang
 	deformVertexes wave 100 sin 0 3 0 0.7
 	tessSize 80
 	{
-		map textures/pad_gfx/harmvorhang.tga
+		map textures/pad_gfx/harmvorhang
 		rgbGen Vertex
 		depthWrite
 		//blendfunc add //durchsichtig !?
@@ -30,7 +30,7 @@ textures/pad_harm/vorhang
 	deformVertexes wave 100 sin 0 3 0 0.7
 	tessSize 80
 	{
-		map textures/pad_harm/vorhang.tga
+		map textures/pad_harm/vorhang
 		rgbGen Vertex
 		depthWrite
 		//blendfunc add //durchsichtig !?
@@ -45,9 +45,9 @@ textures/pad_harm/vorhang
 //Green Gummy :)
 textures/pad_harm/green
 {
-	qer_editorimage textures/pad_harm/green.tga
+	qer_editorimage textures/pad_harm/green
 	{
-                map textures/pad_harm/green.tga
+                map textures/pad_harm/green
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
         }
@@ -57,9 +57,9 @@ textures/pad_harm/green
 //Red Gummy :)
 textures/pad_harm/red
 {
-	qer_editorimage textures/pad_harm/red.tga
+	qer_editorimage textures/pad_harm/red
 	{
-                map textures/pad_harm/red.tga
+                map textures/pad_harm/red
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
         }
@@ -69,9 +69,9 @@ textures/pad_harm/red
 //Yellow Gummy :)
 textures/pad_harm/yellow
 {
-	qer_editorimage textures/pad_harm/yellow.tga
+	qer_editorimage textures/pad_harm/yellow
 	{
-                map textures/pad_harm/yellow.tga
+                map textures/pad_harm/yellow
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
         }
@@ -82,9 +82,9 @@ textures/pad_harm/yellow
 //Orange Gummy :)
 textures/pad_harm/orange
 {
-	qer_editorimage textures/pad_harm/orange.tga
+	qer_editorimage textures/pad_harm/orange
 	{
-                map textures/pad_harm/orange.tga
+                map textures/pad_harm/orange
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
         }
@@ -97,14 +97,14 @@ textures/pad_harm/orange
 //=======================================================
 textures/pad_harm/metal06x
 {
-	qer_editorimage textures/pad_harm/metal06x.tga
+	qer_editorimage textures/pad_harm/metal06x
 	surfaceparm metalsteps
 	{
-		map textures/pad_harm/metal06x.tga
+		map textures/pad_harm/metal06x
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -121,15 +121,15 @@ textures/pad_harm/metal06x
 
 textures/pad_harm/metal06x2
 {
-	qer_editorimage textures/pad_harm/metal06x2.tga
+	qer_editorimage textures/pad_harm/metal06x2
 	surfaceparm nonsolid
 	surfaceparm metalsteps
 	{
-		map textures/pad_harm/metal06x2.tga
+		map textures/pad_harm/metal06x2
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -145,13 +145,13 @@ textures/pad_harm/metal06bnew
 {
     surfaceparm metalsteps
     surfaceparm nonsolid
-	qer_editorimage textures/pad_harm/metal06bnew.tga
+	qer_editorimage textures/pad_harm/metal06bnew
 	{
-		map textures/pad_harm/metal06bnew.tga
+		map textures/pad_harm/metal06bnew
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -175,7 +175,7 @@ textures/pad_harm/closed
     surfaceparm nonsolid
     cull disable
     {
-        map textures/pad_harm/closed.tga
+        map textures/pad_harm/closed
         blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
         RgbGen identityLighting
     }
@@ -189,7 +189,7 @@ textures/pad_harm/nocigs
     surfaceparm nonsolid
     cull disable
     {
-        map textures/pad_harm/nocigs.tga
+        map textures/pad_harm/nocigs
         blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
         RgbGen identityLighting
     }
@@ -204,7 +204,7 @@ textures/pad_harm/open_neon
     surfaceparm nonsolid
     cull disable
     {
-        map textures/pad_harm/open_neon.tga
+        map textures/pad_harm/open_neon
         blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
         RgbGen identityLighting
     }
@@ -219,7 +219,7 @@ textures/pad_harm/route66
     surfaceparm nonsolid
     cull disable
     {
-        map textures/pad_harm/route66.tga
+        map textures/pad_harm/route66
         blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
         RgbGen identityLighting
     }
@@ -232,15 +232,15 @@ textures/pad_harm/route66
 
 textures/pad_harm/pad_harm01
 {
-	q3map_lightimage textures/pad_harm/pad_harm01.tga
+	q3map_lightimage textures/pad_harm/pad_harm01
 	q3map_surfacelight 100
 
 	{
-		map textures/pad_harm/pad_harm01.tga
+		map textures/pad_harm/pad_harm01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/comp_line.tga
+		map textures/pad_gfx02/comp_line
 		blendfunc add
 		rgbGen identity
 		tcmod scroll 0 1
@@ -267,7 +267,7 @@ textures/pad_harm/pad_harm01
 
 textures/pad_harm/color24x
 {
-	qer_editorimage textures/pad_harm/color24x.tga
+	qer_editorimage textures/pad_harm/color24x
     surfaceparm trans
 	cull none
 	surfaceparm nolightmap
@@ -275,7 +275,7 @@ textures/pad_harm/color24x
     q3map_surfacelight 10
 
         {
-		map textures/pad_harm/color24x.tga
+		map textures/pad_harm/color24x
         tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -295,7 +295,7 @@ textures/pad_harm/color24x
 
 textures/pad_harm/milchflare
 {
-	qer_editorimage textures/pad_harm/milchflare.tga
+	qer_editorimage textures/pad_harm/milchflare
     surfaceparm trans
 	cull none
 	surfaceparm nolightmap
@@ -304,7 +304,7 @@ textures/pad_harm/milchflare
         q3map_flareShader flareShader
 
         {
-		map textures/pad_harm/milchflare.tga
+		map textures/pad_harm/milchflare
         tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -324,12 +324,12 @@ textures/pad_harm/milchflare
 
 textures/pad_harm/rubber_chick
 {
-	qer_editorimage textures/pad_harm/rubber_chick.tga
+	qer_editorimage textures/pad_harm/rubber_chick
     surfaceparm trans
     q3map_surfacelight 10
 
 	{
-		map textures/pad_harm/rubber_chick.tga
+		map textures/pad_harm/rubber_chick
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbgen vertex
 		depthWrite
@@ -349,14 +349,14 @@ textures/pad_harm/glow01
      	nomipmaps
 
 	{
-		clampmap textures/pad_harm/glow01.tga
+		clampmap textures/pad_harm/glow01
 		blendfunc gl_one gl_one
 		tcMod stretch sawtooth 1 -.9 .5 1.2
 		tcMod rotate 10
 		rgbGen wave sawtooth .5 .5 .25 1.2
 	}
 	{
-		clampmap textures/pad_harm/glow01.tga
+		clampmap textures/pad_harm/glow01
 		blendfunc gl_one gl_one
 		tcMod stretch sawtooth 1 -.9 .5 1.3
 		tcMod rotate -50
@@ -377,7 +377,7 @@ textures/pad_harm/lighty
     surfaceparm nolightmap
     q3map_styleMarker
     {
-        map textures/pad_harm/lighty.tga
+        map textures/pad_harm/lighty
     }
 }
 
@@ -393,7 +393,7 @@ textures/pad_floorin/col04extra
         rgbGen identity
      }
      {
-        map textures/pad_floorin/col04extra.tga
+        map textures/pad_floorin/col04extra
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -407,7 +407,7 @@ textures/pad_harm/woodnew
         rgbGen identity
      }
      {
-        map textures/pad_harm/woodnew.tga
+        map textures/pad_harm/woodnew
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -422,7 +422,7 @@ textures/pad_harm/metal
         rgbGen identity
      }
      {
-        map textures/pad_harm/metal.tga
+        map textures/pad_harm/metal
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -436,7 +436,7 @@ textures/pad_harm/metal06x2
         rgbGen identity
      }
      {
-        map textures/pad_harm/metal06x2.tga
+        map textures/pad_harm/metal06x2
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -450,7 +450,7 @@ textures/pad_harm/sitzbank01b
         rgbGen identity
      }
      {
-        map textures/pad_harm/sitzbank01b.jpg.tga
+        map textures/pad_harm/sitzbank01b
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -464,7 +464,7 @@ textures/pad_harm/sitzbank01b_black
         rgbGen identity
      }
      {
-        map textures/pad_harm/sitzbank01b_black.tga
+        map textures/pad_harm/sitzbank01b_black
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -478,7 +478,7 @@ textures/pad_harm/sitzbank01b_white
         rgbGen identity
      }
      {
-        map textures/pad_harm/sitzbank01b_white.tga
+        map textures/pad_harm/sitzbank01b_white
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -493,7 +493,7 @@ textures/pad_harm/sitzup
         rgbGen identity
      }
      {
-        map textures/pad_harm/sitzup.tga
+        map textures/pad_harm/sitzup
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -507,7 +507,7 @@ textures/pad_harm/fensterbank
         rgbGen identity
      }
      {
-        map textures/pad_harm/fensterbank.tga
+        map textures/pad_harm/fensterbank
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -521,7 +521,7 @@ textures/pad_harm/fussmatte
         rgbGen identity
      }
      {
-        map textures/pad_harm/fussmatte.tga
+        map textures/pad_harm/fussmatte
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -535,7 +535,7 @@ textures/pad_harm/table01
         rgbGen identity
      }
      {
-        map textures/pad_harm/table01.tga
+        map textures/pad_harm/table01
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -549,7 +549,7 @@ textures/pad_harm/wallcol002b
         rgbGen identity
      }
      {
-        map textures/pad_harm/wallcol002b.tga
+        map textures/pad_harm/wallcol002b
         blendFunc GL_DST_COLOR GL_ZERO
         rgbGen identity
      }
@@ -564,7 +564,7 @@ textures/pad_harm/warpkern
 {
 	deformVertexes wave 300 sin 3 0 0 0
 	{
-		map textures/pad_harm/warpkern.jpg
+		map textures/pad_harm/warpkern
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 tcmod rotate 40
@@ -579,7 +579,7 @@ textures/pad_harm/warpkern
 
 textures/pad_harm/water
 {
-   qer_editorimage textures/pad_harm/water.tga
+   qer_editorimage textures/pad_harm/water
    surfaceparm nodraw
    surfaceparm noimpact
    surfaceparm nolightmap
@@ -596,11 +596,11 @@ textures/pad_harm/water
 textures/pad_harm/padtele_white
 {
 	cull none
-	q3map_lightimage textures/pad_harm/padtele_white.tga
+	q3map_lightimage textures/pad_harm/padtele_white
 	q3map_surfacelight 100
 
 	{
-		map textures/pad_harm/padtele_electric_white.tga
+		map textures/pad_harm/padtele_electric_white
 		blendfunc add
 		rgbGen wave square .25 .25 0 2.5
 		tcmod scale 1 1
@@ -610,7 +610,7 @@ textures/pad_harm/padtele_white
 
 
 	{
-		map textures/pad_harm/padtele_white.tga
+		map textures/pad_harm/padtele_white
 		blendfunc add
 		rgbgen wave square 0 1 0 3
 		tcmod scale 1 1
@@ -625,7 +625,7 @@ textures/pad_harm/padtele_white
 
 textures/pad_harm/bubbles2_1
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -635,7 +635,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.093287 -41.198784 111.500214 sawtooth 0 1 1.000725 0.195925
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 20.229958
 AlphaGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
 rgbGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
@@ -646,7 +646,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_2
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -656,7 +656,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.769913 -21.519264 139.001572 sawtooth 0 1 0.622631 0.252309
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 2.200842
 AlphaGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
 rgbGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
@@ -667,7 +667,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_3
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -677,7 +677,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.625161 -6.980746 57.586830 sawtooth 0 1 1.213530 0.445164
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 19.405041
 AlphaGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
 rgbGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
@@ -688,7 +688,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_4
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -698,7 +698,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.668365 -12.663155 79.066895 sawtooth 0 1 1.085688 0.300365
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 11.414990
 AlphaGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
 rgbGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
@@ -709,7 +709,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_5
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -719,7 +719,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.763139 -30.482132 121.611313 sawtooth 0 1 0.288759 0.189146
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 1.619465
 AlphaGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
 rgbGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
@@ -730,7 +730,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_6
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -740,7 +740,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.834942 -10.679131 70.490509 sawtooth 0 1 1.237915 0.365962
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate -2.907956
 AlphaGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
 rgbGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
@@ -751,7 +751,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_7
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -761,7 +761,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.454388 -41.883984 97.730408 sawtooth 0 1 0.402287 0.207241
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 3.890042
 AlphaGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
 rgbGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
@@ -772,7 +772,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_8
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -782,7 +782,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.112141 -36.627399 86.117142 sawtooth 0 1 0.784623 0.218790
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 24.587999
 AlphaGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
 rgbGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
@@ -793,7 +793,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_9
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -803,7 +803,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 13.988351 -11.087501 73.268707 sawtooth 0 1 1.044519 0.235235
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 12.468795
 AlphaGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
 rgbGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
@@ -814,7 +814,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_10
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -824,7 +824,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 10.265741 7.714635 101.291351 sawtooth 0 1 0.524331 0.144779
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 12.796563
 AlphaGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
 rgbGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
@@ -835,7 +835,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_11
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -845,7 +845,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 25.100649 4.780672 126.159500 sawtooth 0 1 0.907308 0.255448
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate 16.214331
 AlphaGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
 rgbGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
@@ -856,7 +856,7 @@ blendfunc add
 
 textures/pad_harm/bubbles2_12
 {
-qer_editorimage textures/pad_harm/bubbles2.tga
+qer_editorimage textures/pad_harm/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -866,7 +866,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 12.983425 -1.691125 65.949432 sawtooth 0 1 0.845538 0.495670
 {
-clampmap textures/pad_harm/bubbles2.tga
+clampmap textures/pad_harm/bubbles2
 tcMod rotate -2.724845
 AlphaGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
 rgbGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
@@ -884,13 +884,13 @@ textures/pad_harm/sand002
 q3map_nonplanar
 q3map_shadeangle 60
 surfaceparm sandsteps
-qer_editorimage textures/pad_harm/sand002.tga
+qer_editorimage textures/pad_harm/sand002
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_harm/sand002.tga
+map textures/pad_harm/sand002
 blendFunc filter
 }
 }
@@ -905,13 +905,13 @@ textures/pad_objects02/haribo4
 q3map_nonplanar
 q3map_shadeangle 120
 surfaceparm sandsteps
-qer_editorimage textures/pad_objects02/haribo4.tga
+qer_editorimage textures/pad_objects02/haribo4
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_objects02/haribo4.tga
+map textures/pad_objects02/haribo4
 blendFunc filter
 }
 }
@@ -922,13 +922,13 @@ blendFunc filter
 
 textures/pad_poster/gummibaer
 {
-	qer_editorimage textures/pad_poster/gummibaer.tga
+	qer_editorimage textures/pad_poster/gummibaer
 	{
-		map textures/pad_poster/gummibaer.tga
+		map textures/pad_poster/gummibaer
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -942,13 +942,13 @@ textures/pad_poster/gummibaer
 
 textures/pad_harm/girlass03
 {
-	qer_editorimage textures/pad_harm/girlass03.tga
+	qer_editorimage textures/pad_harm/girlass03
 	{
-		map textures/pad_harm/girlass03.tga
+		map textures/pad_harm/girlass03
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -962,13 +962,13 @@ textures/pad_harm/girlass03
 
 textures/pad_poster/poster004
 {
-	qer_editorimage textures/pad_poster/poster004.tga
+	qer_editorimage textures/pad_poster/poster004
 	{
-		map textures/pad_poster/poster004.tga
+		map textures/pad_poster/poster004
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -982,13 +982,13 @@ textures/pad_poster/poster004
 
 textures/pad_poster/poster001
 {
-	qer_editorimage textures/pad_poster/poster001.tga
+	qer_editorimage textures/pad_poster/poster001
 	{
-		map textures/pad_poster/poster001.tga
+		map textures/pad_poster/poster001
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -1002,13 +1002,13 @@ textures/pad_poster/poster001
 
 textures/pad_poster/poster002
 {
-	qer_editorimage textures/pad_poster/poster002.tga
+	qer_editorimage textures/pad_poster/poster002
 	{
-		map textures/pad_poster/poster002.tga
+		map textures/pad_poster/poster002
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -1022,13 +1022,13 @@ textures/pad_poster/poster002
 
 textures/pad_harm/gold_haley
 {
-	qer_editorimage textures/pad_harm/gold_haley.tga
+	qer_editorimage textures/pad_harm/gold_haley
 	{
-		map textures/pad_harm/gold_haley.tga
+		map textures/pad_harm/gold_haley
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -1042,13 +1042,13 @@ textures/pad_harm/gold_haley
 
 textures/pad_harm/gold_buddy
 {
-	qer_editorimage textures/pad_harm/gold_buddy.tga
+	qer_editorimage textures/pad_harm/gold_buddy
 	{
-		map textures/pad_harm/gold_buddy.tga
+		map textures/pad_harm/gold_buddy
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -1062,13 +1062,13 @@ textures/pad_harm/gold_buddy
 
 textures/pad_harm/gold_elvis
 {
-	qer_editorimage textures/pad_harm/gold_elvis.tga
+	qer_editorimage textures/pad_harm/gold_elvis
 	{
-		map textures/pad_harm/gold_elvis.tga
+		map textures/pad_harm/gold_elvis
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -1082,13 +1082,13 @@ textures/pad_harm/gold_elvis
 
 textures/pad_harm/gold_monroe
 {
-	qer_editorimage textures/pad_harm/gold_monroe.tga
+	qer_editorimage textures/pad_harm/gold_monroe
 	{
-		map textures/pad_harm/gold_monroe.tga
+		map textures/pad_harm/gold_monroe
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
 		tcGen environment
@@ -1107,18 +1107,18 @@ textures/pad_harm/gold_monroe
 
 textures/pad_harmsky/padcity
 {
-        qer_editorimage textures/pad_harmsky/padcity.tga
+        qer_editorimage textures/pad_harmsky/padcity
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/white.tga
+        q3map_lightimage textures/pad_petesky/white
 	q3map_sun	0.266383 0.274632 0.358662 100 50 55
 	q3map_surfacelight 100
 
         skyparms env/padcity512 - -
 //       {
-//		map textures/pad_petesky/padcity.tga
+//		map textures/pad_petesky/padcity
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -1129,18 +1129,18 @@ textures/pad_harmsky/padcity
 
 textures/pad_harmsky/morning-madness
 {
-        qer_editorimage textures/pad_harmsky/morning-madness.tga
+        qer_editorimage textures/pad_harmsky/morning-madness
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/orange02.tga
+        q3map_lightimage textures/pad_petesky/orange02
 	q3map_sun	0.368 -0.886 0.258 100 50 55
 	q3map_surfacelight 600
 
         skyparms env/pc-morning-madness512 - -
 //       {
-//		map textures/pad_petesky/morning-madness.tga
+//		map textures/pad_petesky/morning-madness
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -1149,18 +1149,18 @@ textures/pad_harmsky/morning-madness
 
 textures/pad_harmsky/harmnight-life
 {
-        qer_editorimage textures/pad_harmsky/harmnight-life.tga
+        qer_editorimage textures/pad_harmsky/harmnight-life
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/white02.tga
+        q3map_lightimage textures/pad_petesky/white02
 	q3map_sun	0.266383 0.274632 0.358662 50 50 55
 	q3map_surfacelight 50
 
         skyparms env/pc-night-life512 - -
 //       {
-//		map textures/pad_petesky/night-life.tga
+//		map textures/pad_petesky/night-life
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -1170,18 +1170,18 @@ textures/pad_harmsky/harmnight-life
 
 textures/pad_harmsky/harmpc-ground-zero512
 {
-        qer_editorimage textures/pad_harmsky/harmpc-ground-zero512.tga
+        qer_editorimage textures/pad_harmsky/harmpc-ground-zero512
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_petesky/white02.tga
+        q3map_lightimage textures/pad_petesky/white02
 	q3map_sun	0.266383 0.274632 0.358662 20 50 55
 	q3map_surfacelight 10
 
         skyparms env/pc-ground-zero512 - -
 //       {
-//		map textures/pad_petesky/pc-ground-zero512.tga
+//		map textures/pad_petesky/pc-ground-zero512
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -1198,11 +1198,11 @@ textures/pad_harmsky/harmpc-ground-zero512
 
 textures/pad_harm/blend
 {
-	qer_editorimage textures/pad_harm/Floor008mirror.tga
+	qer_editorimage textures/pad_harm/Floor008mirror
 	surfaceparm nolightmap
 	portal
 	{
-		map textures/pad_harm/Floor008mirror.tga
+		map textures/pad_harm/Floor008mirror
 		blendfunc blend
 		depthWrite
 	}
@@ -1210,11 +1210,11 @@ textures/pad_harm/blend
 
 textures/pad_harm/add
 {
-	qer_editorimage textures/pad_harm/Floor008mirror.tga
+	qer_editorimage textures/pad_harm/Floor008mirror
 	surfaceparm nolightmap
 	portal
 	{
-		map textures/pad_harm/Floor008mirror.tga
+		map textures/pad_harm/Floor008mirror
 		blendfunc add
 		depthWrite
 	}
@@ -1222,11 +1222,11 @@ textures/pad_harm/add
 
 textures/pad_harm/filter
 {
-	qer_editorimage textures/pad_harm/Floor008mirror.tga
+	qer_editorimage textures/pad_harm/Floor008mirror
 	surfaceparm nolightmap
 	portal
 	{
-		map textures/pad_harm/Floor008mirror.tga
+		map textures/pad_harm/Floor008mirror
 		blendfunc filter
 		depthWrite
 	}

--- a/wop/scripts.pk3dir/scripts/pad_harmwestern.shader
+++ b/wop/scripts.pk3dir/scripts/pad_harmwestern.shader
@@ -1,6 +1,6 @@
 textures/pad_western/boden01
 {
-   qer_editorimage textures/pad_western/boden01.tga
+   qer_editorimage textures/pad_western/boden01
    surfaceparm sandsteps
 
    q3map_nonplanar
@@ -12,11 +12,11 @@ textures/pad_western/boden01
    q3map_alphaMod dotproduct2 ( 0.0 0.0 0.75 )
    q3map_lightmapSampleSize 16
   {
-     map textures/pad_western/boden01.tga   // Primary
+     map textures/pad_western/boden01   // Primary
      rgbGen identity
   }
   {
-     map textures/pad_western/boden02.tga   // Secondary
+     map textures/pad_western/boden02   // Secondary
      blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
      //alphaFunc GE128
      rgbGen identity
@@ -115,7 +115,7 @@ textures/pad_harm/utopiaatoll512_ft
     q3map_surfacelight 150
     surfaceparm nolightmap
     {
-        map textures/pad_harm/utopiaatoll512_ft.tga
+        map textures/pad_harm/utopiaatoll512_ft
     }
 }
 
@@ -124,7 +124,7 @@ textures/pad_harm/utopiaatoll512_lf
     q3map_surfacelight 150
     surfaceparm nolightmap
     {
-        map textures/pad_harm/utopiaatoll512_lf.tga
+        map textures/pad_harm/utopiaatoll512_lf
     }
 }
 
@@ -139,7 +139,7 @@ textures/pad_harm/notausgang
     q3map_surfacelight 300
     surfaceparm nolightmap
     {
-        map textures/pad_harm/notausgang.tga
+        map textures/pad_harm/notausgang
     }
 }
 
@@ -149,7 +149,7 @@ textures/pad_harm/notausganglight
     q3map_surfacelight 300
     surfaceparm nolightmap
     {
-        map textures/pad_harm/notausganglight.tga
+        map textures/pad_harm/notausganglight
     }
 }
 
@@ -164,7 +164,7 @@ textures/pad_western/studioa
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_western/studioa.tga
+		map textures/pad_western/studioa
                	blendFunc blend
 		rgbGen vertex
 	}
@@ -177,7 +177,7 @@ textures/pad_western/studiob
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_western/studiob.tga
+		map textures/pad_western/studiob
                	blendFunc blend
 		rgbGen vertex
 	}
@@ -190,7 +190,7 @@ textures/pad_western/dressingroom
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_western/dressingroom.tga
+		map textures/pad_western/dressingroom
                	blendFunc blend
 		rgbGen vertex
 	}
@@ -203,7 +203,7 @@ textures/pad_western/djdick
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_western/djdick.tga
+		map textures/pad_western/djdick
                	blendFunc blend
 		rgbGen vertex
 	}
@@ -216,7 +216,7 @@ textures/pad_western/westernmovie
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_western/westernmovie.tga
+		map textures/pad_western/westernmovie
                	blendFunc blend
 		rgbGen vertex
 	}

--- a/wop/scripts.pk3dir/scripts/pad_jail.shader
+++ b/wop/scripts.pk3dir/scripts/pad_jail.shader
@@ -1,19 +1,19 @@
 // ********************************************************
 // *
-// *   MopAn's Jail:  Pocket Lamp  
+// *   MopAn's Jail:  Pocket Lamp
 // *
 // ********************************************************
 textures/pad_jail/pad_jail2_tlampe
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail2_tlampe.tga
+		map textures/pad_jail/pad_jail2_tlampe
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -27,12 +27,12 @@ textures/pad_jail/pad_jail2_tlampe
 
 // ********************************************************
 // *
-// *   MopAn's Jail:  Playcards and fotos  
+// *   MopAn's Jail:  Playcards and fotos
 // *
 // ********************************************************
 textures/pad_jail/pad_jail2_herz_koenig
 {
-        qer_editorimage textures/pad_jail/pad_jail2_herz_koenig.tga
+        qer_editorimage textures/pad_jail/pad_jail2_herz_koenig
         surfaceparm trans
         surfaceparm alphashadow
         surfaceparm playerclip
@@ -40,7 +40,7 @@ textures/pad_jail/pad_jail2_herz_koenig
         cull none
         nopicmip
 	{
-		map textures/pad_jail/pad_jail2_herz_koenig.tga
+		map textures/pad_jail/pad_jail2_herz_koenig
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -56,7 +56,7 @@ textures/pad_jail/pad_jail2_herz_koenig
 
 textures/pad_jail/pad_jail2_pik_bube
 {
-        qer_editorimage textures/pad_jail/pad_jail2_pik_bube.tga
+        qer_editorimage textures/pad_jail/pad_jail2_pik_bube
         surfaceparm trans
         surfaceparm alphashadow
         surfaceparm playerclip
@@ -64,7 +64,7 @@ textures/pad_jail/pad_jail2_pik_bube
         cull none
         nopicmip
 	{
-		map textures/pad_jail/pad_jail2_pik_bube.tga
+		map textures/pad_jail/pad_jail2_pik_bube
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -80,7 +80,7 @@ textures/pad_jail/pad_jail2_pik_bube
 
 textures/pad_jail/pad_jail2_pik_dame
 {
-        qer_editorimage textures/pad_jail/pad_jail2_pik_dame.tga
+        qer_editorimage textures/pad_jail/pad_jail2_pik_dame
         surfaceparm trans
         surfaceparm alphashadow
         surfaceparm playerclip
@@ -88,7 +88,7 @@ textures/pad_jail/pad_jail2_pik_dame
         cull none
         nopicmip
 	{
-		map textures/pad_jail/pad_jail2_pik_dame.tga
+		map textures/pad_jail/pad_jail2_pik_dame
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -110,7 +110,7 @@ textures/pad_jail/pad_jail2_pik_dame
 
 textures/pad_jail/pad_jail2_notrespas
 {
-        qer_editorimage textures/pad_jail/pad_jail2_notrespas.tga
+        qer_editorimage textures/pad_jail/pad_jail2_notrespas
         surfaceparm trans
         surfaceparm alphashadow
         surfaceparm playerclip
@@ -118,7 +118,7 @@ textures/pad_jail/pad_jail2_notrespas
         cull none
         nopicmip
 	{
-		map textures/pad_jail/pad_jail2_notrespas.tga
+		map textures/pad_jail/pad_jail2_notrespas
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -134,12 +134,12 @@ textures/pad_jail/pad_jail2_notrespas
 
 // ********************************************************
 // *
-// *   MopAn's Jail:  Smoke for flame  
+// *   MopAn's Jail:  Smoke for flame
 // *
 // ********************************************************
 textures/pad_jail/jail2_particle_smoke_1
 {
-qer_editorimage textures/pad_jail/jail2_particle_smoke.tga
+qer_editorimage textures/pad_jail/jail2_particle_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -149,7 +149,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 10.166071 11.198917 62.942745 sawtooth 0 1 0.121937 0.227738
 {
-clampmap textures/pad_jail/jail2_particle_smoke.tga
+clampmap textures/pad_jail/jail2_particle_smoke
 tcMod rotate 5.604267
 AlphaGen wave sawtooth 0.319630 -0.219630 0.121937 0.227738
 rgbGen wave sawtooth 0.463366 -0.363366 0.121937 0.227738
@@ -160,7 +160,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_smoke_2
 {
-qer_editorimage textures/pad_jail/jail2_particle_smoke.tga
+qer_editorimage textures/pad_jail/jail2_particle_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -170,7 +170,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.046631 -1.555318 55.872883 sawtooth 0 1 0.386862 0.233563
 {
-clampmap textures/pad_jail/jail2_particle_smoke.tga
+clampmap textures/pad_jail/jail2_particle_smoke
 tcMod rotate 8.344829
 AlphaGen wave sawtooth 0.319910 -0.219910 0.386862 0.233563
 rgbGen wave sawtooth 0.404959 -0.304959 0.386862 0.233563
@@ -181,7 +181,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_smoke_3
 {
-qer_editorimage textures/pad_jail/jail2_particle_smoke.tga
+qer_editorimage textures/pad_jail/jail2_particle_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -191,7 +191,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.571293 0.980481 50.410496 sawtooth 0 1 0.484167 0.227243
 {
-clampmap textures/pad_jail/jail2_particle_smoke.tga
+clampmap textures/pad_jail/jail2_particle_smoke
 tcMod rotate 21.780907
 AlphaGen wave sawtooth 0.448894 -0.348894 0.484167 0.227243
 rgbGen wave sawtooth 0.414078 -0.314078 0.484167 0.227243
@@ -202,7 +202,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_smoke_4
 {
-qer_editorimage textures/pad_jail/jail2_particle_smoke.tga
+qer_editorimage textures/pad_jail/jail2_particle_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -212,7 +212,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.342040 -8.377625 51.995224 sawtooth 0 1 0.388644 0.232534
 {
-clampmap textures/pad_jail/jail2_particle_smoke.tga
+clampmap textures/pad_jail/jail2_particle_smoke
 tcMod rotate 13.214972
 AlphaGen wave sawtooth 0.423014 -0.323014 0.388644 0.232534
 rgbGen wave sawtooth 0.322834 -0.222834 0.388644 0.232534
@@ -224,12 +224,12 @@ blendfunc add
 
 // ********************************************************
 // *
-// *   MopAn's Jail:  flame small (little above original big flames)  
+// *   MopAn's Jail:  flame small (little above original big flames)
 // *
 // ********************************************************
 textures/pad_jail/jail2_particle_flame_small_1
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -239,7 +239,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.104041 -0.987807 21.640051 sawtooth 0 1 0.907599 0.249029
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 2.119053
 AlphaGen wave sawtooth 0.543016 -0.384780 0.907599 0.249029
 rgbGen wave sawtooth 0.000000 0.154805 0.907599 0.249029
@@ -250,7 +250,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_small_2
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -260,7 +260,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.176399 -0.192010 3.166808 sawtooth 0 1 0.793765 0.333036
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 1.164556
 AlphaGen wave sawtooth 0.573009 -0.311682 0.793765 0.333036
 rgbGen wave sawtooth 0.000000 0.107294 0.793765 0.333036
@@ -271,7 +271,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_small_3
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -281,7 +281,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.059288 -0.439767 15.001798 sawtooth 0 1 1.000803 0.241049
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 2.132603
 AlphaGen wave sawtooth 0.420917 -0.257897 1.000803 0.241049
 rgbGen wave sawtooth 0.000000 0.159481 1.000803 0.241049
@@ -292,7 +292,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_small_4
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -302,7 +302,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.507019 0.002786 38.652100 sawtooth 0 1 0.967501 0.234538
 {
-clampmap textures/pad_jail/jail2_particle_flame_red2.tga
+clampmap textures/pad_jail/jail2_particle_flame_red2
 tcMod rotate 2.487594
 AlphaGen wave sawtooth 0.586914 -0.411240 0.967501 0.234538
 rgbGen wave sawtooth 0.000000 0.230454 0.967501 0.234538
@@ -313,7 +313,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_small_5
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -323,7 +323,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.700055 -0.292394 10.281649 sawtooth 0 1 0.838847 0.282531
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 1.964568
 AlphaGen wave sawtooth 0.425947 -0.200681 0.838847 0.282531
 rgbGen wave sawtooth 0.000000 0.134816 0.838847 0.282531
@@ -334,7 +334,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_small_6
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -344,7 +344,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.039768 -0.691628 22.183887 sawtooth 0 1 1.011411 0.374374
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 1.950774
 AlphaGen wave sawtooth 0.547581 -0.313172 1.011411 0.374374
 rgbGen wave sawtooth 0.000000 0.138069 1.011411 0.374374
@@ -357,12 +357,12 @@ blendfunc add
 
 // ********************************************************
 // *
-// *   MopAn's Jail:  big flames  
+// *   MopAn's Jail:  big flames
 // *
 // ********************************************************
 textures/pad_jail/jail2_particle_flame_big_1
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -372,7 +372,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.855649 -0.594220 16.804434 sawtooth 0 1 0.614063 0.222318
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.719169
 AlphaGen wave sawtooth 0.829713 -0.515009 0.614063 0.222318
 rgbGen wave sawtooth 0.000000 0.519384 0.614063 0.222318
@@ -383,7 +383,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_2
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -393,7 +393,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.979301 -1.922151 49.622700 sawtooth 0 1 0.990722 0.224923
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 3.676534
 AlphaGen wave sawtooth 0.852253 -0.505115 0.990722 0.224923
 rgbGen wave sawtooth 0.000000 0.429305 0.990722 0.224923
@@ -404,7 +404,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_3
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -414,7 +414,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.466568 -0.073290 26.564932 sawtooth 0 1 0.700912 0.218787
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 3.616169
 AlphaGen wave sawtooth 0.900192 -0.632621 0.700912 0.218787
 rgbGen wave sawtooth 0.000000 0.410036 0.700912 0.218787
@@ -425,7 +425,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_4
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -435,7 +435,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.204901 -1.038951 42.484089 sawtooth 0 1 0.861190 0.222210
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.661550
 AlphaGen wave sawtooth 1.066814 -0.828016 0.861190 0.222210
 rgbGen wave sawtooth 0.000000 0.424880 0.861190 0.222210
@@ -446,7 +446,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_5
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -456,7 +456,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.081736 -0.500316 16.270197 sawtooth 0 1 0.713218 0.219080
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.440290
 AlphaGen wave sawtooth 1.031272 -0.846748 0.713218 0.219080
 rgbGen wave sawtooth 0.000000 0.445755 0.713218 0.219080
@@ -467,7 +467,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_6
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -477,7 +477,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.139118 -1.656225 53.107990 sawtooth 0 1 1.047908 0.209343
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.344890
 AlphaGen wave sawtooth 0.966634 -0.710977 1.047908 0.209343
 rgbGen wave sawtooth 0.000000 0.359961 1.047908 0.209343
@@ -488,7 +488,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_7
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -498,7 +498,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.186446 -0.896679 39.035198 sawtooth 0 1 1.025275 0.206471
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.674123
 AlphaGen wave sawtooth 0.876690 -0.575194 1.025275 0.206471
 rgbGen wave sawtooth 0.000000 0.383851 1.025275 0.206471
@@ -509,7 +509,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_8
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -519,7 +519,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.856490 -0.412961 49.444454 sawtooth 0 1 0.727921 0.225967
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 3.731407
 AlphaGen wave sawtooth 0.931550 -0.762505 0.727921 0.225967
 rgbGen wave sawtooth 0.000000 0.508916 0.727921 0.225967
@@ -530,7 +530,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_9
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -540,7 +540,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.378977 -1.107010 17.809118 sawtooth 0 1 0.673611 0.226183
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.674184
 AlphaGen wave sawtooth 0.790664 -0.509860 0.673611 0.226183
 rgbGen wave sawtooth 0.000000 0.355335 0.673611 0.226183
@@ -551,7 +551,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_10
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -561,7 +561,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.001536 0.003535 -0.106998 sawtooth 0 1 1.044832 0.219511
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.155736
 AlphaGen wave sawtooth 0.789922 -0.559303 1.044832 0.219511
 rgbGen wave sawtooth 0.000000 0.477323 1.044832 0.219511
@@ -572,7 +572,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_11
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -582,7 +582,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.491899 -0.285495 9.005352 sawtooth 0 1 0.936851 0.214816
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.287087
 AlphaGen wave sawtooth 0.923740 -0.775533 0.936851 0.214816
 rgbGen wave sawtooth 0.000000 0.364350 0.936851 0.214816
@@ -593,7 +593,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_12
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -603,7 +603,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.570885 -0.648670 13.179045 sawtooth 0 1 0.877999 0.223266
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 3.173528
 AlphaGen wave sawtooth 0.783706 -0.457661 0.877999 0.223266
 rgbGen wave sawtooth 0.000000 0.519976 0.877999 0.223266
@@ -614,7 +614,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_13
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -624,7 +624,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.830791 -1.903828 35.594635 sawtooth 0 1 1.006433 0.220798
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.392498
 AlphaGen wave sawtooth 0.843034 -0.598571 1.006433 0.220798
 rgbGen wave sawtooth 0.000000 0.365387 1.006433 0.220798
@@ -635,7 +635,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_14
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -645,7 +645,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.077821 0.002449 1.788899 sawtooth 0 1 0.761577 0.214307
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 3.703635
 AlphaGen wave sawtooth 0.860970 -0.579250 0.761577 0.214307
 rgbGen wave sawtooth 0.000000 0.410421 0.761577 0.214307
@@ -656,7 +656,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_15
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -666,7 +666,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.793900 -1.750969 29.973316 sawtooth 0 1 0.849580 0.219915
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 4.232582
 AlphaGen wave sawtooth 0.907983 -0.740013 0.849580 0.219915
 rgbGen wave sawtooth 0.000000 0.513353 0.849580 0.219915
@@ -677,7 +677,7 @@ blendfunc add
 
 textures/pad_jail/jail2_particle_flame_big_16
 {
-qer_editorimage textures/pad_jail/jail2_particle_flame_red.tga
+qer_editorimage textures/pad_jail/jail2_particle_flame_red
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -687,7 +687,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.976570 -0.946683 35.304443 sawtooth 0 1 0.895102 0.219551
 {
-clampmap textures/pad_jail/jail2_particle_flame_red.tga
+clampmap textures/pad_jail/jail2_particle_flame_red
 tcMod rotate 3.026551
 AlphaGen wave sawtooth 0.883153 -0.608697 0.895102 0.219551
 rgbGen wave sawtooth 0.000000 0.435879 0.895102 0.219551
@@ -699,23 +699,23 @@ blendfunc add
 
 // ********************************************************
 // *
-// *   MopAn's Jail:  for flames, base fireball  
+// *   MopAn's Jail:  for flames, base fireball
 // *
 // ********************************************************
 textures/pad_jail/jail2_flameball1
 {
-	qer_editorimage textures/pad_jail/jail2_flameball.tga
+	qer_editorimage textures/pad_jail/jail2_flameball
 	q3map_globaltexture
 	surfaceparm nomarks
 	surfaceparm nolightmap
 	surfaceparm trans
 	cull none
 	deformvertexes autosprite
-	
+
 	{
-		map textures/pad_jail/jail2_flameball.tga
+		map textures/pad_jail/jail2_flameball
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+		rgbGen wave sin .6 .2 0 .6
 	}
 
 }
@@ -723,25 +723,25 @@ textures/pad_jail/jail2_flameball1
 
 // ********************************************************
 // *
-// *   MopAn's Jail:  this is light emitting surface for the key underneath the bed  
+// *   MopAn's Jail:  this is light emitting surface for the key underneath the bed
 // *
 // ********************************************************
 textures/pad_jail/pad_jail_keys_light
 {
-	qer_editorimage textures/pad_jail/pad_jail_keys.tga
-	q3map_lightimage textures/pad_jail/pad_jail_keys.tga
+	qer_editorimage textures/pad_jail/pad_jail_keys
+	q3map_lightimage textures/pad_jail/pad_jail_keys
 	q3map_surfacelight 400
 	light 1
 	//surfaceparm nolightmap
 	surfaceparm trans
 
-	{	
+	{
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	{
-		map textures/pad_jail/pad_jail_keys.tga
+		map textures/pad_jail/pad_jail_keys
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -755,7 +755,7 @@ textures/pad_jail/pad_jail_keys_light
 // ********************************************************
 textures/pad_jail/pad_jail_imp_fog
 {
-		qer_editorimage textures/pad_gfx02b/padfog_green.tga
+		qer_editorimage textures/pad_gfx02b/padfog_green
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -774,8 +774,8 @@ textures/pad_jail/pad_jail_imp_fog
 textures/pad_jail/pad_jail_liquid_gas
 {
 	qer_trans 0.6
-	qer_editorimage textures/pad_jail/pad_jail_liquid_gas.tga
-	q3map_lightimage textures/pad_jail/pad_jail_liquid_gas.tga
+	qer_editorimage textures/pad_jail/pad_jail_liquid_gas
+	q3map_lightimage textures/pad_jail/pad_jail_liquid_gas
         	q3map_surfacelight 180
 	q3map_globaltexture
 	surfaceparm nolightmap
@@ -785,20 +785,20 @@ textures/pad_jail/pad_jail_liquid_gas
 	tessSize 64
 	cull disable
 	deformVertexes wave 100 sin 4 2 .1 0.1
-	
+
 	{
-		map textures/pad_jail/pad_jail_liquid_gas.tga
+		map textures/pad_jail/pad_jail_liquid_gas
 		tcMod turb .3 .2 1 .05
 		tcMod scroll .01 .01
 	}
 	{
-		map textures/pad_jail/pad_jail_liquid_gas.tga
+		map textures/pad_jail/pad_jail_liquid_gas
 		blendfunc GL_ONE GL_ONE
 		tcMod turb .2 .1 1 .05
 		tcMod scale .5 .5
 		tcMod scroll .01 .01
 	}
-		
+
 }
 
 
@@ -814,33 +814,33 @@ textures/pad_jail/pad_jail_zap2
 	surfaceparm nomarks
 	surfaceparm nolightmap
 	cull none
-	
+
 	{
-		map textures/pad_jail/pad_jail_zap2_blend.tga
+		map textures/pad_jail/pad_jail_zap2_blend
 		blendFunc GL_ONE GL_ONE
                 	rgbgen wave triangle .8 2 0 7
                 	tcMod scroll 0 1
-	}	
+	}
         	{
-		map textures/pad_jail/pad_jail_zap2_blend.tga
+		map textures/pad_jail/pad_jail_zap2_blend
 		blendFunc GL_ONE GL_ONE
                 	rgbgen wave triangle 1 1.4 0 5
                 	tcMod scale  -1 1
                 	tcMod scroll 0 1
-	}	
+	}
         	{
-		map textures/pad_jail/pad_jail_zap2.tga
+		map textures/pad_jail/pad_jail_zap2
 		blendFunc GL_ONE GL_ONE
                 	rgbgen wave triangle 1 1.4 0 6.3
                 	tcMod scale  -1 1
                 	tcMod scroll 2 1
-	}	
+	}
          	{
-		map textures/pad_jail/pad_jail_zap2.tga
+		map textures/pad_jail/pad_jail_zap2
 		blendFunc GL_ONE GL_ONE
                 	rgbgen wave triangle 1 1.4 0 7.7
                 	tcMod scroll -1.3 1
-	}	
+	}
 }
 
 
@@ -852,14 +852,14 @@ textures/pad_jail/pad_jail_zap2
 textures/pad_jail/pad_jail_metaltools
 	{
 	q3map_surfacelight 100
-	q3map_lightimage textures/pad_jail/pad_jail_metaltools_blend.tga
-	qer_editorimage textures/pad_jail/pad_jail_metaltools.tga
-	
+	q3map_lightimage textures/pad_jail/pad_jail_metaltools_blend
+	qer_editorimage textures/pad_jail/pad_jail_metaltools
+
 	{
-		map textures/pad_jail/pad_jail_metaltools.tga
+		map textures/pad_jail/pad_jail_metaltools
 		rgbGen identity
 	}
-	
+
 	{
 		map $lightmap
 		rgbGen identity
@@ -868,53 +868,53 @@ textures/pad_jail/pad_jail_metaltools
 
 
 	{
-		map textures/pad_jail/pad_jail_metaltools_blend.tga
+		map textures/pad_jail/pad_jail_metaltools_blend
 		blendfunc gl_one gl_one
 		rgbgen wave sin 0 1 0 .5
 		tcmod scale 1 .05
 		tcmod scroll 0 1
 	}
-	
+
 }
 
 
 // ********************************************************
 // *
-// *   MopAn's Jail:  Beam  
+// *   MopAn's Jail:  Beam
 // *
 // ********************************************************
 textures/pad_jail/pad_jail_beam
 {
-        qer_editorimage textures/pad_jail/pad_jail_beam.tga
-        surfaceparm trans	
-        surfaceparm nomarks	
+        qer_editorimage textures/pad_jail/pad_jail_beam
+        surfaceparm trans
+        surfaceparm nomarks
         surfaceparm nonsolid
         surfaceparm nolightmap
        cull none
        {
-	map textures/pad_jail/pad_jail_beam.tga
+	map textures/pad_jail/pad_jail_beam
                 blendFunc add
         }
 }
 
 // ********************************************************
 // *
-// *   MopAn's Jail:  Dunkelheit  
+// *   MopAn's Jail:  Dunkelheit
 // *
 // ********************************************************
 textures/pad_jail/pad_jail_dunkelheit
-{	
+{
 	surfaceparm nolightmap
 	surfaceparm noimpact
 	surfaceparm nomarks
 	{
-		map textures/pad_jail/pad_jail_dunkelheit.tga
+		map textures/pad_jail/pad_jail_dunkelheit
 	}
 }
 
 // ********************************************************
 // *
-// *   MopAn's Jail:  Pad-Flagge im Sprayroom und Spraytafeln -> by MopAn 
+// *   MopAn's Jail:  Pad-Flagge im Sprayroom und Spraytafeln -> by MopAn
 // *
 // ********************************************************
 textures/pad_jail/jail_padflagred
@@ -925,11 +925,11 @@ textures/pad_jail/jail_padflagred
         surfaceparm nomarks
         cull none
         {
-		map textures/pad_jail/jail_padflagred.tga
+		map textures/pad_jail/jail_padflagred
 		rgbGen identity
 	}
         	{
-		map textures/pad_jail/jail_padflagred.tga
+		map textures/pad_jail/jail_padflagred
                 	blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -939,8 +939,8 @@ textures/pad_jail/jail_padflagred
 		rgbGen identity
 	}
         	{
-        		map textures/pad_jail/jail2_shadow.tga
-                	tcGen environment 
+        		map textures/pad_jail/jail2_shadow
+                	tcGen environment
                                 blendFunc GL_DST_COLOR GL_ZERO
                		rgbGen identity
 	}
@@ -955,7 +955,7 @@ textures/pad_jail/pad_jail2_flagge_blue
 	nomipmaps
 
 	{
-		map textures/pad_jail/pad_jail2_flagge_blue.tga
+		map textures/pad_jail/pad_jail2_flagge_blue
 		rgbgen identity
 		alphaFunc GE128
 		blendFunc GL_ONE GL_ZERO
@@ -979,7 +979,7 @@ textures/pad_jail/pad_jail2_flagge_red
 	nomipmaps
 
 	{
-		map textures/pad_jail/pad_jail2_flagge_red.tga
+		map textures/pad_jail/pad_jail2_flagge_red
 		rgbgen identity
 		alphaFunc GE128
 		blendFunc GL_ONE GL_ZERO
@@ -1002,7 +1002,7 @@ textures/pad_jail/pad_jail2_flagge_red
 
 textures/pad_jail/ice_blue
 {
-	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_iceblue.tga
+	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_iceblue
 	q3map_globaltexture
 	qer_trans 0.6
 	surfaceparm slick
@@ -1011,7 +1011,7 @@ textures/pad_jail/ice_blue
 	surfaceparm nomarks
 	cull twosided
 	{
-		map textures/pad_jail/pad_jail_sprayroom2_iceblue.tga
+		map textures/pad_jail/pad_jail_sprayroom2_iceblue
 		blendfunc add
 		tcMod scale .75 .75
 		rgbgen identity
@@ -1020,7 +1020,7 @@ textures/pad_jail/ice_blue
 
 textures/pad_jail/ice_red
 {
-	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_icered.tga
+	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_icered
 	q3map_globaltexture
 	qer_trans 0.6
 	surfaceparm slick
@@ -1029,7 +1029,7 @@ textures/pad_jail/ice_red
 	surfaceparm nomarks
 	cull twosided
 	{
-		map textures/pad_jail/pad_jail_sprayroom2_icered.tga
+		map textures/pad_jail/pad_jail_sprayroom2_icered
 		blendfunc add
 		tcMod scale .75 .75
 		rgbgen identity
@@ -1044,7 +1044,7 @@ textures/pad_jail/ice_red
 // ********************************************************
 textures/pad_jail/pad_jail_icicles
 {
-	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_icicles.tga
+	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_icicles
 	qer_nocarve
 	surfaceparm nonsolid
 	surfaceparm noimpact
@@ -1054,7 +1054,7 @@ textures/pad_jail/pad_jail_icicles
 	cull disable
 
 	{
-		map textures/pad_jail/pad_jail_sprayroom2_icicles.tga
+		map textures/pad_jail/pad_jail_sprayroom2_icicles
 		alphaFunc GE128
 		blendFunc add
 		rgbgen identity
@@ -1068,13 +1068,13 @@ textures/pad_jail/pad_jail_icicles
 // ********************************************************
 textures/pad_jail/jail_snowrock10
 {
-	polygonOffset		
+	polygonOffset
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/jail_snowrock10.tga
+		map textures/pad_jail/jail_snowrock10
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1088,7 +1088,7 @@ textures/pad_jail/jail_snowrock10
 // ********************************************************
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_1
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1098,7 +1098,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -375.257996 154.770050 -565.861633 sawtooth 0 1 1.352910 0.099800
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 3.051912
 AlphaGen wave sawtooth 0.400000 0.300882 1.352910 0.099800
 rgbGen wave sawtooth 0.077523 0.799829 1.352910 0.099800
@@ -1109,7 +1109,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_2
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1119,7 +1119,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.499016 -224.011414 -626.246338 sawtooth 0 1 0.475368 0.103483
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 2.352428
 AlphaGen wave sawtooth 0.400000 0.436726 0.475368 0.103483
 rgbGen wave sawtooth 0.184936 0.510697 0.475368 0.103483
@@ -1130,7 +1130,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_3
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1140,7 +1140,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -154.043091 14.982594 -726.850281 sawtooth 0 1 0.640901 0.097267
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 5.265236
 AlphaGen wave sawtooth 0.400000 0.634291 0.640901 0.097267
 rgbGen wave sawtooth 0.186071 0.744786 0.640901 0.097267
@@ -1151,7 +1151,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_4
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1161,7 +1161,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -263.780121 186.777710 -597.590820 sawtooth 0 1 1.344780 0.106198
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 5.488754
 AlphaGen wave sawtooth 0.400000 0.437947 1.344780 0.106198
 rgbGen wave sawtooth -0.043672 0.933915 1.344780 0.106198
@@ -1172,7 +1172,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_5
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1182,7 +1182,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -296.760834 161.784958 -741.389587 sawtooth 0 1 1.216932 0.082746
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 3.747124
 AlphaGen wave sawtooth 0.400000 0.672256 1.216932 0.082746
 rgbGen wave sawtooth 0.021784 0.607135 1.216932 0.082746
@@ -1193,7 +1193,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_6
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1203,7 +1203,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 209.174606 6.703498 -726.740662 sawtooth 0 1 0.927323 0.093157
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 3.294961
 AlphaGen wave sawtooth 0.400000 0.217823 0.927323 0.093157
 rgbGen wave sawtooth -0.184704 1.055867 0.927323 0.093157
@@ -1214,7 +1214,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_7
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1224,7 +1224,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 57.602821 -2.882029 -631.782776 sawtooth 0 1 1.243593 0.116368
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 4.607624
 AlphaGen wave sawtooth 0.400000 0.251588 1.243593 0.116368
 rgbGen wave sawtooth 0.019391 0.603143 1.243593 0.116368
@@ -1235,7 +1235,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_8
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1245,7 +1245,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 388.237518 -115.402596 -718.924927 sawtooth 0 1 1.484311 0.088551
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 2.229743
 AlphaGen wave sawtooth 0.400000 0.972485 1.484311 0.088551
 rgbGen wave sawtooth -0.083920 0.839186 1.484311 0.088551
@@ -1256,7 +1256,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_9
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1266,7 +1266,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 317.205292 277.092224 -813.609863 sawtooth 0 1 0.741429 0.072724
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 4.589313
 AlphaGen wave sawtooth 0.400000 0.638954 0.741429 0.072724
 rgbGen wave sawtooth 0.159752 0.692001 0.741429 0.072724
@@ -1277,7 +1277,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_10
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1287,7 +1287,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -55.973358 234.626526 -589.671814 sawtooth 0 1 1.535984 0.104206
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 2.901028
 AlphaGen wave sawtooth 0.400000 0.910300 1.535984 0.104206
 rgbGen wave sawtooth 0.181518 0.711435 1.535984 0.104206
@@ -1298,7 +1298,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_11
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1308,7 +1308,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 41.063725 239.369080 -756.462402 sawtooth 0 1 1.393268 0.087009
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 2.399060
 AlphaGen wave sawtooth 0.400000 0.485409 1.393268 0.087009
 rgbGen wave sawtooth -0.141856 0.761766 1.393268 0.087009
@@ -1319,7 +1319,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_12
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1329,7 +1329,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 412.659912 -61.512161 -561.618713 sawtooth 0 1 1.273586 0.103239
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 5.855831
 AlphaGen wave sawtooth 0.400000 0.287332 1.273586 0.103239
 rgbGen wave sawtooth -0.136229 0.779846 1.273586 0.103239
@@ -1340,7 +1340,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_13
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1350,7 +1350,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -307.889954 -55.496883 -906.551331 sawtooth 0 1 0.438966 0.073420
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 5.616687
 AlphaGen wave sawtooth 0.400000 0.800165 0.438966 0.073420
 rgbGen wave sawtooth -0.163353 1.141575 0.438966 0.073420
@@ -1361,7 +1361,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_14
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1371,7 +1371,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 31.069443 272.092072 -866.389038 sawtooth 0 1 0.946660 0.082528
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 5.325175
 AlphaGen wave sawtooth 0.400000 0.896725 0.946660 0.082528
 rgbGen wave sawtooth -0.112803 0.730345 0.946660 0.082528
@@ -1382,7 +1382,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_15
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1392,7 +1392,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 291.100616 244.395432 -452.378082 sawtooth 0 1 0.562896 0.120144
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 2.586077
 AlphaGen wave sawtooth 0.400000 0.937840 0.562896 0.120144
 rgbGen wave sawtooth -0.111582 1.108432 0.562896 0.120144
@@ -1403,7 +1403,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake1_16
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1413,7 +1413,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 263.455383 -164.752884 -520.489136 sawtooth 0 1 0.991302 0.109964
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 2.249519
 AlphaGen wave sawtooth 0.400000 0.973827 0.991302 0.109964
 rgbGen wave sawtooth -0.170873 1.087130 0.991302 0.109964
@@ -1432,7 +1432,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_1
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1442,7 +1442,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -91.875648 49.249176 -669.370667 sawtooth 0 1 1.171700 0.107643
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.197262 1.028489 1.171700 0.107643
 rgbGen wave sawtooth 0.192969 0.690829 1.171700 0.107643
@@ -1453,7 +1453,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_2
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1463,7 +1463,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -30.536669 32.385159 -693.094421 sawtooth 0 1 0.302045 0.098351
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.130696 0.497015 0.302045 0.098351
 rgbGen wave sawtooth 0.133372 0.754369 0.302045 0.098351
@@ -1474,7 +1474,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_3
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1484,7 +1484,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -179.239807 24.907839 -726.113037 sawtooth 0 1 0.645775 0.093454
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.253813 0.545900 0.645775 0.093454
 rgbGen wave sawtooth 0.072237 0.595648 0.645775 0.093454
@@ -1495,7 +1495,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_4
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1505,7 +1505,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 124.700798 -77.800995 -640.541443 sawtooth 0 1 0.887909 0.097926
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.162264 0.998056 0.887909 0.097926
 rgbGen wave sawtooth 0.028803 0.905680 0.887909 0.097926
@@ -1516,7 +1516,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_5
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1526,7 +1526,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -19.279312 -5.407333 -738.776245 sawtooth 0 1 1.119239 0.093866
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.185043 0.718848 1.119239 0.093866
 rgbGen wave sawtooth 0.157286 0.452199 1.119239 0.093866
@@ -1537,7 +1537,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_6
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1547,7 +1547,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -119.079674 -82.322777 -845.236877 sawtooth 0 1 0.714777 0.084093
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.222019 1.068261 0.714777 0.084093
 rgbGen wave sawtooth -0.047224 0.684738 0.714777 0.084093
@@ -1558,7 +1558,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_7
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1568,7 +1568,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 41.701729 276.545380 -700.711975 sawtooth 0 1 1.152413 0.089498
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.132112 0.942439 1.152413 0.089498
 rgbGen wave sawtooth -0.076473 0.944340 1.152413 0.089498
@@ -1579,7 +1579,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_8
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1589,7 +1589,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -265.627167 165.084656 -621.369385 sawtooth 0 1 0.362502 0.095352
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.111902 0.638151 0.362502 0.095352
 rgbGen wave sawtooth -0.002008 0.671419 0.362502 0.095352
@@ -1600,7 +1600,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_9
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1610,7 +1610,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 215.580246 342.617493 -695.396912 sawtooth 0 1 1.075964 0.081699
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.227738 0.898303 1.075964 0.081699
 rgbGen wave sawtooth -0.036189 0.682565 1.075964 0.081699
@@ -1621,7 +1621,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_10
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1631,7 +1631,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -250.471252 7.080132 -915.334106 sawtooth 0 1 0.409897 0.077977
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.256859 1.102295 0.409897 0.077977
 rgbGen wave sawtooth 0.182385 0.777758 0.409897 0.077977
@@ -1642,7 +1642,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_11
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1652,7 +1652,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 228.175308 207.763031 -888.754883 sawtooth 0 1 0.467730 0.077472
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.144826 0.575832 0.467730 0.077472
 rgbGen wave sawtooth -0.196045 1.030830 0.467730 0.077472
@@ -1663,7 +1663,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_sprayroom2_snowflake2_12
 {
-qer_editorimage textures/pad_jail/pad_jail_snowflake1.tga
+qer_editorimage textures/pad_jail/pad_jail_snowflake1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1673,7 +1673,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -36.482327 -209.509018 -705.667603 sawtooth 0 1 0.745326 0.095180
 {
-clampmap textures/pad_jail/pad_jail_snowflake1.tga
+clampmap textures/pad_jail/pad_jail_snowflake1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.135951 1.004642 0.745326 0.095180
 rgbGen wave sawtooth -0.061885 0.699545 0.745326 0.095180
@@ -1692,7 +1692,7 @@ blendfunc add
 
 textures/pad_jail/wave3_1
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1701,7 +1701,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.585986 0.278106
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 9.146581
 AlphaGen wave sawtooth 0.283844 -0.283844 1.585986 0.278106
 rgbGen wave sawtooth 0.198733 -0.198733 1.585986 0.278106
@@ -1713,7 +1713,7 @@ blendfunc GL_DST_COLOR GL_ONE
 
 textures/pad_jail/wave3_2
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1722,7 +1722,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.239296 0.292045
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 7.904111
 AlphaGen wave sawtooth 0.213291 -0.213291 1.239296 0.292045
 rgbGen wave sawtooth 0.134114 -0.134114 1.239296 0.292045
@@ -1734,7 +1734,7 @@ blendfunc add
 
 textures/pad_jail/wave3_3
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1743,7 +1743,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.070852 0.235548
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 8.617512
 AlphaGen wave sawtooth 0.212510 -0.212510 0.070852 0.235548
 rgbGen wave sawtooth 0.287658 -0.287658 0.070852 0.235548
@@ -1755,7 +1755,7 @@ blendfunc GL_DST_COLOR GL_ONE
 
 textures/pad_jail/wave3_4
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1764,7 +1764,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.669552 0.283332
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 8.694662
 AlphaGen wave sawtooth 0.251653 -0.251653 0.669552 0.283332
 rgbGen wave sawtooth 0.154585 -0.154585 0.669552 0.283332
@@ -1776,7 +1776,7 @@ blendfunc add
 
 textures/pad_jail/wave3_5
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1785,7 +1785,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.544011 0.263802
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 11.808039
 AlphaGen wave sawtooth 0.124970 -0.124970 0.544011 0.263802
 rgbGen wave sawtooth 0.180380 -0.180380 0.544011 0.263802
@@ -1797,7 +1797,7 @@ blendfunc add
 
 textures/pad_jail/wave3_6
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1806,7 +1806,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.026447 0.281844
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 9.286477
 AlphaGen wave sawtooth 0.248485 -0.248485 1.026447 0.281844
 rgbGen wave sawtooth 0.109912 -0.109912 1.026447 0.281844
@@ -1818,7 +1818,7 @@ blendfunc add
 
 textures/pad_jail/wave3_7
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1827,7 +1827,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.440620 0.242127
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 12.746544
 AlphaGen wave sawtooth 0.211991 -0.211991 1.440620 0.242127
 rgbGen wave sawtooth 0.208707 -0.208707 1.440620 0.242127
@@ -1839,7 +1839,7 @@ blendfunc GL_DST_COLOR GL_ONE
 
 textures/pad_jail/wave3_8
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1848,7 +1848,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.745872 0.256581
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 13.971923
 AlphaGen wave sawtooth 0.159755 -0.159755 0.745872 0.256581
 rgbGen wave sawtooth 0.277349 -0.277349 0.745872 0.256581
@@ -1860,7 +1860,7 @@ blendfunc add
 
 textures/pad_jail/wave3_9
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1869,7 +1869,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.334922 0.273740
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 10.825830
 AlphaGen wave sawtooth 0.222446 -0.222446 0.334922 0.273740
 rgbGen wave sawtooth 0.218296 -0.218296 0.334922 0.273740
@@ -1881,7 +1881,7 @@ blendfunc GL_DST_COLOR GL_ONE
 
 textures/pad_jail/wave3_10
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1890,7 +1890,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.470992 0.293101
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 11.824884
 AlphaGen wave sawtooth 0.133900 -0.133900 1.470992 0.293101
 rgbGen wave sawtooth 0.153127 -0.153127 1.470992 0.293101
@@ -1902,7 +1902,7 @@ blendfunc add
 
 textures/pad_jail/wave3_11
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1911,7 +1911,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.989337 0.273592
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 11.077547
 AlphaGen wave sawtooth 0.246123 -0.246123 0.989337 0.273592
 rgbGen wave sawtooth 0.234263 -0.234263 0.989337 0.273592
@@ -1924,7 +1924,7 @@ blendfunc GL_DST_COLOR GL_ONE
 
 textures/pad_jail/wave3_12
 {
-qer_editorimage textures/pad_jail/wave3.tga
+qer_editorimage textures/pad_jail/wave3
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -1933,7 +1933,7 @@ surfaceparm nonsolid
 surfaceparm nodlight
 deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.189459 0.224522
 {
-clampmap textures/pad_jail/pad_jail_sprayroom2_wave3.tga
+clampmap textures/pad_jail/pad_jail_sprayroom2_wave3
 tcMod rotate 12.702108
 AlphaGen wave sawtooth 0.282159 -0.282159 0.189459 0.224522
 rgbGen wave sawtooth 0.299695 -0.299695 0.189459 0.224522
@@ -1948,8 +1948,8 @@ blendfunc add
 textures/pad_jail/pad_jail_sprayroom2_telefield
 {
 	qer_trans 0.6
-	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_telefield2.tga
-	//q3map_lightimage textures/pad_jail/pad_jail_sprayroom2_telefield2.tga
+	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_telefield2
+	//q3map_lightimage textures/pad_jail/pad_jail_sprayroom2_telefield2
         	//q3map_surfacelight 300
 	q3map_globaltexture
 	surfaceparm nolightmap
@@ -1965,7 +1965,7 @@ textures/pad_jail/pad_jail_sprayroom2_telefield
 
 
 	{
-		map textures/pad_jail/pad_jail_sprayroom2_telefield.tga
+		map textures/pad_jail/pad_jail_sprayroom2_telefield
 		blendfunc add
 		//blendFunc GL_ONE_MINUS_SRC_ALPHA GL_SRC_ALPHA
 		//tcMod scroll 0.005 -0.0125
@@ -1977,12 +1977,12 @@ textures/pad_jail/pad_jail_sprayroom2_telefield
 		rgbGen identity
 		//tcgen environment
 	}
-	
+
 }
 
 textures/pad_jail/pad_jail_sprayroom2_telefield3
 {
-	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_telefield3.tga
+	qer_editorimage textures/pad_jail/pad_jail_sprayroom2_telefield3
 	q3map_globaltexture
 	qer_trans 0.6
 	surfaceparm slick
@@ -1991,7 +1991,7 @@ textures/pad_jail/pad_jail_sprayroom2_telefield3
 	surfaceparm nomarks
 	cull twosided
 	{
-		map textures/pad_jail/pad_jail_sprayroom2_telefield3.tga
+		map textures/pad_jail/pad_jail_sprayroom2_telefield3
 		blendfunc GL_DST_COLOR GL_ONE
 		tcMod scale .75 .75
 		rgbgen identity
@@ -2006,8 +2006,8 @@ textures/pad_jail/pad_jail_sprayroom2_telefield3
 
 textures/pad_jail/pad_jail_sprayroom2_lightred1
 {
-	q3map_lightimage textures/pad_jail/pad_jail_lightred.tga
-	qer_editorimage textures/pad_jail/pad_jail_lightred1.tga
+	q3map_lightimage textures/pad_jail/pad_jail_lightred
+	qer_editorimage textures/pad_jail/pad_jail_lightred1
 	q3map_globaltexture
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -2015,20 +2015,20 @@ textures/pad_jail/pad_jail_sprayroom2_lightred1
 	q3map_lightsubdivide 128
 	q3map_surfacelight 150
 	cull none
-	//deformVertexes autosprite 
+	//deformVertexes autosprite
 	tesssize 128
 	{
-		clampmap textures/pad_jail/pad_jail_lightred1.tga
+		clampmap textures/pad_jail/pad_jail_lightred1
 		tcMod rotate -11
 		blendFunc add
 	}
 	{
-		clampmap textures/pad_jail/pad_jail_lightred2.tga
+		clampmap textures/pad_jail/pad_jail_lightred2
 		tcMod rotate 8
 		blendFunc add
 	}
 }
-    
+
 
 
 // ********************************************************
@@ -2038,31 +2038,31 @@ textures/pad_jail/pad_jail_sprayroom2_lightred1
 // ********************************************************
 //textures/pad_jail/sky2
 //{
-//	qer_editorimage textures/pad_jail/sky_arc_masked.tga
-//	
+//	qer_editorimage textures/pad_jail/sky_arc_masked
+//
 //	q3map_sunExt 1 1 1 140 -35 25 2 1
-//	
+//
 //	q3map_lightRGB 0.7 0.8 1.0
 //	q3map_lightmapFilterRadius 0 64
 //	q3map_skyLight 90 3
-//	
+//
 //	surfaceparm sky
 //	surfaceparm noimpact
 //	surfaceparm nolightmap
-//	
+//
 //	skyparms textures/env/sky 1024 -
-//	
+//
 //	nopicmip
 //	nomipmaps
-//	
+//
 //	{
-//		map textures/pad_jail/sky_clouds.tga
+//		map textures/pad_jail/sky_clouds
 //		tcMod scale 3 3
 //		tcMod scroll 0.005 -0.0125
 //		rgbGen identityLighting
 //	}
 //	{
-//		map textures/pad_jail/sky_arc_masked.tga
+//		map textures/pad_jail/sky_arc_masked
 //		blendFunc GL_ONE_MINUS_SRC_ALPHA GL_SRC_ALPHA
 //		tcMod transform 0.25 0 0 0.25 0.1075 0.1075
 //		rgbGen identityLighting
@@ -2073,8 +2073,8 @@ textures/pad_jail/pad_jail_sprayroom2_lightred1
 
 textures/pad_jail/pad_jail_sky4
 {
-	qer_editorimage textures/pad_jail/pad_jail_sky4.tga
-       	//q3map_lightimage textures/pad_jail/jail_sprayroom4_envcolor.tga
+	qer_editorimage textures/pad_jail/pad_jail_sky4
+       	//q3map_lightimage textures/pad_jail/jail_sprayroom4_envcolor
 	q3map_globaltexture
 	surfaceparm noimpact
 	surfaceparm nolightmap
@@ -2088,7 +2088,7 @@ textures/pad_jail/pad_jail_sky4
 	//q3map_surfacelight 70
 	//nopicmip
 	//nomipmaps
-	
+
                 skyparms env/jail_sprayroom3 - -
 
 }
@@ -2100,8 +2100,8 @@ textures/pad_jail/pad_jail_sky4
 // ***********************************************************
 textures/pad_jail/pad_jail_envcolor
 {
-        	qer_editorimage textures/pad_jail/pad_jail_envcolor.tga
-	q3map_lightimage textures/pad_jail/pad_jail_envcolor.tga
+        	qer_editorimage textures/pad_jail/pad_jail_envcolor
+	q3map_lightimage textures/pad_jail/pad_jail_envcolor
 	q3map_globaltexture
 	surfaceparm noimpact
 	surfaceparm nolightmap
@@ -2123,8 +2123,8 @@ textures/pad_jail/pad_jail_envcolor
 // ======================================================================
 textures/pad_jail/jail_grassmud
 {
-        qer_editorimage textures/pad_jail/jail_grassmud.tga
-	
+        qer_editorimage textures/pad_jail/jail_grassmud
+
 	q3map_nonplanar
 	q3map_shadeangle 70
 	q3map_lightmapAxis z
@@ -2134,19 +2134,19 @@ textures/pad_jail/jail_grassmud
 	q3map_alphaMod dotproduct2 ( 0.0 0.0 0.75 )
 	q3map_lightmapSampleSize 16
 	surfaceparm sandsteps
-	
+
 	{
-		map textures/pad_jail/jail_dirt1.tga	// Primary
+		map textures/pad_jail/jail_dirt1	// Primary
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/jail_moss1.tga	// Secondary
+		map textures/pad_jail/jail_moss1	// Secondary
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen identity
 		alphaGen vertex
 		detail
-		
+
 	}
 	{
 		map $lightmap
@@ -2158,8 +2158,8 @@ textures/pad_jail/jail_grassmud
 
 textures/pad_jail/jail_snowrock
 {
-        qer_editorimage textures/pad_jail/jail_snowrock.tga
-	
+        qer_editorimage textures/pad_jail/jail_snowrock
+
 	q3map_nonplanar
 	q3map_shadeangle 70
 	q3map_lightmapAxis z
@@ -2169,19 +2169,19 @@ textures/pad_jail/jail_snowrock
 	q3map_alphaMod dotproduct2 ( 0.0 0.0 0.75 )
 	q3map_lightmapSampleSize 16
 	surfaceparm snowsteps
-	
+
 	{
-		map textures/pad_jail/jail_snowrock5.tga	// Primary
+		map textures/pad_jail/jail_snowrock5	// Primary
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/jail_snowrock10.tga	// Secondary
+		map textures/pad_jail/jail_snowrock10	// Secondary
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen identity
 		alphaGen vertex
 		detail
-		
+
 	}
 	{
 		map $lightmap
@@ -2192,21 +2192,21 @@ textures/pad_jail/jail_snowrock
 
 //textures/pad_jail/jail_snowandrock
 //{
-//        qer_editorimage textures/pad_jail/jail_place_snowrock.tga
-//	
+//        qer_editorimage textures/pad_jail/jail_place_snowrock
+//
 //	q3map_nonplanar
 //	q3map_shadeangle 70
 //	q3map_lightmapAxis z
 //	q3map_lightmapmergable
 //	q3map_tcGen ivector ( 256 0 0 ) ( 0 256 0 )
 //	q3map_alphaMod dotproduct2 ( 0.0 0.0 0.75 )
-//	q3map_lightmapSampleSize 16 
+//	q3map_lightmapSampleSize 16
 //	{
-//		map textures/pad_jail/jail_snowrock1.tga	// Primary
+//		map textures/pad_jail/jail_snowrock1	// Primary
 //		rgbGen identity
 //	}
 //	{
-//		map textures/pad_jail/jail_snowrock10.tga	// Secondary
+//		map textures/pad_jail/jail_snowrock10	// Secondary
 //		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 //		//alphaFunc GE128
 //		rgbGen identity
@@ -2228,13 +2228,13 @@ textures/pad_jail/jail_snowrock
 //{
 //	q3map_nonplanar
 //	q3map_shadeangle 120
-//	qer_editorimage textures/pad_jail/snowrock5.jpg
+//	qer_editorimage textures/pad_jail/snowrock5
 //	{
 //		map $lightmap
 //		rgbGen identity
 //	}
 //	{
-//		map textures/pad_jail/snowrock5.jpg
+//		map textures/pad_jail/snowrock5
 //		blendFunc filter
 //	}
 //
@@ -2249,17 +2249,17 @@ textures/pad_jail/jail_snowrock
 
 //textures/pad_jail/jail_dcl_rock3_moss		// Normal texture blending
 //{
-//        qer_editorimage textures/pad_jail/bld_rock2moss1.jpg
-//	
+//        qer_editorimage textures/pad_jail/bld_rock2moss1
+//
 //	q3map_nonplanar
 //	q3map_shadeAngle 120
-//	
+//
 //	{
-//		map textures/pad_jail/jail_rock3.tga	// Primary
+//		map textures/pad_jail/jail_rock3	// Primary
 //		rgbGen identity
 //	}
 //	{
-//		map textures/pad_jail/jail_moss1.tga	// Secondary
+//		map textures/pad_jail/jail_moss1	// Secondary
 //		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 //		alphaFunc GE128
 //		rgbGen identity
@@ -2378,7 +2378,7 @@ textures/pad_jail/pad_jail_basket
 	cull disable
 
 	{
-		map textures/pad_jail/pad_jail_basket.tga
+		map textures/pad_jail/pad_jail_basket
 		rgbGen vertex
 		alphaFunc GE128
 		blendFunc GL_ONE GL_ZERO
@@ -2393,11 +2393,11 @@ textures/pad_jail/pad_jail_basket
 // ********************************************************
 textures/pad_jail/pad_jail_fly1
 {
-       qer_editorimage textures/pad_jail/pad_jail_fly1.tga
-       surfaceparm trans	
+       qer_editorimage textures/pad_jail/pad_jail_fly1
+       surfaceparm trans
        surfaceparm pointlight
-       surfaceparm nomarks	
-       surfaceparm nodamage        
+       surfaceparm nomarks
+       surfaceparm nodamage
        surfaceparm nonsolid
         surfaceparm nolightmap
         deformVertexes move 2 3 1.5  sin 0 5 0 0.3
@@ -2407,18 +2407,18 @@ textures/pad_jail/pad_jail_fly1
         cull none
 {
 	map $lightmap
-	rgbGen identity	
+	rgbGen identity
 	blendfunc gl_zero gl_one
 }
 {
-	
-	map textures/pad_jail/pad_jail_fly1.tga
+
+	map textures/pad_jail/pad_jail_fly1
                 tcMod Scroll -5 0.1
                 tcMod turb .3 .25 0 .1
                 blendfunc gl_src_alpha gl_one_minus_src_alpha
 }
 {
- 	map textures/pad_jail/pad_jail_fly2.tga
+ 	map textures/pad_jail/pad_jail_fly2
                 tcMod Scroll 4 -0.5
                 tcMod turb .1 .25 0 -.1
                 blendfunc gl_src_alpha gl_one_minus_src_alpha
@@ -2427,11 +2427,11 @@ textures/pad_jail/pad_jail_fly1
 
 textures/pad_jail/pad_jail_fly2
 {
-       qer_editorimage textures/pad_jail/pad_jail_fly1.tga
-       surfaceparm trans	
+       qer_editorimage textures/pad_jail/pad_jail_fly1
+       surfaceparm trans
        surfaceparm pointlight
-       surfaceparm nomarks	
-       surfaceparm nodamage        
+       surfaceparm nomarks
+       surfaceparm nodamage
        surfaceparm nonsolid
         surfaceparm nolightmap
         deformVertexes move 1 2.5 2  sin 0 6 0 0.4
@@ -2441,18 +2441,18 @@ textures/pad_jail/pad_jail_fly2
         cull none
 {
 	map $lightmap
-	rgbGen identity	
+	rgbGen identity
 	blendfunc gl_zero gl_one
 }
 {
-	
-	map textures/pad_jail/pad_jail_fly2.tga
+
+	map textures/pad_jail/pad_jail_fly2
                 tcMod Scroll -4 0.3
                 tcMod turb .2 .3 0 -.1
                 blendfunc gl_src_alpha gl_one_minus_src_alpha
 }
 {
- 	map textures/pad_jail/pad_jail_fly1.tga
+ 	map textures/pad_jail/pad_jail_fly1
                 tcMod Scroll 6 -0.4
                 tcMod turb .2 .25 0 -.2
                 blendfunc gl_src_alpha gl_one_minus_src_alpha
@@ -2462,7 +2462,7 @@ textures/pad_jail/pad_jail_fly2
 
 textures/pad_jail/pad_jail_butterfly
 {
-	qer_editorimage textures/pad_jail/pad_jail_butterfly.tga
+	qer_editorimage textures/pad_jail/pad_jail_butterfly
 	surfaceparm nodamage
 	surfaceparm noimpact
 	surfaceparm nolightmap
@@ -2470,11 +2470,11 @@ textures/pad_jail/pad_jail_butterfly
 	surfaceparm nonsolid
 	surfaceparm trans
 	deformVertexes wave 12 sin 0 18 0 3.2
-	deformVertexes move 4 4 4 sin 0 1 0.75 0.5 
+	deformVertexes move 4 4 4 sin 0 1 0.75 0.5
 	tessSize 16
         	cull disable
 	{
-		map textures/pad_jail/pad_jail_butterfly.tga
+		map textures/pad_jail/pad_jail_butterfly
 		blendfunc blend
 		rgbGen identity
 	}
@@ -2482,7 +2482,7 @@ textures/pad_jail/pad_jail_butterfly
 
 textures/pad_jail/pad_jail_bat
 {
-	qer_editorimage textures/pad_jail/pad_jail_bat.tga
+	qer_editorimage textures/pad_jail/pad_jail_bat
 	surfaceparm nodamage
 	surfaceparm noimpact
 	surfaceparm nolightmap
@@ -2490,11 +2490,11 @@ textures/pad_jail/pad_jail_bat
 	surfaceparm nonsolid
 	surfaceparm trans
 	deformVertexes wave 12 sin 0 18 0 3.2
-	deformVertexes move 4 4 4 sin 0 1 0.75 0.5 
+	deformVertexes move 4 4 4 sin 0 1 0.75 0.5
 	tessSize 16
         	cull disable
 	{
-		map textures/pad_jail/pad_jail_bat.tga
+		map textures/pad_jail/pad_jail_bat
 		blendfunc blend
 		rgbGen identity
 	}
@@ -2508,7 +2508,7 @@ textures/pad_jail/pad_jail_bat
 // ********************************************************
 textures/pad_jail/pad_jail_glowstar1_1
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2518,7 +2518,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1850.000000 0.000000 0 sawtooth 0 1 0.923795 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 0.923795 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 0.923795 0.125000
@@ -2529,7 +2529,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar1_2
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2539,7 +2539,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1850.000000 0.000000 0 sawtooth 0 1 0.207709 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 0.207709 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 0.207709 0.125000
@@ -2550,7 +2550,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar1_3
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2560,7 +2560,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1850.000000 0.000000 0 sawtooth 0 1 1.573229 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 1.573229 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 1.573229 0.125000
@@ -2571,7 +2571,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar1_4
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2581,7 +2581,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1850.000000 0.000000 0 sawtooth 0 1 0.432081 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 0.432081 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 0.432081 0.125000
@@ -2592,7 +2592,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar1_5
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2602,7 +2602,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1850.000000 0.000000 0 sawtooth 0 1 1.816828 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 1.816828 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 1.816828 0.125000
@@ -2613,7 +2613,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar1_6
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2623,7 +2623,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1850.000000 0.000000 0 sawtooth 0 1 0.600848 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 0.600848 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 0.600848 0.125000
@@ -2634,7 +2634,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar1_7
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2644,7 +2644,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1850.000000 0.000000 0 sawtooth 0 1 1.889340 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 1.889340 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 1.889340 0.125000
@@ -2655,7 +2655,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar1_8
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2665,7 +2665,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1850.000000 0.000000 0 sawtooth 0 1 1.053560 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 1.053560 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 1.053560 0.125000
@@ -2676,7 +2676,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar2_1
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2686,7 +2686,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1850.000000 0.000000 0 sawtooth 0 1 0.923795 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 0.923795 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 0.923795 0.125000
@@ -2697,7 +2697,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar2_2
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2707,7 +2707,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1850.000000 0.000000 0 sawtooth 0 1 0.207709 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 0.207709 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 0.207709 0.125000
@@ -2718,7 +2718,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar2_3
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2728,7 +2728,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1850.000000 0.000000 0 sawtooth 0 1 1.573229 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 1.573229 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 1.573229 0.125000
@@ -2739,7 +2739,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar2_4
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2749,7 +2749,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1850.000000 0.000000 0 sawtooth 0 1 0.432081 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 0.432081 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 0.432081 0.125000
@@ -2760,7 +2760,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar2_5
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2770,7 +2770,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1850.000000 0.000000 0 sawtooth 0 1 1.816828 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 1.816828 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 1.816828 0.125000
@@ -2781,7 +2781,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar2_6
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2791,7 +2791,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1850.000000 0.000000 0 sawtooth 0 1 0.600848 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 0.600848 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 0.600848 0.125000
@@ -2802,7 +2802,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar2_7
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2812,7 +2812,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1850.000000 0.000000 0 sawtooth 0 1 1.889340 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 1.889340 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 1.889340 0.125000
@@ -2823,7 +2823,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_glowstar2_8
 {
-qer_editorimage textures/pad_jail/pad_jail_glowstar1.tga
+qer_editorimage textures/pad_jail/pad_jail_glowstar1
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2833,7 +2833,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1850.000000 0.000000 0 sawtooth 0 1 1.053560 0.125000
 {
-clampmap textures/pad_jail/pad_jail_glowstar1.tga
+clampmap textures/pad_jail/pad_jail_glowstar1
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.000000 -0.800000 1.053560 0.125000
 rgbGen wave sawtooth 1.000000 0.000000 1.053560 0.125000
@@ -2849,7 +2849,7 @@ blendfunc add
 // ********************************************************
 textures/pad_jail/waterdrop_1
 {
-qer_editorimage textures/pad_jail/pad_jail_waterdrop.tga
+qer_editorimage textures/pad_jail/pad_jail_waterdrop
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2859,7 +2859,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.722174 0.000012 -360 sawtooth 0 1 0.415662 0.700000
 {
-clampmap textures/pad_jail/pad_jail_waterdrop.tga
+clampmap textures/pad_jail/pad_jail_waterdrop
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.700000 0.300000 0.415662 0.500000
 rgbGen wave sawtooth 1.000000 0.000000 0.415662 0.500000
@@ -2870,7 +2870,7 @@ blendfunc add
 
 textures/pad_jail/waterdrop_2
 {
-qer_editorimage textures/pad_jail/pad_jail_waterdrop.tga
+qer_editorimage textures/pad_jail/pad_jail_waterdrop
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2880,7 +2880,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.184236 0.000013 -360 sawtooth 0 1 0.013184 0.700000
 {
-clampmap textures/pad_jail/pad_jail_waterdrop.tga
+clampmap textures/pad_jail/pad_jail_waterdrop
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.700000 0.300000 0.013184 0.500000
 rgbGen wave sawtooth 1.000000 0.000000 0.013184 0.500000
@@ -2891,7 +2891,7 @@ blendfunc add
 
 textures/pad_jail/waterdrop_3
 {
-qer_editorimage textures/pad_jail/pad_jail_waterdrop.tga
+qer_editorimage textures/pad_jail/pad_jail_waterdrop
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2901,7 +2901,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.155827 0.000013 -360 sawtooth 0 1 0.688711 0.700000
 {
-clampmap textures/pad_jail/pad_jail_waterdrop.tga
+clampmap textures/pad_jail/pad_jail_waterdrop
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.700000 0.300000 0.688711 0.500000
 rgbGen wave sawtooth 1.000000 0.000000 0.688711 0.500000
@@ -2912,7 +2912,7 @@ blendfunc add
 
 textures/pad_jail/waterdrop_4
 {
-qer_editorimage textures/pad_jail/pad_jail_waterdrop.tga
+qer_editorimage textures/pad_jail/pad_jail_waterdrop
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2922,7 +2922,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -4.344173 0.000012 -360 sawtooth 0 1 0.067751 0.700000
 {
-clampmap textures/pad_jail/pad_jail_waterdrop.tga
+clampmap textures/pad_jail/pad_jail_waterdrop
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.700000 0.300000 0.067751 0.500000
 rgbGen wave sawtooth 1.000000 0.000000 0.067751 0.500000
@@ -2933,7 +2933,7 @@ blendfunc add
 
 textures/pad_jail/waterdrop_5
 {
-qer_editorimage textures/pad_jail/pad_jail_waterdrop.tga
+qer_editorimage textures/pad_jail/pad_jail_waterdrop
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -2943,7 +2943,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.709201 0.000012 -360 sawtooth 0 1 0.015198 0.700000
 {
-clampmap textures/pad_jail/pad_jail_waterdrop.tga
+clampmap textures/pad_jail/pad_jail_waterdrop
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.700000 0.300000 0.015198 0.500000
 rgbGen wave sawtooth 1.000000 0.000000 0.015198 0.500000
@@ -2958,22 +2958,22 @@ blendfunc add
 // *
 // ********************************************************
 textures/pad_jail/pad_jail_floor2_slimy
-{    
-     	qer_editorimage textures/pad_jail/pad_jail_floor2_slimy.tga
-	//surfaceparm metalsteps	   
+{
+     	qer_editorimage textures/pad_jail/pad_jail_floor2_slimy
+	//surfaceparm metalsteps
                 {
-		map textures/pad_jail/pad_jail_slimy.tga
+		map textures/pad_jail/pad_jail_slimy
                 	blendFunc GL_ONE GL_ZERO
                		tcMod scroll .01 .03
                 	tcMod turb 0 0.05 0 .05
 	}
                 {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 	blendFunc GL_ONE GL_ONE
                 	tcGen environment
        	}
                {
-		map textures/pad_jail/pad_jail_floor2_slimy.tga
+		map textures/pad_jail/pad_jail_floor2_slimy
                 	blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -2985,22 +2985,22 @@ textures/pad_jail/pad_jail_floor2_slimy
 }
 
 textures/pad_jail/pad_jail2_redfloor_water
-{    
-     	qer_editorimage textures/pad_jail/pad_jail2_redfloor_slimy.tga
-	//surfaceparm metalsteps	   
+{
+     	qer_editorimage textures/pad_jail/pad_jail2_redfloor_slimy
+	//surfaceparm metalsteps
                 {
-		map textures/pad_jail/pad_jail_slimy.tga
+		map textures/pad_jail/pad_jail_slimy
                 	blendFunc GL_ONE GL_ZERO
                		tcMod scroll .01 .03
                 	tcMod turb 0 0.05 0 .05
 	}
                 {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 	blendFunc GL_ONE GL_ONE
                 	tcGen environment
        	}
                {
-		map textures/pad_jail/pad_jail2_redfloor_slimy.tga
+		map textures/pad_jail/pad_jail2_redfloor_slimy
                 	blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3018,7 +3018,7 @@ textures/pad_jail/pad_jail2_redfloor_water
 // ********************************************************
 textures/pad_jail/pad_jail_tele_stripes
 {
-	qer_editorimage textures/pad_jail/pad_jail_tele_stripes.tga
+	qer_editorimage textures/pad_jail/pad_jail_tele_stripes
 	surfaceparm noimpact
 	surfaceparm nomarks
 	surfaceparm trans
@@ -3026,7 +3026,7 @@ textures/pad_jail/pad_jail_tele_stripes
 	surfaceparm nolightmap
 	cull disable
 	{
-		map textures/pad_jail/pad_jail_tele_stripes.tga
+		map textures/pad_jail/pad_jail_tele_stripes
 		blendfunc add
 		rgbGen wave sin 0.4 0.2 0 0.2
 		tcMod Scroll 2 0.5
@@ -3035,7 +3035,7 @@ textures/pad_jail/pad_jail_tele_stripes
 
 textures/pad_jail/pad_jail_teleentry
 {
-	qer_editorimage textures/pad_jail/pad_jail_teleentry.tga
+	qer_editorimage textures/pad_jail/pad_jail_teleentry
 	surfaceparm noimpact
 	surfaceparm nomarks
 	surfaceparm trans
@@ -3043,7 +3043,7 @@ textures/pad_jail/pad_jail_teleentry
 	surfaceparm nolightmap
 	cull disable
 	{
-		map textures/pad_jail/pad_jail_teleentry.tga
+		map textures/pad_jail/pad_jail_teleentry
 		blendfunc add
 		rgbGen wave sin 0.4 0.2 0 0.2
 	}
@@ -3056,19 +3056,19 @@ textures/pad_jail/pad_jail_teleentry
 // ********************************************************
 textures/pad_jail/wallrast_a_blend
 {
-	qer_editorimage textures/pad_metal/wallrast_a.tga
-	surfaceparm	metalsteps		
+	qer_editorimage textures/pad_metal/wallrast_a
+	surfaceparm	metalsteps
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_metal/wallrast_a.tga
+		map textures/pad_metal/wallrast_a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/wallrast_a_blend.tga
+		map textures/pad_jail/wallrast_a_blend
 		blendFunc add
 		rgbGen wave sin 0.4 0.2 0 0.2
 	}
@@ -3088,7 +3088,7 @@ textures/pad_jail/pad_jail_busch
 	cull disable
 
 	{
-		map textures/pad_jail/pad_jail_busch.tga
+		map textures/pad_jail/pad_jail_busch
 		rgbGen vertex
 		alphaFunc GE128
 		blendFunc GL_ONE GL_ZERO
@@ -3104,7 +3104,7 @@ textures/pad_jail/pad_jail_blatt
 	cull disable
 	deformVertexes wave 100 sin 3 5 .1 0.1
 	{
-		map textures/pad_jail/pad_jail_blatt.tga
+		map textures/pad_jail/pad_jail_blatt
 		rgbGen vertex
 		alphaFunc GE128
 		blendFunc GL_ONE GL_ZERO
@@ -3125,7 +3125,7 @@ textures/pad_jail/pad_jail_buegel
 	cull disable
 
 	{
-		map textures/pad_jail/pad_jail_buegel.tga
+		map textures/pad_jail/pad_jail_buegel
 		rgbGen vertex
 		alphaFunc GE128
 		blendFunc GL_ONE GL_ZERO
@@ -3143,7 +3143,7 @@ textures/pad_jail/telepad1
 	surfaceparm nonsolid
 	cull twosided
 	{
-	map textures/pad_tex02/telepad.tga
+	map textures/pad_tex02/telepad
 	tcGen environment
                 tcMod turb 0 0.25 0 0.5
                 tcmod scroll 1 1
@@ -3158,7 +3158,7 @@ textures/pad_jail/telepad1
 // ********************************************************
 textures/pad_jail/pad_jail_spidernet1
 {
-	qer_editorimage textures/pad_jail/pad_jail_spidernet1.tga
+	qer_editorimage textures/pad_jail/pad_jail_spidernet1
 	surfaceparm noimpact
 	surfaceparm nomarks
 	surfaceparm trans
@@ -3166,7 +3166,7 @@ textures/pad_jail/pad_jail_spidernet1
 	cull disable
 
 	{
-		map textures/pad_jail/pad_jail_spidernet1.tga
+		map textures/pad_jail/pad_jail_spidernet1
 		blendfunc add
 		rgbgen identity
 	}
@@ -3174,7 +3174,7 @@ textures/pad_jail/pad_jail_spidernet1
 
 textures/pad_jail/pad_jail_spidernet2
 {
-	qer_editorimage textures/pad_jail/pad_jail_spidernet2.tga
+	qer_editorimage textures/pad_jail/pad_jail_spidernet2
 	surfaceparm noimpact
 	surfaceparm nomarks
 	surfaceparm trans
@@ -3184,7 +3184,7 @@ textures/pad_jail/pad_jail_spidernet2
         	deformVertexes wave 194 sin 0 3 0 .4
         	deformVertexes normal .5 .1
 	{
-		map textures/pad_jail/pad_jail_spidernet2.tga
+		map textures/pad_jail/pad_jail_spidernet2
 		blendfunc add
 		rgbgen identity
 	}
@@ -3192,7 +3192,7 @@ textures/pad_jail/pad_jail_spidernet2
 
 textures/pad_jail/pad_jail_spidernet3
 {
-	qer_editorimage textures/pad_jail/pad_jail_spidernet3.tga
+	qer_editorimage textures/pad_jail/pad_jail_spidernet3
 	surfaceparm noimpact
 	surfaceparm nomarks
 	surfaceparm trans
@@ -3202,7 +3202,7 @@ textures/pad_jail/pad_jail_spidernet3
         	deformVertexes wave 194 sin 0 3 0 .4
         	deformVertexes normal .5 .1
 	{
-		map textures/pad_jail/pad_jail_spidernet3.tga
+		map textures/pad_jail/pad_jail_spidernet3
 		blendfunc add
 		rgbgen identity
 	}
@@ -3215,23 +3215,23 @@ textures/pad_jail/pad_jail_spidernet3
 // ***********************************************************
 textures/pad_jail/pad_jail_rain
 {
-        surfaceparm trans	
-        surfaceparm nomarks	
+        surfaceparm trans
+        surfaceparm nomarks
         surfaceparm nonsolid
         surfaceparm nolightmap
-        
+
         deformVertexes move 3 1 0  sin 0 5 0 0.2
         deformVertexes move .6 3.3 0  sin 0 5 0 0.4
         deformVertexes wave 30 sin 0 10 0 .2
         cull none
 {
-	map textures/pad_jail/pad_jail_rain.tga
+	map textures/pad_jail/pad_jail_rain
                 tcMod Scroll .5 -8
                 tcMod turb .1 .25 0 -.1
                 blendFunc GL_ONE GL_ONE
         }
         {
-	map textures/pad_jail/pad_jail_rain.tga
+	map textures/pad_jail/pad_jail_rain
                 tcMod Scroll .01 -6.3
                 blendFunc GL_ONE GL_ONE
         }
@@ -3252,7 +3252,7 @@ textures/pad_jail/pad_jail_barbed_wire1
 	cull disable
 
 	{
-		map textures/pad_jail/pad_jail_barbed_wire1.tga
+		map textures/pad_jail/pad_jail_barbed_wire1
 		alphaFunc GE128
 		depthWrite
 
@@ -3280,38 +3280,38 @@ textures/pad_jail/pad_jail_tin
 		map $lightmap
 	}
 	{
-		map textures/pad_jail/pad_jail_tin.tga
+		map textures/pad_jail/pad_jail_tin
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 	tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         	{
-		map textures/pad_jail/pad_jail_tin.tga
+		map textures/pad_jail/pad_jail_tin
                		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}       
+}
 
 
 
 textures/pad_jail/pad_jail_metal14
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
-		tcmod scale .25 .25 
+		tcmod scale .25 .25
 	}
 	{
-		map textures/pad_jail/pad_jail_metal14.tga
+		map textures/pad_jail/pad_jail_metal14
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		detail
         		tcMod scale 0.0693 0.0712
@@ -3327,15 +3327,15 @@ textures/pad_jail/pad_jail_metal14
 
 textures/pad_jail/pad_jail_plasticred
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_plasticred.tga
+		map textures/pad_jail/pad_jail_plasticred
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3348,16 +3348,16 @@ textures/pad_jail/pad_jail_plasticred
 
 textures/pad_jail/pad_jail_trash
 {
-	
+
 	surfaceparm woodsteps
-	
+
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_trash.tga
+		map textures/pad_jail/pad_jail_trash
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3370,16 +3370,16 @@ textures/pad_jail/pad_jail_trash
 
 textures/pad_jail/pad_jail_trashb
 {
-	
+
 	surfaceparm metalsteps
-	
+
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_trashb.tga
+		map textures/pad_jail/pad_jail_trashb
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3392,15 +3392,15 @@ textures/pad_jail/pad_jail_trashb
 
 textures/pad_jail/pad_jail_metal_shine
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_metal_shine.tga
+		map textures/pad_jail/pad_jail_metal_shine
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3413,12 +3413,12 @@ textures/pad_jail/pad_jail_metal_shine
 
 textures/pad_jail/pad_jail_grate1
 {
-	qer_editorimage textures/pad_jail/pad_jail_grate1.tga
+	qer_editorimage textures/pad_jail/pad_jail_grate1
 	cull disable
     	surfaceparm alphashadow
         	surfaceparm latticesteps
 	{
-		map textures/pad_jail/pad_jail_grate1.tga
+		map textures/pad_jail/pad_jail_grate1
 		tcMod scale 1.0 1.0
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
@@ -3435,12 +3435,12 @@ textures/pad_jail/pad_jail_grate1
 
 textures/pad_jail/pad_jail_farbsieb
 {
-	qer_editorimage textures/pad_jail/pad_jail_farbsieb.tga
+	qer_editorimage textures/pad_jail/pad_jail_farbsieb
 	cull disable
     	surfaceparm alphashadow
         	//surfaceparm latticesteps
 	{
-		map textures/pad_jail/pad_jail_farbsieb.tga
+		map textures/pad_jail/pad_jail_farbsieb
 		tcMod scale 1.0 1.0
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
@@ -3457,14 +3457,14 @@ textures/pad_jail/pad_jail_farbsieb
 
 textures/pad_jail/pad_jail_maschendrahtzaun
 {
-	qer_editorimage textures/pad_jail/jail2_maschendrahtzaun.tga
+	qer_editorimage textures/pad_jail/jail2_maschendrahtzaun
 	cull disable
     	surfaceparm alphashadow
         surfaceparm latticesteps
         surfaceparm nomarks
 	surfaceparm trans
 	{
-		map textures/pad_jail/jail2_maschendrahtzaun.tga
+		map textures/pad_jail/jail2_maschendrahtzaun
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -3482,12 +3482,12 @@ textures/pad_jail/pad_jail_maschendrahtzaun
 
 textures/pad_jail/pad_jail_grate2
 {
-	qer_editorimage textures/pad_jail/pad_jail_grate2.tga
+	qer_editorimage textures/pad_jail/pad_jail_grate2
 	cull disable
     	surfaceparm alphashadow
         	surfaceparm latticesteps
 	{
-		map textures/pad_jail/pad_jail_grate2.tga
+		map textures/pad_jail/pad_jail_grate2
 		tcMod scale 1.0 1.0
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
@@ -3505,12 +3505,12 @@ textures/pad_jail/pad_jail_grate2
 
 textures/pad_jail/jail2_krippgitter
 {
-	qer_editorimage textures/pad_jail/jail2_krippgitter.tga
+	qer_editorimage textures/pad_jail/jail2_krippgitter
 	cull disable
     	surfaceparm alphashadow
         	surfaceparm latticesteps
 	{
-		map textures/pad_jail/jail2_krippgitter.tga
+		map textures/pad_jail/jail2_krippgitter
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -3527,11 +3527,11 @@ textures/pad_jail/jail2_krippgitter
 
 textures/pad_jail/pad_jail_vine
 {
-	qer_editorimage textures/pad_jail/pad_jail_vine.tga
+	qer_editorimage textures/pad_jail/pad_jail_vine
 	cull disable
     	surfaceparm alphashadow
   	{
-		map textures/pad_jail/pad_jail_vine.tga
+		map textures/pad_jail/pad_jail_vine
 		tcMod scale 1.0 1.0
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
@@ -3548,15 +3548,15 @@ textures/pad_jail/pad_jail_vine
 
 textures/pad_jail/pad_jail_zink_geruest_tools
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_zink_geruest_tools.tga
+		map textures/pad_jail/pad_jail_zink_geruest_tools
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3570,15 +3570,15 @@ textures/pad_jail/pad_jail_zink_geruest_tools
 
 textures/pad_jail/pad_jail_zink_geruest_klein
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_zink_geruest_klein.tga
+		map textures/pad_jail/pad_jail_zink_geruest_klein
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3592,15 +3592,15 @@ textures/pad_jail/pad_jail_zink_geruest_klein
 
 textures/pad_jail/pad_jail_zink_ger_klein_dark
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_zink_ger_klein_dark.tga
+		map textures/pad_jail/pad_jail_zink_ger_klein_dark
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3614,15 +3614,15 @@ textures/pad_jail/pad_jail_zink_ger_klein_dark
 
 textures/pad_jail/pad_jail_zink1
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_zink1.tga
+		map textures/pad_jail/pad_jail_zink1
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3636,12 +3636,12 @@ textures/pad_jail/pad_jail_zink1
 
 textures/pad_jail/pad_jail_grate6
 {
-	qer_editorimage textures/pad_jail/pad_jail_grate6.tga
+	qer_editorimage textures/pad_jail/pad_jail_grate6
 	cull disable
     	surfaceparm alphashadow
         	surfaceparm latticesteps
 	{
-		map textures/pad_jail/pad_jail_grate6.tga
+		map textures/pad_jail/pad_jail_grate6
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -3659,12 +3659,12 @@ textures/pad_jail/pad_jail_grate6
 
 textures/pad_jail/pad_jail_grate6_deckel
 {
-	qer_editorimage textures/pad_jail/pad_jail_grate6_deckel.tga
+	qer_editorimage textures/pad_jail/pad_jail_grate6_deckel
 	cull disable
     	surfaceparm alphashadow
         	surfaceparm latticesteps
 	{
-		map textures/pad_jail/pad_jail_grate6_deckel.tga
+		map textures/pad_jail/pad_jail_grate6_deckel
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -3682,12 +3682,12 @@ textures/pad_jail/pad_jail_grate6_deckel
 
 textures/pad_jail/pad_jail_metallstufe
 {
-	qer_editorimage textures/pad_jail/pad_jail_metallstufe.tga
+	qer_editorimage textures/pad_jail/pad_jail_metallstufe
 	cull disable
     	surfaceparm alphashadow
         	surfaceparm latticesteps
 	{
-		map textures/pad_jail/pad_jail_metallstufe.tga
+		map textures/pad_jail/pad_jail_metallstufe
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -3705,15 +3705,15 @@ textures/pad_jail/pad_jail_metallstufe
 
 textures/pad_jail/pad_jail_zink1a
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_zink1a.tga
+		map textures/pad_jail/pad_jail_zink1a
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3727,15 +3727,15 @@ textures/pad_jail/pad_jail_zink1a
 
 textures/pad_jail/pad_jail_zink2
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_zink2.tga
+		map textures/pad_jail/pad_jail_zink2
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3748,15 +3748,15 @@ textures/pad_jail/pad_jail_zink2
 
 textures/pad_jail/pad_jail_zink2_border
 {
-	
+
 	surfaceparm metalsteps
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		tcGen environment
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_zink2_border.tga
+		map textures/pad_jail/pad_jail_zink2_border
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen identity
 	}
@@ -3777,74 +3777,74 @@ textures/pad_jail/pad_jail_zink2_border
 
 textures/pad_jail/jail2_holzkiste_deckel1
 {
-	surfaceparm woodsteps 
-	{	
+	surfaceparm woodsteps
+	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/jail2_holzkiste_deckel1.tga
+		map textures/pad_jail/jail2_holzkiste_deckel1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_jail/pad_jail_wood1
 {
-	surfaceparm woodsteps 
-	{	
+	surfaceparm woodsteps
+	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_wood1.tga
+		map textures/pad_jail/pad_jail_wood1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_jail/pad_jail_wood2
 {
-	surfaceparm woodsteps 
-	{	
+	surfaceparm woodsteps
+	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_wood2.tga
+		map textures/pad_jail/pad_jail_wood2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_jail/jail_holzkiste_sound
 {
-	qer_editorimage textures/pad_woodobjects/chest01_6.tga
-	surfaceparm woodsteps 
-	{	
+	qer_editorimage textures/pad_woodobjects/chest01_6
+	surfaceparm woodsteps
+	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_woodobjects/chest01_6.tga
+		map textures/pad_woodobjects/chest01_6
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_jail/pad_jail_metalfloor1
 {
-	surfaceparm metalsteps		
+	surfaceparm metalsteps
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_metalfloor1.tga
+		map textures/pad_jail/pad_jail_metalfloor1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3852,13 +3852,13 @@ textures/pad_jail/pad_jail_metalfloor1
 
 textures/pad_jail/pad_jail_metalfloor1_zink
 {
-	surfaceparm metalsteps		
+	surfaceparm metalsteps
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_metalfloor1_zink.tga
+		map textures/pad_jail/pad_jail_metalfloor1_zink
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3866,13 +3866,13 @@ textures/pad_jail/pad_jail_metalfloor1_zink
 
 textures/pad_jail/pad_jail_metal11
 {
-	surfaceparm metalsteps		
+	surfaceparm metalsteps
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_metal11.tga
+		map textures/pad_jail/pad_jail_metal11
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3880,13 +3880,13 @@ textures/pad_jail/pad_jail_metal11
 
 textures/pad_jail/pad_jail_metal1
 {
-	surfaceparm metalsteps		
+	surfaceparm metalsteps
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_metal1.tga
+		map textures/pad_jail/pad_jail_metal1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3899,13 +3899,13 @@ textures/pad_jail/pad_jail_metal1
 // *
 // ***********************************************************
 textures/pad_jail/pad_jail_rust1
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_rust1.tga
+		map textures/pad_jail/pad_jail_rust1
                		blendFunc add
 		rgbGen vertex
 	}
@@ -3918,7 +3918,7 @@ textures/pad_jail/pad_jail_rust1
 // ***********************************************************
 textures/pad_jail/jail_padlamp
 {
-	qer_editorimage textures/pad_jail/jail_padlamp.tga
+	qer_editorimage textures/pad_jail/jail_padlamp
 	light 1
 	surfaceparm nomarks
 	q3map_surfacelight 4000
@@ -3927,12 +3927,12 @@ textures/pad_jail/jail_padlamp
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/jail_padlamp.tga
+		map textures/pad_jail/jail_padlamp
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/jail_padlamp_blend.tga
+		map textures/pad_jail/jail_padlamp_blend
 		rgbGen wave sin .6 .1 .1 .1
 		blendFunc GL_ONE GL_ONE
 	}
@@ -3940,7 +3940,7 @@ textures/pad_jail/jail_padlamp
 
 textures/pad_jail/pad_jail_light_white
 {
-	qer_editorimage textures/pad_jail/pad_jail_light_white.tga
+	qer_editorimage textures/pad_jail/pad_jail_light_white
 	q3map_surfacelight 200
 	light 1
 	surfaceparm noimpact
@@ -3949,18 +3949,18 @@ textures/pad_jail/pad_jail_light_white
 	surfaceparm trans
 
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendFunc GL_dst_color GL_one
 	}
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendfunc GL_ONE GL_ONE
 	}
 }
 
 textures/pad_jail/pad_jail_light_white2
 {
-	qer_editorimage textures/pad_jail/pad_jail_light_white.tga
+	qer_editorimage textures/pad_jail/pad_jail_light_white
 	q3map_surfacelight 200
 	light 1
 	surfaceparm noimpact
@@ -3969,18 +3969,18 @@ textures/pad_jail/pad_jail_light_white2
 	surfaceparm trans
 
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendFunc GL_dst_color GL_one
 	}
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendfunc GL_ONE GL_ONE
 	}
 }
 
 textures/pad_jail/pad_jail_light_white3
 {
-	qer_editorimage textures/pad_jail/pad_jail_light_white.tga
+	qer_editorimage textures/pad_jail/pad_jail_light_white
 	q3map_surfacelight 200
 	light 1
 	surfaceparm noimpact
@@ -3989,11 +3989,11 @@ textures/pad_jail/pad_jail_light_white3
 	surfaceparm trans
 
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendFunc GL_dst_color GL_one
 	}
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendfunc GL_ONE GL_ONE
 		rgbGen wave square .5 .5 0 1
 	}
@@ -4001,7 +4001,7 @@ textures/pad_jail/pad_jail_light_white3
 
 textures/pad_jail/pad_jail_light_white1000
 {
-	qer_editorimage textures/pad_jail/pad_jail_light_white.tga
+	qer_editorimage textures/pad_jail/pad_jail_light_white
 	q3map_surfacelight 1000
 	light 1
 	surfaceparm noimpact
@@ -4010,11 +4010,11 @@ textures/pad_jail/pad_jail_light_white1000
 	surfaceparm trans
 
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendFunc GL_dst_color GL_one
 	}
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendfunc GL_ONE GL_ONE
 		//rgbGen wave square .5 .5 0 1
 	}
@@ -4022,7 +4022,7 @@ textures/pad_jail/pad_jail_light_white1000
 
 textures/pad_jail/pad_jail_light_white2400
 {
-	qer_editorimage textures/pad_jail/pad_jail_light_white.tga
+	qer_editorimage textures/pad_jail/pad_jail_light_white
 	q3map_surfacelight 2400
 	light 1
 	surfaceparm noimpact
@@ -4031,11 +4031,11 @@ textures/pad_jail/pad_jail_light_white2400
 	surfaceparm trans
 
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendFunc GL_dst_color GL_one
 	}
 	{
-		map textures/pad_jail/pad_jail_light_white.tga
+		map textures/pad_jail/pad_jail_light_white
 		blendfunc GL_ONE GL_ONE
 		//rgbGen wave square .5 .5 0 1
 	}
@@ -4049,11 +4049,11 @@ textures/pad_jail/pad_jail_light_white2400
 // ***********************************************************
 textures/pad_jail/pad_jail_glass
 {
-	qer_editorimage textures/pad_gfx02/plas07.tga
+	qer_editorimage textures/pad_gfx02/plas07
 	surfaceparm nolightmap
 	cull twosided
 	{
-		map textures/pad_gfx02/plas07.tga
+		map textures/pad_gfx02/plas07
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
                 }
@@ -4062,11 +4062,11 @@ textures/pad_jail/pad_jail_glass
 
 textures/pad_jail/pad_jail2_glass_matt
 {
-	qer_editorimage textures/pad_jail/pad_jail2_glass_matt.tga
+	qer_editorimage textures/pad_jail/pad_jail2_glass_matt
 	surfaceparm nolightmap
 	cull twosided
 	{
-		map textures/pad_jail/pad_jail2_glass_matt.tga
+		map textures/pad_jail/pad_jail2_glass_matt
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
                 }
@@ -4080,7 +4080,7 @@ textures/pad_jail/pad_jail2_glass_matt
 // ***********************************************************
 textures/pad_objects/obj047d
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4089,7 +4089,7 @@ textures/pad_objects/obj047d
 		rgbGen identity
 	}
 	{
-		map textures/pad_objects/obj047d.tga
+		map textures/pad_objects/obj047d
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4097,7 +4097,7 @@ textures/pad_objects/obj047d
 
 textures/pad_poster/poster007
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4106,7 +4106,7 @@ textures/pad_poster/poster007
 		rgbGen identity
 	}
 	{
-		map textures/pad_poster/poster007.tga
+		map textures/pad_poster/poster007
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4115,7 +4115,7 @@ textures/pad_poster/poster007
 
 textures/pad_poster/poster036
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4124,7 +4124,7 @@ textures/pad_poster/poster036
 		rgbGen identity
 	}
 	{
-		map textures/pad_poster/poster036.tga
+		map textures/pad_poster/poster036
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4133,7 +4133,7 @@ textures/pad_poster/poster036
 
 textures/pad_poster/posterX003
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4142,7 +4142,7 @@ textures/pad_poster/posterX003
 		rgbGen identity
 	}
 	{
-		map textures/pad_poster/posterX003.tga
+		map textures/pad_poster/posterX003
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4150,7 +4150,7 @@ textures/pad_poster/posterX003
 
 textures/pad_poster/posterX004
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4159,7 +4159,7 @@ textures/pad_poster/posterX004
 		rgbGen identity
 	}
 	{
-		map textures/pad_poster/posterX004.tga
+		map textures/pad_poster/posterX004
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4168,7 +4168,7 @@ textures/pad_poster/posterX004
 
 textures/pad_jail/pad_jail_pinup1
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4177,7 +4177,7 @@ textures/pad_jail/pad_jail_pinup1
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_pinup1.tga
+		map textures/pad_jail/pad_jail_pinup1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4185,7 +4185,7 @@ textures/pad_jail/pad_jail_pinup1
 
 textures/pad_jail/jail_raquel
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4194,46 +4194,46 @@ textures/pad_jail/jail_raquel
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/jail_raquel.tga
+		map textures/pad_jail/jail_raquel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 }
 
 textures/pad_jail/pad_jail_striche
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_striche.tga
+		map textures/pad_jail/pad_jail_striche
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_jack
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_jack.tga
+		map textures/pad_jail/pad_jail_jack
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_kratzer
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_kratzer.tga
+		map textures/pad_jail/pad_jail_kratzer
                		blendFunc add
 		rgbGen vertex
 	}
@@ -4241,7 +4241,7 @@ textures/pad_jail/pad_jail_kratzer
 
 textures/pad_jail/pad_jail_trash_sign
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4250,7 +4250,7 @@ textures/pad_jail/pad_jail_trash_sign
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_trash_sign.tga
+		map textures/pad_jail/pad_jail_trash_sign
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4258,7 +4258,7 @@ textures/pad_jail/pad_jail_trash_sign
 
 textures/pad_jail/pad_jail_flash
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4267,7 +4267,7 @@ textures/pad_jail/pad_jail_flash
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/pad_jail_flash.tga
+		map textures/pad_jail/pad_jail_flash
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4275,7 +4275,7 @@ textures/pad_jail/pad_jail_flash
 
 textures/pad_objects/obj059
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4284,7 +4284,7 @@ textures/pad_objects/obj059
 		rgbGen identity
 	}
 	{
-		map textures/pad_objects/obj059.tga
+		map textures/pad_objects/obj059
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4292,7 +4292,7 @@ textures/pad_objects/obj059
 
 textures/pad_jail/wanted_pad1
 {
-	surfaceparm noimpact		
+	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
 	polygonOffset
@@ -4301,20 +4301,20 @@ textures/pad_jail/wanted_pad1
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/wanted_pad1.tga
+		map textures/pad_jail/wanted_pad1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 }
 
 textures/pad_jail/pad_jail_padsymbol
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
-    
+
         {
-		map textures/pad_jail/pad_jail_padsymbol.tga
+		map textures/pad_jail/pad_jail_padsymbol
                		blendFunc add
 		rgbGen wave sin 0.4 0.2 0 0.2
 	}
@@ -4322,26 +4322,26 @@ textures/pad_jail/pad_jail_padsymbol
 
 
 textures/pad_jail/jail2_farbkleks
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
-     polygonOffset	
+     polygonOffset
         {
-		map textures/pad_jail/jail2_farbkleks.tga
+		map textures/pad_jail/jail2_farbkleks
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_dirt1
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
-     polygonOffset	
+     polygonOffset
         {
-		map textures/pad_jail/pad_jail_dirt1.tga
+		map textures/pad_jail/pad_jail_dirt1
                		blendFunc add
 		rgbGen vertex
 	}
@@ -4349,130 +4349,130 @@ textures/pad_jail/pad_jail_dirt1
 
 
 textures/pad_jail/pad_jail_dirt1a
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_dirt1a.tga
+		map textures/pad_jail/pad_jail_dirt1a
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_dirt1c
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_dirt1c.tga
+		map textures/pad_jail/pad_jail_dirt1c
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_dirt1d
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_dirt1d.tga
+		map textures/pad_jail/pad_jail_dirt1d
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_dirt1e
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_dirt1e.tga
+		map textures/pad_jail/pad_jail_dirt1e
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_dirt1f
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_dirt1f.tga
+		map textures/pad_jail/pad_jail_dirt1f
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_observation
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_observation.tga
+		map textures/pad_jail/pad_jail_observation
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_nr1
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_nr1.tga
+		map textures/pad_jail/pad_jail_nr1
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_nr2
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_nr2.tga
+		map textures/pad_jail/pad_jail_nr2
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_nr3
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
-     polygonOffset   
+     polygonOffset
         {
-		map textures/pad_jail/pad_jail_nr3.tga
+		map textures/pad_jail/pad_jail_nr3
                		blendFunc add
 		rgbGen vertex
 	}
 }
 
 textures/pad_jail/pad_jail_nr4
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_jail/pad_jail_nr4.tga
+		map textures/pad_jail/pad_jail_nr4
                		blendFunc add
 		rgbGen vertex
 	}
@@ -4485,7 +4485,7 @@ textures/pad_jail/pad_jail_nr4
 // **************************************************************************************
 textures/pad_jail/pad_jail_water2
 {
-	qer_editorimage textures/pad_jail/pad_jail_water2.tga
+	qer_editorimage textures/pad_jail/pad_jail_water2
 	q3map_lightsubdivide 32
 	qer_trans .8
 	qer_nocarve
@@ -4497,8 +4497,8 @@ textures/pad_jail/pad_jail_water2
 	q3map_surfacelight 50
 	cull disable
 	tesssize 64
-	{ 
-		map textures/pad_jail/pad_jail_water2.tga
+	{
+		map textures/pad_jail/pad_jail_water2
 		//blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		//blendfunc add
 		//blendfunc GL_DST_COLOR GL_ONE
@@ -4508,8 +4508,8 @@ textures/pad_jail/pad_jail_water2
 		tcMod turb .3 .2 1 .05
 		tcmod scroll .015 .001
       	}
-	{ 
-		map textures/pad_jail/pad_jail_water2.tga
+	{
+		map textures/pad_jail/pad_jail_water2
 		//blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
 		//blendfunc add
 		//blendfunc GL_DST_COLOR GL_ONE
@@ -4519,7 +4519,7 @@ textures/pad_jail/pad_jail_water2
 		tcMod turb .2 .1 1 .05
 		tcmod scroll -.01 -.01
        	}
-	
+
 }
 
 
@@ -4530,7 +4530,7 @@ textures/pad_jail/pad_jail_water2
 // ***********************************************************
 textures/pad_jail/pad_jail_splash_1
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4540,7 +4540,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.001783 -0.017516 0.171927 sawtooth 0 1 0.050000 5.415586
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.168883 -0.927244 0.050000 5.415586
 rgbGen wave sawtooth 0.735966 -0.142424 0.050000 5.415586
@@ -4551,7 +4551,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_2
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4561,7 +4561,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.003432 -0.013143 0.196668 sawtooth 0 1 0.050000 4.289267
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.015302 -0.293161 0.050000 4.289267
 rgbGen wave sawtooth 0.813166 -0.318186 0.050000 4.289267
@@ -4572,7 +4572,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_3
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4582,7 +4582,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.082027 -0.074155 0.419187 sawtooth 0 1 0.050000 2.758142
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.179943 -0.923197 0.050000 2.758142
 rgbGen wave sawtooth 0.957604 -0.446760 0.050000 2.758142
@@ -4593,7 +4593,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_4
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4603,7 +4603,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.096731 0.030182 0.397254 sawtooth 0 1 0.050000 2.821846
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.076534 -0.301932 0.050000 2.821846
 rgbGen wave sawtooth 0.826069 -0.287912 0.050000 2.821846
@@ -4614,7 +4614,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_5
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4624,7 +4624,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.006604 0.014914 0.259085 sawtooth 0 1 0.050000 3.494662
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.113401 -0.445424 0.050000 3.494662
 rgbGen wave sawtooth 0.733903 -0.219044 0.050000 3.494662
@@ -4635,7 +4635,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_6
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4645,7 +4645,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.035492 -0.033019 0.404591 sawtooth 0 1 0.050000 2.068297
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.017341 -0.727104 0.050000 2.068297
 rgbGen wave sawtooth 0.698184 -0.226295 0.050000 2.068297
@@ -4656,7 +4656,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_7
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4666,7 +4666,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.012884 -0.000916 0.178425 sawtooth 0 1 0.050000 6.675291
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.173962 -0.647713 0.050000 6.675291
 rgbGen wave sawtooth 0.643605 -0.064510 0.050000 6.675291
@@ -4677,7 +4677,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_8
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4687,7 +4687,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.060222 0.027980 0.505405 sawtooth 0 1 0.050000 1.748795
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.869045 -0.291763 0.050000 1.748795
 rgbGen wave sawtooth 0.639760 -0.086288 0.050000 1.748795
@@ -4698,7 +4698,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_9
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4708,7 +4708,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.068247 0.030351 0.452946 sawtooth 0 1 0.050000 2.311882
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.806836 -0.164367 0.050000 2.311882
 rgbGen wave sawtooth 0.861324 -0.351811 0.050000 2.311882
@@ -4719,7 +4719,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_10
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4729,7 +4729,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.011632 -0.040931 0.533328 sawtooth 0 1 0.050000 1.565514
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.838856 -0.092288 0.050000 1.565514
 rgbGen wave sawtooth 0.667507 -0.154943 0.050000 1.565514
@@ -4740,7 +4740,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_11
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4750,7 +4750,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.051393 0.090922 0.726240 sawtooth 0 1 0.050000 1.557789
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.931498 -0.606214 0.050000 1.557789
 rgbGen wave sawtooth 0.902292 -0.405335 0.050000 1.557789
@@ -4761,7 +4761,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_12
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4771,7 +4771,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.009477 -0.058013 0.509409 sawtooth 0 1 0.050000 2.104320
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.917887 -0.699539 0.050000 2.104320
 rgbGen wave sawtooth 0.905429 -0.376501 0.050000 2.104320
@@ -4782,7 +4782,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_13
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4792,7 +4792,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.030592 0.009375 0.474610 sawtooth 0 1 0.050000 1.744549
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.842579 -0.482101 0.050000 1.744549
 rgbGen wave sawtooth 0.796429 -0.339640 0.050000 1.744549
@@ -4803,7 +4803,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_14
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4813,7 +4813,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.029733 -0.034695 0.207681 sawtooth 0 1 0.050000 5.299960
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.811036 -0.261513 0.050000 5.299960
 rgbGen wave sawtooth 0.906784 -0.322111 0.050000 5.299960
@@ -4824,7 +4824,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_15
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4834,7 +4834,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.080672 0.009013 0.327256 sawtooth 0 1 0.050000 3.306758
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.091452 -0.619770 0.050000 3.306758
 rgbGen wave sawtooth 0.912265 -0.337150 0.050000 3.306758
@@ -4845,7 +4845,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_16
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4855,7 +4855,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.039629 0.000462 0.687502 sawtooth 0 1 0.050000 1.604236
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.890738 -0.318326 0.050000 1.604236
 rgbGen wave sawtooth 0.915525 -0.452083 0.050000 1.604236
@@ -4866,7 +4866,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_17
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4876,7 +4876,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.014417 0.000118 0.438142 sawtooth 0 1 0.050000 2.578800
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.140391 -0.693246 0.050000 2.578800
 rgbGen wave sawtooth 0.961083 -0.445314 0.050000 2.578800
@@ -4887,7 +4887,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_18
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4897,7 +4897,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.007536 -0.004976 0.341288 sawtooth 0 1 0.050000 2.494348
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.027277 -0.669967 0.050000 2.494348
 rgbGen wave sawtooth 0.942833 -0.509574 0.050000 2.494348
@@ -4908,7 +4908,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_19
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4918,7 +4918,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.084113 0.021117 0.370545 sawtooth 0 1 0.050000 2.133421
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.967180 -0.583026 0.050000 2.133421
 rgbGen wave sawtooth 0.978478 -0.435908 0.050000 2.133421
@@ -4929,7 +4929,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_20
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4939,7 +4939,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.038920 0.013735 0.531535 sawtooth 0 1 0.050000 1.943187
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.080734 -0.363903 0.050000 1.943187
 rgbGen wave sawtooth 0.722513 -0.255074 0.050000 1.943187
@@ -4950,7 +4950,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_21
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4960,7 +4960,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.090587 -0.050741 0.417229 sawtooth 0 1 0.050000 2.485719
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.938786 -0.372509 0.050000 2.485719
 rgbGen wave sawtooth 0.952757 -0.550298 0.050000 2.485719
@@ -4971,7 +4971,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_22
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -4981,7 +4981,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.109010 -0.050115 0.629636 sawtooth 0 1 0.050000 1.849226
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.002582 -0.567174 0.050000 1.849226
 rgbGen wave sawtooth 0.678420 -0.224928 0.050000 1.849226
@@ -4992,7 +4992,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_23
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5002,7 +5002,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.000845 -0.011895 0.261985 sawtooth 0 1 0.050000 4.265481
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.820557 -0.596570 0.050000 4.265481
 rgbGen wave sawtooth 0.698868 -0.277212 0.050000 4.265481
@@ -5013,7 +5013,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_24
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5023,7 +5023,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.066402 0.092666 0.547784 sawtooth 0 1 0.050000 2.056769
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.139647 -0.432521 0.050000 2.056769
 rgbGen wave sawtooth 0.638173 -0.099149 0.050000 2.056769
@@ -5034,7 +5034,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_25
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5044,7 +5044,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.060990 0.023611 0.487691 sawtooth 0 1 0.050000 2.229852
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.991522 -0.279470 0.050000 2.229852
 rgbGen wave sawtooth 0.611499 -0.097208 0.050000 2.229852
@@ -5055,7 +5055,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_26
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5065,7 +5065,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.043759 -0.023044 0.589881 sawtooth 0 1 0.050000 1.844978
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.908817 -0.335545 0.050000 1.844978
 rgbGen wave sawtooth 0.809125 -0.318723 0.050000 1.844978
@@ -5076,7 +5076,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_27
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5086,7 +5086,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.051986 -0.012217 0.262871 sawtooth 0 1 0.050000 4.269483
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.046236 -0.305216 0.050000 4.269483
 rgbGen wave sawtooth 0.922422 -0.406452 0.050000 4.269483
@@ -5097,7 +5097,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_28
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5107,7 +5107,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.049827 -0.027156 0.361145 sawtooth 0 1 0.050000 2.293147
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.968206 -0.322440 0.050000 2.293147
 rgbGen wave sawtooth 0.946092 -0.526005 0.050000 2.293147
@@ -5118,7 +5118,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_29
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5128,7 +5128,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.013764 -0.026963 0.410878 sawtooth 0 1 0.050000 2.776794
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.830189 -0.128739 0.050000 2.776794
 rgbGen wave sawtooth 0.684744 -0.226746 0.050000 2.776794
@@ -5139,7 +5139,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_splash_30
 {
-qer_editorimage textures/pad_jail/pad_jail_splash.tga
+qer_editorimage textures/pad_jail/pad_jail_splash
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5149,7 +5149,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.085460 -0.031875 0.601655 sawtooth 0 1 0.050000 1.826589
 {
-clampmap textures/pad_jail/pad_jail_splash.tga
+clampmap textures/pad_jail/pad_jail_splash
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 1.198181 -0.544633 0.050000 1.826589
 rgbGen wave sawtooth 0.734672 -0.137870 0.050000 1.826589
@@ -5165,7 +5165,7 @@ blendfunc add
 // ***********************************************************
 textures/pad_jail/pad_jail_smoke2_1
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5175,7 +5175,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.758931 1.195109 9.779077 sawtooth 0 1 0.351521 1.429064
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 9.804224
 AlphaGen wave sawtooth 0.751726 -0.363005 0.351521 1.429064
 rgbGen wave sawtooth 1.000000 -0.271340 0.351521 1.429064
@@ -5186,7 +5186,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke2_2
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5196,7 +5196,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 4.525688 -2.174430 29.160147 sawtooth 0 1 0.242314 0.846443
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 21.364635
 AlphaGen wave sawtooth 0.836775 -0.798151 0.242314 0.846443
 rgbGen wave sawtooth 1.000000 -0.304605 0.242314 0.846443
@@ -5207,7 +5207,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke2_3
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5217,7 +5217,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.144382 -0.464500 8.018268 sawtooth 0 1 0.273992 1.619099
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 5.690939
 AlphaGen wave sawtooth 0.629847 -0.504404 0.273992 1.619099
 rgbGen wave sawtooth 1.000000 -0.330033 0.273992 1.619099
@@ -5228,7 +5228,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke2_4
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5238,7 +5238,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.344450 -0.415958 21.152004 sawtooth 0 1 0.493579 0.755372
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 19.886318
 AlphaGen wave sawtooth 0.777191 -0.463326 0.493579 0.755372
 rgbGen wave sawtooth 1.000000 -0.301358 0.493579 0.755372
@@ -5249,7 +5249,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke2_5
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5259,7 +5259,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.366418 0.591261 27.499413 sawtooth 0 1 0.414158 1.023246
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 22.946714
 AlphaGen wave sawtooth 0.692349 -0.551500 0.414158 1.023246
 rgbGen wave sawtooth 1.000000 -0.448872 0.414158 1.023246
@@ -5270,7 +5270,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke2_6
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5280,7 +5280,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.777955 -1.489562 9.252100 sawtooth 0 1 0.345405 1.377401
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 22.987610
 AlphaGen wave sawtooth 0.761931 -0.399628 0.345405 1.377401
 rgbGen wave sawtooth 1.000000 -0.557591 0.345405 1.377401
@@ -5291,7 +5291,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke2_7
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5301,7 +5301,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 3.191568 3.936936 24.095812 sawtooth 0 1 0.363692 0.739084
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 11.371655
 AlphaGen wave sawtooth 0.778802 -0.744633 0.363692 0.739084
 rgbGen wave sawtooth 1.000000 -0.335746 0.363692 0.739084
@@ -5312,7 +5312,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke2_8
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5322,7 +5322,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -0.501696 -1.628014 12.020740 sawtooth 0 1 0.474755 1.002239
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 7.193060
 AlphaGen wave sawtooth 0.986010 -0.877523 0.474755 1.002239
 rgbGen wave sawtooth 1.000000 -0.302762 0.474755 1.002239
@@ -5333,7 +5333,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke2_9
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5343,7 +5343,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.220373 1.662529 9.744644 sawtooth 0 1 0.331782 1.603317
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 10.222938
 AlphaGen wave sawtooth 0.890231 -0.751653 0.331782 1.603317
 rgbGen wave sawtooth 1.000000 -0.566344 0.331782 1.603317
@@ -5354,7 +5354,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke2_10
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5364,7 +5364,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -3.757527 1.067393 25.584791 sawtooth 0 1 0.496313 0.775437
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 23.487503
 AlphaGen wave sawtooth 0.975402 -0.673757 0.496313 0.775437
 rgbGen wave sawtooth 1.000000 -0.431635 0.496313 0.775437
@@ -5381,7 +5381,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_1
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5391,7 +5391,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -45.229370 -5.494783 -27.901167 sawtooth 0 1 0.737034 0.922323
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 15.116886
 AlphaGen wave sawtooth 0.786114 -0.776775 0.737034 0.922323
 rgbGen wave sawtooth 1.000000 -0.449348 0.737034 0.922323
@@ -5402,7 +5402,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_2
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5412,7 +5412,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -54.298782 -8.733896 -32.662361 sawtooth 0 1 0.442396 0.760873
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 15.932341
 AlphaGen wave sawtooth 0.800201 -0.417988 0.442396 0.760873
 rgbGen wave sawtooth 1.000000 -0.451045 0.442396 0.760873
@@ -5423,7 +5423,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_3
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5433,7 +5433,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -58.349571 -6.087270 -30.759367 sawtooth 0 1 0.531608 0.958856
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 14.005402
 AlphaGen wave sawtooth 0.789984 -0.408161 0.531608 0.958856
 rgbGen wave sawtooth 1.000000 -0.340251 0.531608 0.958856
@@ -5444,7 +5444,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_4
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5454,7 +5454,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -31.388313 1.587495 -18.587152 sawtooth 0 1 0.043873 1.296932
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 23.623005
 AlphaGen wave sawtooth 0.747588 -0.427119 0.043873 1.296932
 rgbGen wave sawtooth 1.000000 -0.407550 0.043873 1.296932
@@ -5465,7 +5465,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_5
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5475,7 +5475,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -40.811230 2.639762 -31.198219 sawtooth 0 1 0.092166 0.931574
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 18.643604
 AlphaGen wave sawtooth 0.850215 -0.569628 0.092166 0.931574
 rgbGen wave sawtooth 1.000000 -0.218445 0.092166 0.931574
@@ -5486,7 +5486,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_6
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5496,7 +5496,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -61.938358 3.989294 -39.098846 sawtooth 0 1 0.362291 0.733946
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 24.509262
 AlphaGen wave sawtooth 0.813886 -0.544908 0.362291 0.733946
 rgbGen wave sawtooth 1.000000 -0.494809 0.362291 0.733946
@@ -5507,7 +5507,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_7
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5517,7 +5517,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -63.940540 12.319346 -46.902851 sawtooth 0 1 0.039283 0.766914
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 17.220222
 AlphaGen wave sawtooth 0.873031 -0.693851 0.039283 0.766914
 rgbGen wave sawtooth 1.000000 -0.587158 0.039283 0.766914
@@ -5528,7 +5528,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_8
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5538,7 +5538,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -48.332302 -5.596929 -35.665512 sawtooth 0 1 0.089602 0.885820
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 7.847987
 AlphaGen wave sawtooth 0.949059 -0.921702 0.089602 0.885820
 rgbGen wave sawtooth 1.000000 -0.549754 0.089602 0.885820
@@ -5549,7 +5549,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_9
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5559,7 +5559,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -53.902626 -1.053432 -30.814821 sawtooth 0 1 0.419349 0.800503
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 21.010620
 AlphaGen wave sawtooth 0.662697 -0.368780 0.419349 0.800503
 rgbGen wave sawtooth 1.000000 -0.200342 0.419349 0.800503
@@ -5570,7 +5570,7 @@ blendfunc add
 
 textures/pad_jail/pad_jail_smoke_10
 {
-qer_editorimage textures/pad_jail/pad_jail_smoke.tga
+qer_editorimage textures/pad_jail/pad_jail_smoke
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -5580,7 +5580,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -24.899492 2.065606 -19.649031 sawtooth 0 1 0.075369 1.531097
 {
-clampmap textures/pad_jail/pad_jail_smoke.tga
+clampmap textures/pad_jail/pad_jail_smoke
 tcMod rotate 23.264717
 AlphaGen wave sawtooth 0.832759 -0.765484 0.075369 1.531097
 rgbGen wave sawtooth 1.000000 -0.260146 0.075369 1.531097

--- a/wop/scripts.pk3dir/scripts/pad_journey.shader
+++ b/wop/scripts.pk3dir/scripts/pad_journey.shader
@@ -2,19 +2,19 @@
 textures/pad_journey/abhaube005
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_journey/abhaube005.tga
+	qer_editorimage textures/pad_journey/abhaube005
 	{
-		map textures/pad_journey/abhaube005.tga
+		map textures/pad_journey/abhaube005
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -23,19 +23,19 @@ textures/pad_journey/abhaube005
 textures/pad_journey/metal05
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_journey/metal05.tga
+	qer_editorimage textures/pad_journey/metal05
 	{
-		map textures/pad_journey/metal05.tga
+		map textures/pad_journey/metal05
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -43,19 +43,19 @@ textures/pad_journey/metal05
 
 textures/pad_journey/mirror_01
 {
-	qer_editorimage textures/pad_journey/mirror_01.tga
+	qer_editorimage textures/pad_journey/mirror_01
 	{
-		map textures/pad_journey/mirror_01.tga
+		map textures/pad_journey/mirror_01
 		rgbGen identity
 	}
 	{
-		map textures/pad_journey/mirrorgl_02.tga
+		map textures/pad_journey/mirrorgl_02
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -64,19 +64,19 @@ textures/pad_journey/mirror_01
 
 textures/pad_journey/mirror_02
 {
-	qer_editorimage textures/pad_journey/mirror_02.tga
+	qer_editorimage textures/pad_journey/mirror_02
 	{
-		map textures/pad_journey/mirror_02.tga
+		map textures/pad_journey/mirror_02
 		rgbGen identity
 	}
 	{
-		map textures/pad_journey/mirrorgl_03.tga
+		map textures/pad_journey/mirrorgl_03
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -85,19 +85,19 @@ textures/pad_journey/mirror_02
 
 textures/pad_journey/mirror_03
 {
-	qer_editorimage textures/pad_journey/mirror_01.tga
+	qer_editorimage textures/pad_journey/mirror_01
 	{
-		map textures/pad_journey/mirror_01.tga
+		map textures/pad_journey/mirror_01
 		rgbGen identity
 	}
 	{
-		map textures/pad_journey/mirrorgl_04.tga
+		map textures/pad_journey/mirrorgl_04
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -106,19 +106,19 @@ textures/pad_journey/mirror_03
 
 textures/pad_journey/mirror_04
 {
-	qer_editorimage textures/pad_journey/mirror_02.tga
+	qer_editorimage textures/pad_journey/mirror_02
 	{
-		map textures/pad_journey/mirror_02.tga
+		map textures/pad_journey/mirror_02
 		rgbGen identity
 	}
 	{
-		map textures/pad_journey/mirrorgl_05.tga
+		map textures/pad_journey/mirrorgl_05
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -127,19 +127,19 @@ textures/pad_journey/mirror_04
 
 textures/pad_journey/mirror_05
 {
-	qer_editorimage textures/pad_journey/mirror_01.tga
+	qer_editorimage textures/pad_journey/mirror_01
 	{
-		map textures/pad_journey/mirror_01.tga
+		map textures/pad_journey/mirror_01
 		rgbGen identity
 	}
 	{
-		map textures/pad_journey/mirrorgl_06.tga
+		map textures/pad_journey/mirrorgl_06
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -148,19 +148,19 @@ textures/pad_journey/mirror_05
 
 textures/pad_journey/mirror_06
 {
-	qer_editorimage textures/pad_journey/mirror_02.tga
+	qer_editorimage textures/pad_journey/mirror_02
 	{
-		map textures/pad_journey/mirror_02.tga
+		map textures/pad_journey/mirror_02
 		rgbGen identity
 	}
 	{
-		map textures/pad_journey/mirrorgl_07.tga
+		map textures/pad_journey/mirrorgl_07
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -169,16 +169,16 @@ textures/pad_journey/mirror_06
 
 textures/pad_journey/milchglass02
 {
-	qer_editorimage textures/pad_journey/greywhite.tga
+	qer_editorimage textures/pad_journey/greywhite
 	cull back
 	{
-		map textures/pad_journey/greywhite.tga
+		map textures/pad_journey/greywhite
 		blendfunc add
 	}
 	{
-		map textures/pad_gfx/env2.tga
+		map textures/pad_gfx/env2
 		blendfunc filter
-		tcGen environment 
+		tcGen environment
 	}
 }
 
@@ -187,12 +187,12 @@ textures/pad_journey/puppet_window02
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
-         
-     
+
+
         {
-                map textures/pad_journey/puppet_window02.tga
+                map textures/pad_journey/puppet_window02
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -212,13 +212,13 @@ textures/pad_journey/trainticket
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_journey/trainticket.tga
+                map textures/pad_journey/trainticket
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -238,13 +238,13 @@ textures/pad_journey/trainticketr
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_journey/trainticketr.tga
+                map textures/pad_journey/trainticketr
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -264,12 +264,12 @@ textures/pad_journey/oberl01
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
-         
-     
+
+
         {
-                map textures/pad_journey/oberl01.tga
+                map textures/pad_journey/oberl01
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -293,7 +293,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_journey/blue_trainchair02.tga
+map textures/pad_journey/blue_trainchair02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -308,7 +308,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_journey/red_trainchair02.tga
+map textures/pad_journey/red_trainchair02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -323,7 +323,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_journey/riffelblech01.tga
+map textures/pad_journey/riffelblech01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -338,7 +338,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_journey/wood019blu.tga
+map textures/pad_journey/wood019blu
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -353,7 +353,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_journey/wood019red.tga
+map textures/pad_journey/wood019red
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -362,19 +362,19 @@ rgbGen identity
 
 textures/pad_journey/schienen01
 {
-      qer_editorimage textures/pad_journey/schienen01.tga
+      qer_editorimage textures/pad_journey/schienen01
       surfaceparm nolightmap
       surfaceparm nonsolid
       surfaceparm trans
       cull disable
 
       {
-            map textures/pad_journey/schienen01.tga
+            map textures/pad_journey/schienen01
             blendfunc blend
             tcMod scroll 0 -2.6
       }
       {
-            map textures/pad_journey/schienen01.tga
+            map textures/pad_journey/schienen01
             blendfunc blend
             tcMod scroll 0 -2.6
       }
@@ -383,19 +383,19 @@ textures/pad_journey/schienen01
 
 textures/pad_journey/nature_train
 {
-      qer_editorimage textures/pad_journey/nature_train.tga
+      qer_editorimage textures/pad_journey/nature_train
       surfaceparm nolightmap
       surfaceparm nonsolid
       surfaceparm trans
       cull disable
 
       {
-            map textures/pad_journey/nature_train.tga
+            map textures/pad_journey/nature_train
             blendfunc blend
             tcMod scroll 0 -2.5
       }
       {
-            map textures/pad_journey/nature_train.tga
+            map textures/pad_journey/nature_train
             blendfunc blend
             tcMod scroll 0 -2.5
       }
@@ -404,19 +404,19 @@ textures/pad_journey/nature_train
 
 textures/pad_journey/wall_stone_train
 {
-      qer_editorimage textures/pad_journey/wall_stone_train.tga
+      qer_editorimage textures/pad_journey/wall_stone_train
       surfaceparm nolightmap
       surfaceparm nonsolid
       surfaceparm trans
       cull disable
 
       {
-            map textures/pad_journey/wall_stone_train.tga
+            map textures/pad_journey/wall_stone_train
             blendfunc blend
             tcMod scroll 0 -1.2
       }
       {
-            map textures/pad_journey/wall_stone_train.tga
+            map textures/pad_journey/wall_stone_train
             blendfunc blend
             tcMod scroll 0 -1.2
       }
@@ -425,19 +425,19 @@ textures/pad_journey/wall_stone_train
 
 textures/pad_journey/wall_stone036_train
 {
-      qer_editorimage textures/pad_journey/wall_stone036_train.tga
+      qer_editorimage textures/pad_journey/wall_stone036_train
       surfaceparm nolightmap
       surfaceparm nonsolid
       surfaceparm trans
       cull disable
 
       {
-            map textures/pad_journey/wall_stone036_train.tga
+            map textures/pad_journey/wall_stone036_train
             blendfunc blend
             tcMod scroll 0 -3.6
       }
       {
-            map textures/pad_journey/wall_stone036_train.tga
+            map textures/pad_journey/wall_stone036_train
             blendfunc blend
             tcMod scroll 0 -3.6
       }
@@ -446,19 +446,19 @@ textures/pad_journey/wall_stone036_train
 
 textures/pad_journey/plakat
 {
-        qer_editorimage textures/pad_journey/plakat.tga
+        qer_editorimage textures/pad_journey/plakat
 	{
-		map textures/pad_journey/plakat.tga
+		map textures/pad_journey/plakat
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}

--- a/wop/scripts.pk3dir/scripts/pad_kitchen.shader
+++ b/wop/scripts.pk3dir/scripts/pad_kitchen.shader
@@ -1,18 +1,18 @@
 textures/pad_kitchen/cookstation
 {
-	qer_editorimage textures/pad_kitchen/cookstation.tga
+	qer_editorimage textures/pad_kitchen/cookstation
 	{
-		map textures/pad_kitchen/cookstation.tga
+		map textures/pad_kitchen/cookstation
 		rgbGen identity
 	}
 	{
-		map textures/pad_kitchen/cookstation02.tga
+		map textures/pad_kitchen/cookstation02
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -21,19 +21,19 @@ textures/pad_kitchen/cookstation
 
 textures/pad_kitchen/herdblende
 {
-	qer_editorimage textures/pad_kitchen/herdblende.tga
+	qer_editorimage textures/pad_kitchen/herdblende
 	{
-		map textures/pad_kitchen/herdblende.tga
+		map textures/pad_kitchen/herdblende
 		rgbGen identity
 	}
 	{
-		map textures/pad_kitchen/kitchenglass_05.tga
+		map textures/pad_kitchen/kitchenglass_05
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -42,19 +42,19 @@ textures/pad_kitchen/herdblende
 
 textures/pad_kitchen/smilieb
 {
-	qer_editorimage textures/pad_kitchen/smilieb.tga
+	qer_editorimage textures/pad_kitchen/smilieb
 	{
-		map textures/pad_kitchen/smilieb.tga
+		map textures/pad_kitchen/smilieb
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -63,19 +63,19 @@ textures/pad_kitchen/smilieb
 
 textures/pad_kitchen/smilie02
 {
-	qer_editorimage textures/pad_kitchen/smilie02.tga
+	qer_editorimage textures/pad_kitchen/smilie02
 	{
-		map textures/pad_kitchen/smilie02.tga
+		map textures/pad_kitchen/smilie02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -85,19 +85,19 @@ textures/pad_kitchen/smilie02
 textures/pad_kitchen/potwand
 {
 	surfaceparm metalsteps
-                qer_editorimage textures/pad_kitchen/potwand.tga
+                qer_editorimage textures/pad_kitchen/potwand
 	{
-		map textures/pad_kitchen/potwand.tga
+		map textures/pad_kitchen/potwand
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -108,19 +108,19 @@ textures/pad_kitchen/potwand
 textures/pad_kitchen/pot001c
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_kitchen/pot001c.tga
+	qer_editorimage textures/pad_kitchen/pot001c
 	{
-		map textures/pad_kitchen/pot001c.tga
+		map textures/pad_kitchen/pot001c
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -131,19 +131,19 @@ textures/pad_kitchen/pot001c
 textures/pad_kitchen/abhaube007
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_kitchen/abhaube007.tga
+	qer_editorimage textures/pad_kitchen/abhaube007
 	{
-		map textures/pad_kitchen/abhaube007.tga
+		map textures/pad_kitchen/abhaube007
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -155,19 +155,19 @@ textures/pad_kitchen/abhaube007
 textures/pad_kitchen/abhaube004
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_kitchen/abhaube004.tga
+	qer_editorimage textures/pad_kitchen/abhaube004
 	{
-		map textures/pad_kitchen/abhaube004.tga
+		map textures/pad_kitchen/abhaube004
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -177,19 +177,19 @@ textures/pad_kitchen/abhaube004
 textures/pad_kitchen/metal06b
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_kitchen/metal06b.tga
+	qer_editorimage textures/pad_kitchen/metal06b
 	{
-		map textures/pad_kitchen/metal06b.tga
+		map textures/pad_kitchen/metal06b
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -199,19 +199,19 @@ textures/pad_kitchen/metal06b
 textures/pad_kitchen/metal08
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_kitchen/metal08.tga
+	qer_editorimage textures/pad_kitchen/metal08
 	{
-		map textures/pad_kitchen/metal08.tga
+		map textures/pad_kitchen/metal08
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -221,19 +221,19 @@ textures/pad_kitchen/metal08
 textures/pad_kitchen/metal11
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_kitchen/metal11.tga
+	qer_editorimage textures/pad_kitchen/metal11
 	{
-		map textures/pad_kitchen/metal11.tga
+		map textures/pad_kitchen/metal11
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -243,19 +243,19 @@ textures/pad_kitchen/metal11
 
 textures/pad_kitchen/plas01
 {
-	qer_editorimage textures/pad_kitchen/plas01.tga
+	qer_editorimage textures/pad_kitchen/plas01
 	{
-		map textures/pad_kitchen/plas01.tga
+		map textures/pad_kitchen/plas01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -264,19 +264,19 @@ textures/pad_kitchen/plas01
 
 textures/pad_kitchen/plas03
 {
-	qer_editorimage textures/pad_kitchen/plas03.tga
+	qer_editorimage textures/pad_kitchen/plas03
 	{
-		map textures/pad_kitchen/plas03.tga
+		map textures/pad_kitchen/plas03
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -285,19 +285,19 @@ textures/pad_kitchen/plas03
 
 textures/pad_kitchen/plas05
 {
-	qer_editorimage textures/pad_kitchen/plas05.tga
+	qer_editorimage textures/pad_kitchen/plas05
 	{
-		map textures/pad_kitchen/plas05.tga
+		map textures/pad_kitchen/plas05
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -305,19 +305,19 @@ textures/pad_kitchen/plas05
 
 textures/pad_kitchen/plas07
 {
-	qer_editorimage textures/pad_kitchen/plas07.tga
+	qer_editorimage textures/pad_kitchen/plas07
 	{
-		map textures/pad_kitchen/plas07.tga
+		map textures/pad_kitchen/plas07
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -327,19 +327,19 @@ textures/pad_kitchen/plas07
 textures/pad_kitchen/metal02
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_kitchen/metal02.tga
+	qer_editorimage textures/pad_kitchen/metal02
 	{
-		map textures/pad_kitchen/metal02.tga
+		map textures/pad_kitchen/metal02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -350,36 +350,36 @@ textures/pad_kitchen/metal02
 
 textures/pad_kitchen/urban-chaos
 {
-        qer_editorimage textures/pad_kitchen/urban-chaos.tga
+        qer_editorimage textures/pad_kitchen/urban-chaos
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
 //	surfaceparm sky
-              q3map_lightimage textures/pad_kitchen/white02.tga
+              q3map_lightimage textures/pad_kitchen/white02
 	q3map_sun	0.266383 0.274632 0.358662 100 50 55
 	q3map_surfacelight 240
 
         skyparms env/urban-chaos512 - -
-	
+
 }
 
 
 textures/pad_kitchen/micro
 {
-	qer_editorimage textures/pad_kitchen/micro.tga
+	qer_editorimage textures/pad_kitchen/micro
 	{
-		map textures/pad_kitchen/micro.tga
+		map textures/pad_kitchen/micro
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -388,19 +388,19 @@ textures/pad_kitchen/micro
 textures/pad_kitchen/micro02
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_kitchen/micro02.tga
+	qer_editorimage textures/pad_kitchen/micro02
 	{
-		map textures/pad_kitchen/micro02.tga
+		map textures/pad_kitchen/micro02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -412,7 +412,7 @@ textures/pad_kitchen/microglass01
 	q3map_nolightmap
 	q3map_onlyvertexlighting
     {
-        map textures/pad_kitchen/microglass01.tga
+        map textures/pad_kitchen/microglass01
         blendFunc GL_ONE GL_ONE
     }
 }
@@ -420,12 +420,12 @@ textures/pad_kitchen/microglass01
 
 textures/pad_kitchen/microglass03
 {
-	qer_editorimage	textures/pad_kitchen/microglass03.tga
+	qer_editorimage	textures/pad_kitchen/microglass03
               surfaceparm trans
 	q3map_nolightmap
 	q3map_onlyvertexlighting
     {
-        map textures/pad_kitchen/microglass03.tga
+        map textures/pad_kitchen/microglass03
         blendFunc GL_ONE GL_ONE
     }
 }
@@ -436,7 +436,7 @@ textures/pad_kitchen/microglass04
 	q3map_nolightmap
 	q3map_onlyvertexlighting
     {
-        map textures/pad_kitchen/microglass04.tga
+        map textures/pad_kitchen/microglass04
         blendFunc GL_ONE GL_ONE
     }
 }
@@ -444,7 +444,7 @@ textures/pad_kitchen/microglass04
 
 textures/pad_kitchen/tomatosoup
 {
-	qer_editorimage textures/pad_kitchen/suppe001small.tga
+	qer_editorimage textures/pad_kitchen/suppe001small
 	qer_trans .8
 	q3map_globaltexture
 	surfaceparm nonsolid
@@ -454,7 +454,7 @@ textures/pad_kitchen/tomatosoup
 	deformVertexes wave 100 sin 4 3 0 0.3
 
 	{
-		map textures/pad_kitchen/suppe001small.tga
+		map textures/pad_kitchen/suppe001small
 		rgbgen vertex
 		tcmod scale .4 .4
 		tcmod scroll .002 .002
@@ -466,19 +466,19 @@ textures/pad_kitchen/tomatosoup
 textures/pad_kitchen/toaster02
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_kitchen/toaster02.tga
+	qer_editorimage textures/pad_kitchen/toaster02
 	{
-		map textures/pad_kitchen/toaster02.tga
+		map textures/pad_kitchen/toaster02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -487,7 +487,7 @@ textures/pad_kitchen/toaster02
 
 textures/pad_kitchen/toaster_draht
 {
-	qer_editorimage textures/pad_kitchen/toaster_draht.tga
+	qer_editorimage textures/pad_kitchen/toaster_draht
 	q3map_surfacelight 30
 //	light 1
 	surfaceparm nomarks
@@ -496,12 +496,12 @@ textures/pad_kitchen/toaster_draht
 		rgbGen identity
 	}
 	{
-		map textures/pad_kitchen/toaster_draht.tga
+		map textures/pad_kitchen/toaster_draht
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_kitchen/toaster_draht02.tga
+		map textures/pad_kitchen/toaster_draht02
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -512,13 +512,13 @@ textures/pad_kitchen/filti
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_kitchen/filti.tga
+                map textures/pad_kitchen/filti
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -536,19 +536,19 @@ textures/pad_kitchen/filti
 
 textures/pad_kitchen/mosawindow
 {
-	qer_editorimage textures/pad_kitchen/mosawindow.tga
+	qer_editorimage textures/pad_kitchen/mosawindow
 	{
-		map textures/pad_kitchen/mosawindow.tga
+		map textures/pad_kitchen/mosawindow
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -558,19 +558,19 @@ textures/pad_kitchen/mosawindow
 
 textures/pad_kitchen/kitcheng_01
 {
-	qer_editorimage textures/pad_kitchen/kitcheng_01.tga
+	qer_editorimage textures/pad_kitchen/kitcheng_01
 	{
-		map textures/pad_kitchen/kitcheng_01.tga
+		map textures/pad_kitchen/kitcheng_01
 		rgbGen identity
 	}
 	{
-		map textures/pad_kitchen/kitchenglass_02.tga
+		map textures/pad_kitchen/kitchenglass_02
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -579,19 +579,19 @@ textures/pad_kitchen/kitcheng_01
 
 textures/pad_kitchen/kitcheng_neutral
 {
-	qer_editorimage textures/pad_kitchen/kitcheng_03.tga
+	qer_editorimage textures/pad_kitchen/kitcheng_03
 	{
-		map textures/pad_kitchen/kitcheng_03.tga
+		map textures/pad_kitchen/kitcheng_03
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -604,14 +604,14 @@ textures/pad_kitchen/lighty
     q3map_surfacelight 500
     surfaceparm nolightmap
     {
-        map textures/pad_kitchen/lighty.tga
+        map textures/pad_kitchen/lighty
     }
 }
 
 
 textures/pad_kitchen/modder01
 {
-		qer_editorimage textures/pad_kitchen/modder01.tga
+		qer_editorimage textures/pad_kitchen/modder01
 		qer_trans 0.5
 		q3map_globaltexture
 		surfaceparm trans
@@ -619,18 +619,18 @@ textures/pad_kitchen/modder01
 		surfaceparm water
 		cull disable
 
-{ 
-		
-		map textures/pad_kitchen/modder01.tga
+{
+
+		map textures/pad_kitchen/modder01
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale 0.70 0.70
 		tcmod transform 1.2 0 1.2 1 1 2
 		tcmod scroll -.05 .001
 	}
-	
-{ 
-		map textures/pad_kitchen/modder02.tga
+
+{
+		map textures/pad_kitchen/modder02
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale 0.5 0.5
@@ -638,18 +638,18 @@ textures/pad_kitchen/modder01
 		tcmod scroll .025 -.001
 	}
 
-{ 
-		map textures/pad_kitchen/modder01.tga
+{
+		map textures/pad_kitchen/modder01
 		blendFunc GL_dst_color GL_one
 		rgbgen identity
 		tcmod scale .25 .5
 		tcmod scroll .001 .025
 	}
-	
+
 {
 		map $lightmap
 		blendFunc GL_dst_color GL_zero
-		rgbgen identity		
+		rgbgen identity
 	}
 }
 
@@ -657,126 +657,126 @@ textures/pad_kitchen/modder01
 
 
 textures/pad_kitchen/moddersmall
-{ 
-        qer_editorimage textures/pad_kitchen/modder03small.tga 
-      //q3map_lightimage textures/pad_kitchen/modder03small.tga 
-        qer_trans 0.5 
-        q3map_globaltexture 
-        surfaceparm trans 
-        surfaceparm nolightmap 
-        surfaceparm nonsolid 
-        surfaceparm water 
+{
+        qer_editorimage textures/pad_kitchen/modder03small
+      //q3map_lightimage textures/pad_kitchen/modder03small
+        qer_trans 0.5
+        q3map_globaltexture
+        surfaceparm trans
+        surfaceparm nolightmap
+        surfaceparm nonsolid
+        surfaceparm water
         surfaceparm fog
-        cull disable 
-        
+        cull disable
+
         fogparms ( .211 .231 .094 ) 650
-        { 
-               map textures/pad_kitchen/modder03small.tga 
-               tcMod turb 0.2 0.1 1 0.05 
-               tcMod scale 0.5 0.5 
-               tcMod scroll 0.01 0.01 
-               blendfunc GL_DST_COLOR GL_ZERO 
-               rgbGen identity 
+        {
+               map textures/pad_kitchen/modder03small
+               tcMod turb 0.2 0.1 1 0.05
+               tcMod scale 0.5 0.5
+               tcMod scroll 0.01 0.01
+               blendfunc GL_DST_COLOR GL_ZERO
+               rgbGen identity
 
-        } 
+        }
 
-} 
+}
 
 
 textures/pad_kitchen/moddersmall02_nofog
-{ 
-        qer_editorimage textures/pad_kitchen/modder03small.tga 
-      //q3map_lightimage textures/pad_kitchen/modder03small.tga 
-        qer_trans 0.5 
-        q3map_globaltexture 
-        surfaceparm trans 
-        surfaceparm nolightmap 
-        surfaceparm nonsolid 
-        surfaceparm water 
-        cull disable 
+{
+        qer_editorimage textures/pad_kitchen/modder03small
+      //q3map_lightimage textures/pad_kitchen/modder03small
+        qer_trans 0.5
+        q3map_globaltexture
+        surfaceparm trans
+        surfaceparm nolightmap
+        surfaceparm nonsolid
+        surfaceparm water
+        cull disable
 
-        { 
-               map textures/pad_kitchen/modder03small.tga 
-               tcMod turb 0.2 0.1 1 0.05 
-               tcMod scale 0.5 0.5 
-               tcMod scroll 0.01 0.01 
-               blendfunc GL_DST_COLOR GL_ZERO 
-               rgbGen identity 
+        {
+               map textures/pad_kitchen/modder03small
+               tcMod turb 0.2 0.1 1 0.05
+               tcMod scale 0.5 0.5
+               tcMod scroll 0.01 0.01
+               blendfunc GL_DST_COLOR GL_ZERO
+               rgbGen identity
 
-        } 
+        }
 
-} 
-
-
+}
 
 
-textures/pad_kitchen/spuelwater 
-{ 
-        qer_editorimage textures/pad_kitchen/spuelwater.tga 
-      //q3map_lightimage textures/pad_gfx/water_02.tga 
-        qer_trans 0.5 
-        q3map_globaltexture 
-        surfaceparm trans 
-        surfaceparm nolightmap 
-        surfaceparm nonsolid 
-        surfaceparm water 
+
+
+textures/pad_kitchen/spuelwater
+{
+        qer_editorimage textures/pad_kitchen/spuelwater
+      //q3map_lightimage textures/pad_gfx/water_02
+        qer_trans 0.5
+        q3map_globaltexture
+        surfaceparm trans
+        surfaceparm nolightmap
+        surfaceparm nonsolid
+        surfaceparm water
         surfaceparm fog
-        cull disable 
-        
+        cull disable
+
         fogparms ( 0.1 0.1 0.3 ) 650
-        { 
-               map textures/pad_kitchen/spuelwater.tga 
-               tcMod turb 0.2 0.1 1 0.05 
-               tcMod scale 0.5 0.5 
-               tcMod scroll 0.01 0.01 
-               blendfunc add 
-               rgbGen identity 
+        {
+               map textures/pad_kitchen/spuelwater
+               tcMod turb 0.2 0.1 1 0.05
+               tcMod scale 0.5 0.5
+               tcMod scroll 0.01 0.01
+               blendfunc add
+               rgbGen identity
 
-        } 
+        }
 
-} 
+}
 
 
 textures/pad_kitchen/spuelwater_nofog
-{ 
-        qer_editorimage textures/pad_kitchen/spuelwater.tga 
-        qer_trans 0.5 
-        q3map_globaltexture 
-        surfaceparm trans 
-        surfaceparm nolightmap 
-        surfaceparm nonsolid 
+{
+        qer_editorimage textures/pad_kitchen/spuelwater
+        qer_trans 0.5
+        q3map_globaltexture
+        surfaceparm trans
+        surfaceparm nolightmap
+        surfaceparm nonsolid
         surfaceparm water
-        cull disable 
+        cull disable
 
-        { 
-               map textures/pad_kitchen/spuelwater.tga 
-               tcMod turb 0.2 0.1 1 0.05 
-               tcMod scale 0.5 0.5 
-               tcMod scroll 0.01 0.01 
-               blendfunc add 
-               rgbGen identity 
+        {
+               map textures/pad_kitchen/spuelwater
+               tcMod turb 0.2 0.1 1 0.05
+               tcMod scale 0.5 0.5
+               tcMod scroll 0.01 0.01
+               blendfunc add
+               rgbGen identity
 
-        } 
+        }
 
-} 
+}
 
 
 
 textures/pad_kitchen/coffy01
 {
-	qer_editorimage textures/pad_kitchen/coffy01.tga
+	qer_editorimage textures/pad_kitchen/coffy01
 	{
-		map textures/pad_kitchen/coffy01.tga
+		map textures/pad_kitchen/coffy01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen vertex
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -784,19 +784,19 @@ textures/pad_kitchen/coffy01
 
 textures/pad_kitchen/coffy02
 {
-	qer_editorimage textures/pad_kitchen/coffy02.tga
+	qer_editorimage textures/pad_kitchen/coffy02
 	{
-		map textures/pad_kitchen/coffy02.tga
+		map textures/pad_kitchen/coffy02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen vertex
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -805,19 +805,19 @@ textures/pad_kitchen/coffy02
 
 textures/pad_kitchen/coffy03
 {
-	qer_editorimage textures/pad_kitchen/coffy03.tga
+	qer_editorimage textures/pad_kitchen/coffy03
 	{
-		map textures/pad_kitchen/coffy03.tga
+		map textures/pad_kitchen/coffy03
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen vertex
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -826,19 +826,19 @@ textures/pad_kitchen/coffy03
 
 textures/pad_kitchen/coffy04
 {
-	qer_editorimage textures/pad_kitchen/coffy04.tga
+	qer_editorimage textures/pad_kitchen/coffy04
 	{
-		map textures/pad_kitchen/coffy04.tga
+		map textures/pad_kitchen/coffy04
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen vertex
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -848,19 +848,19 @@ textures/pad_kitchen/coffy04
 
 textures/pad_kitchen/coffy05
 {
-	qer_editorimage textures/pad_kitchen/coffy05.tga
+	qer_editorimage textures/pad_kitchen/coffy05
 	{
-		map textures/pad_kitchen/coffy05.tga
+		map textures/pad_kitchen/coffy05
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -869,19 +869,19 @@ textures/pad_kitchen/coffy05
 
 textures/pad_kitchen/coffy06
 {
-	qer_editorimage textures/pad_kitchen/coffy06.tga
+	qer_editorimage textures/pad_kitchen/coffy06
 	{
-		map textures/pad_kitchen/coffy06.tga
+		map textures/pad_kitchen/coffy06
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -893,13 +893,13 @@ textures/pad_kitchen/lampi06
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_kitchen/lampi06.tga
+                map textures/pad_kitchen/lampi06
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -917,7 +917,7 @@ textures/pad_kitchen/lampi06
 
 textures/pad_kitchen/radio
 {
-	qer_editorimage textures/pad_kitchen/radio001.tga
+	qer_editorimage textures/pad_kitchen/radio001
 	surfaceparm nomarks
 	q3map_surfacelight 60
 	//light 1
@@ -928,12 +928,12 @@ textures/pad_kitchen/radio
 		rgbGen identity
 	}
 	{
-		map textures/pad_kitchen/radio001.tga
+		map textures/pad_kitchen/radio001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_kitchen/radio_blend.tga
+		map textures/pad_kitchen/radio_blend
                 rgbGen wave sin 0.1 0.2 0 2
 		blendfunc GL_ONE GL_ONE
 	}
@@ -942,7 +942,7 @@ textures/pad_kitchen/radio
 
 textures/pad_kitchen/coffybutton
 {
-	qer_editorimage textures/pad_kitchen/coffybutton.tga
+	qer_editorimage textures/pad_kitchen/coffybutton
 	surfaceparm nomarks
 	q3map_surfacelight 60
 	//light 1
@@ -953,12 +953,12 @@ textures/pad_kitchen/coffybutton
 		rgbGen identity
 	}
 	{
-		map textures/pad_kitchen/coffybutton.tga
+		map textures/pad_kitchen/coffybutton
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_kitchen/coffybutton02.tga
+		map textures/pad_kitchen/coffybutton02
                 rgbGen wave sin 0.1 0.2 0 2
 		blendfunc GL_ONE GL_ONE
 	}
@@ -967,94 +967,94 @@ textures/pad_kitchen/coffybutton
 
 textures/pad_kitchen/metal06curv
 {
-          qer_editorimage textures/pad_kitchen/metal06curv.tga
-          surfaceparm nonsolid		
+          qer_editorimage textures/pad_kitchen/metal06curv
+          surfaceparm nonsolid
         {
 		rgbGen identity
 		map $lightmap
 	}
 	{
-		map textures/pad_kitchen/metal06curv.tga
+		map textures/pad_kitchen/metal06curv
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_kitchen/metal06curv.tga
+		map textures/pad_kitchen/metal06curv
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 
 
 textures/pad_kitchen/metal09curv
 {
-          qer_editorimage textures/pad_kitchen/metal09curv.tga
-          surfaceparm nonsolid		
+          qer_editorimage textures/pad_kitchen/metal09curv
+          surfaceparm nonsolid
         {
 		rgbGen identity
 		map $lightmap
 	}
 	{
-		map textures/pad_kitchen/metal09curv.tga
+		map textures/pad_kitchen/metal09curv
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_kitchen/metal09curv.tga
+		map textures/pad_kitchen/metal09curv
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_kitchen/metal10curv
 {
-          qer_editorimage textures/pad_kitchen/metal10curv.tga
-          surfaceparm nonsolid		
+          qer_editorimage textures/pad_kitchen/metal10curv
+          surfaceparm nonsolid
         {
 		rgbGen identity
 		map $lightmap
 	}
 	{
-		map textures/pad_kitchen/metal10curv.tga
+		map textures/pad_kitchen/metal10curv
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_kitchen/metal10curv.tga
+		map textures/pad_kitchen/metal10curv
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_kitchen/degge
@@ -1065,11 +1065,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/degge.tga
+map textures/pad_kitchen/degge
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/deggeb
 {
@@ -1079,11 +1079,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/deggeb.tga
+map textures/pad_kitchen/deggeb
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/flowpot001m
 {
@@ -1093,11 +1093,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/flowpot001m.tga
+map textures/pad_kitchen/flowpot001m
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/buche005c
 {
@@ -1107,11 +1107,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/buche005c.tga
+map textures/pad_kitchen/buche005c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/buche003
 {
@@ -1121,11 +1121,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/buche003.tga
+map textures/pad_kitchen/buche003
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/buche002
 {
@@ -1135,11 +1135,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/buche002.tga
+map textures/pad_kitchen/buche002
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/wood002brown1b
 {
@@ -1149,11 +1149,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/wood002brown1b.tga
+map textures/pad_kitchen/wood002brown1b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/wood002brownb
 {
@@ -1163,11 +1163,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/wood002brownb.tga
+map textures/pad_kitchen/wood002brownb
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/woodboard
 {
@@ -1177,11 +1177,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/woodboard.tga
+map textures/pad_kitchen/woodboard
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/woodboardbrown06
 {
@@ -1191,11 +1191,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/woodboardbrown06.tga
+map textures/pad_kitchen/woodboardbrown06
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/lampi007
 {
@@ -1205,11 +1205,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/lampi007.tga
+map textures/pad_kitchen/lampi007
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/ofeninnen02
 {
@@ -1219,11 +1219,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/ofeninnen02.tga
+map textures/pad_kitchen/ofeninnen02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/schacht01c
 {
@@ -1233,11 +1233,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/schacht01c.tga
+map textures/pad_kitchen/schacht01c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/schacht01b
@@ -1248,11 +1248,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/schacht01b.tga
+map textures/pad_kitchen/schacht01b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/ballo001
@@ -1263,11 +1263,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/ballo001.tga
+map textures/pad_kitchen/ballo001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/ballo003
 {
@@ -1277,11 +1277,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/ballo003.tga
+map textures/pad_kitchen/ballo003
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/ballo004
 {
@@ -1291,11 +1291,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/ballo004.tga
+map textures/pad_kitchen/ballo004
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/ballo005
 {
@@ -1305,11 +1305,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/ballo005.tga
+map textures/pad_kitchen/ballo005
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/blackwoodd
 {
@@ -1319,12 +1319,12 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/blackwoodd.tga
+map textures/pad_kitchen/blackwoodd
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
-	
+}
+
 textures/pad_kitchen/buche001b
 {
 surfaceparm woodsteps
@@ -1333,11 +1333,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/buche001b.tga
+map textures/pad_kitchen/buche001b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 	
+}
 
 textures/pad_kitchen/kitborder03small
 {
@@ -1347,11 +1347,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/kitborder03small.tga
+map textures/pad_kitchen/kitborder03small
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/ofeninnen03small
 {
@@ -1361,11 +1361,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/ofeninnen03small.tga
+map textures/pad_kitchen/ofeninnen03small
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 	
+}
 
 textures/pad_kitchen/ofeninnen04
 {
@@ -1375,11 +1375,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/ofeninnen04.tga
+map textures/pad_kitchen/ofeninnen04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 	
+}
 
 textures/pad_kitchen/ofeninnen05
 {
@@ -1389,11 +1389,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/ofeninnen05.tga
+map textures/pad_kitchen/ofeninnen05
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/ofeninnen06
 {
@@ -1403,11 +1403,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/ofeninnen06.tga
+map textures/pad_kitchen/ofeninnen06
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/sp_boden
 {
@@ -1417,11 +1417,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/sp_boden.tga
+map textures/pad_kitchen/sp_boden
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/sp_wand
 {
@@ -1431,11 +1431,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/sp_wand.tga
+map textures/pad_kitchen/sp_wand
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/sp_waterdrops
 {
@@ -1445,11 +1445,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/sp_waterdrops.tga
+map textures/pad_kitchen/sp_waterdrops
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/sp_rillen
 {
@@ -1459,11 +1459,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/sp_rillen.tga
+map textures/pad_kitchen/sp_rillen
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/tunnelgroundbig
@@ -1474,11 +1474,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/tunnelgroundbig.tga
+map textures/pad_kitchen/tunnelgroundbig
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 
@@ -1490,25 +1490,25 @@ textures/pad_kitchen/hahnred
 		map $lightmap
 	}
 	{
-		map textures/pad_kitchen/hahnred.tga
+		map textures/pad_kitchen/hahnred
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_kitchen/hahnred.tga
+		map textures/pad_kitchen/hahnred
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}    
+}
 
 
 textures/pad_kitchen/hahnblue
@@ -1519,36 +1519,36 @@ textures/pad_kitchen/hahnblue
 		map $lightmap
 	}
 	{
-		map textures/pad_kitchen/hahnblue.tga
+		map textures/pad_kitchen/hahnblue
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_kitchen/hahnblue.tga
+		map textures/pad_kitchen/hahnblue
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}    
+}
 
 
 textures/pad_kitchen/schrankglass
 {
-  	qer_editorimage textures/pad_kitchen/kitchenglass_02.tga
-              surfaceparm trans	
+  	qer_editorimage textures/pad_kitchen/kitchenglass_02
+              surfaceparm trans
 	cull none
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_kitchen/kitchenglass_02.tga
+		map textures/pad_kitchen/kitchenglass_02
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -1558,7 +1558,7 @@ textures/pad_kitchen/schrankglass
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
@@ -1570,11 +1570,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/flowpot001c.tga
+map textures/pad_kitchen/flowpot001c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/flowpot001e
@@ -1585,11 +1585,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/flowpot001e.tga
+map textures/pad_kitchen/flowpot001e
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/flowpot001i
@@ -1600,11 +1600,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/flowpot001i.tga
+map textures/pad_kitchen/flowpot001i
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/flowpot001k
 {
@@ -1614,11 +1614,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/flowpot001k.tga
+map textures/pad_kitchen/flowpot001k
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/woodsockelbb
 {
@@ -1628,11 +1628,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/woodsockelbb.tga
+map textures/pad_kitchen/woodsockelbb
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/woodboardblue
@@ -1643,11 +1643,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/woodboardblue.tga
+map textures/pad_kitchen/woodboardblue
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/woodboardbrown03
@@ -1658,11 +1658,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/woodboardbrown03.tga
+map textures/pad_kitchen/woodboardbrown03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/lampi001
@@ -1673,11 +1673,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/lampi001.tga
+map textures/pad_kitchen/lampi001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/boarddoor011
@@ -1688,11 +1688,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/boarddoor011.tga
+map textures/pad_kitchen/boarddoor011
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/boarddoor01b
 {
@@ -1702,11 +1702,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/boarddoor01b.tga
+map textures/pad_kitchen/boarddoor01b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/boarddoor02b
 {
@@ -1716,11 +1716,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/boarddoor02b.tga
+map textures/pad_kitchen/boarddoor02b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/boarddoor04b
 {
@@ -1730,11 +1730,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/boarddoor04b.tga
+map textures/pad_kitchen/boarddoor04b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/cup_border2
 {
@@ -1744,11 +1744,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/cup_border2.tga
+map textures/pad_kitchen/cup_border2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/cup_border2brown
 {
@@ -1758,11 +1758,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/cup_border2brown.tga
+map textures/pad_kitchen/cup_border2brown
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/cup_border2red
 {
@@ -1772,11 +1772,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/cup_border2red.tga
+map textures/pad_kitchen/cup_border2red
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/flowpot002c
 {
@@ -1786,11 +1786,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/flowpot002c.tga
+map textures/pad_kitchen/flowpot002c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/flowpot002d
 {
@@ -1800,11 +1800,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/flowpot002d.tga
+map textures/pad_kitchen/flowpot002d
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_kitchen/flowpot002dd
 {
@@ -1814,11 +1814,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/flowpot002dd.tga
+map textures/pad_kitchen/flowpot002dd
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/flowpot003
@@ -1829,11 +1829,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/flowpot003.tga
+map textures/pad_kitchen/flowpot003
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_kitchen/kitborder02small
@@ -1844,11 +1844,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_kitchen/kitborder02small.tga
+map textures/pad_kitchen/kitborder02small
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 

--- a/wop/scripts.pk3dir/scripts/pad_mapobjects.shader
+++ b/wop/scripts.pk3dir/scripts/pad_mapobjects.shader
@@ -9,7 +9,7 @@ models/mapobjects/gummybears/greengum
 {
 
 	{
-                map models/mapobjects/gummybears/greengum.tga
+                map models/mapobjects/gummybears/greengum
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
         }
@@ -21,7 +21,7 @@ models/mapobjects/gummybears/redgum
 {
 
 	{
-                map models/mapobjects/gummybears/redgum.tga
+                map models/mapobjects/gummybears/redgum
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
         }
@@ -33,7 +33,7 @@ models/mapobjects/gummybears/redgum
 models/mapobjects/gummybears/yellowgum
 {
 	{
-                map models/mapobjects/gummybears/yellowgum.tga
+                map models/mapobjects/gummybears/yellowgum
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
         }
@@ -46,7 +46,7 @@ models/mapobjects/gummybears/yellowgum
 models/mapobjects/gummybears/orangegum
 {
 	{
-                map models/mapobjects/gummybears/orangegum.tga
+                map models/mapobjects/gummybears/orangegum
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
         }
@@ -65,9 +65,9 @@ models/mapobjects/pad_cake/pad_cakeplatetop
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_cake/plate001.tga
+	qer_editorimage models/mapobjects/pad_cake/plate001
 	{
-		map models/mapobjects/pad_cake/plate001.tga
+		map models/mapobjects/pad_cake/plate001
 		rgbGen vertex
 	}
 	{
@@ -76,7 +76,7 @@ models/mapobjects/pad_cake/pad_cakeplatetop
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -89,9 +89,9 @@ models/mapobjects/pad_cake/pad_cakeplaterim
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_cake/plate_pack005.tga
+	qer_editorimage models/mapobjects/pad_cake/plate_pack005
 	{
-		map models/mapobjects/pad_cake/plate_pack005.tga
+		map models/mapobjects/pad_cake/plate_pack005
 		rgbGen vertex
 	}
 	{
@@ -100,7 +100,7 @@ models/mapobjects/pad_cake/pad_cakeplaterim
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -113,9 +113,9 @@ models/mapobjects/pad_cake/pad_cakestandbase
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_cake/plate_under.tga
+	qer_editorimage models/mapobjects/pad_cake/plate_under
 	{
-		map models/mapobjects/pad_cake/plate_under.tga
+		map models/mapobjects/pad_cake/plate_under
         	rgbGen vertex
 	}
 	{
@@ -124,7 +124,7 @@ models/mapobjects/pad_cake/pad_cakestandbase
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -138,7 +138,7 @@ models/mapobjects/pad_cake/pad_cake
 	nomipmaps
 
 	{
-		map models/mapobjects/pad_cake/pad_cake.tga
+		map models/mapobjects/pad_cake/pad_cake
 		rgbGen vertex
 	}
 	{
@@ -157,7 +157,7 @@ models/mapobjects/pad_cake/pad_cakeglass
 	sort additive
 
 	{
-		map models/mapobjects/pad_cake/pad_cakeglass.tga
+		map models/mapobjects/pad_cake/pad_cakeglass
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
 		rgbGen vertex
@@ -168,7 +168,7 @@ models/mapobjects/pad_cake/pad_cakeglass
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		tcGen environment
 		blendfunc GL_ONE GL_ONE
 		rgbGen vertex
@@ -190,7 +190,7 @@ models/mapobjects/pad_condiments/saltandpepper
 	//sort 16
 
 	{
-		map models/mapobjects/pad_condiments/saltandpepper.tga
+		map models/mapobjects/pad_condiments/saltandpepper
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -201,7 +201,7 @@ models/mapobjects/pad_condiments/saltandpepper
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -217,7 +217,7 @@ models/mapobjects/pad_condiments/sugar
 	//sort 16
 
 	{
-		map models/mapobjects/pad_condiments/sugar.tga
+		map models/mapobjects/pad_condiments/sugar
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -228,7 +228,7 @@ models/mapobjects/pad_condiments/sugar
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -248,7 +248,7 @@ models/mapobjects/pad_cups/cup001
 	//sort 16
 
 	{
-		map models/mapobjects/pad_cups/cup001.tga
+		map models/mapobjects/pad_cups/cup001
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -259,7 +259,7 @@ models/mapobjects/pad_cups/cup001
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -274,7 +274,7 @@ models/mapobjects/pad_cups/cup002
 	//sort 16
 
 	{
-		map models/mapobjects/pad_cups/cup002.tga
+		map models/mapobjects/pad_cups/cup002
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -285,7 +285,7 @@ models/mapobjects/pad_cups/cup002
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -301,7 +301,7 @@ models/mapobjects/pad_cups/cup003
 	//sort 16
 
 	{
-		map models/mapobjects/pad_cups/cup003.tga
+		map models/mapobjects/pad_cups/cup003
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -312,7 +312,7 @@ models/mapobjects/pad_cups/cup003
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -328,7 +328,7 @@ models/mapobjects/pad_cups/cup004
 	//sort 16
 
 	{
-		map models/mapobjects/pad_cups/cup004.tga
+		map models/mapobjects/pad_cups/cup004
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -339,7 +339,7 @@ models/mapobjects/pad_cups/cup004
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -355,7 +355,7 @@ models/mapobjects/pad_cups/cup_under
 	//sort 16
 
 	{
-		map models/mapobjects/pad_cups/cup_under.tga
+		map models/mapobjects/pad_cups/cup_under
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -366,7 +366,7 @@ models/mapobjects/pad_cups/cup_under
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -382,7 +382,7 @@ models/mapobjects/pad_cups/handle
 	//sort 16
 
 	{
-		map models/mapobjects/pad_cups/handle.tga
+		map models/mapobjects/pad_cups/handle
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -393,7 +393,7 @@ models/mapobjects/pad_cups/handle
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -409,7 +409,7 @@ models/mapobjects/pad_plates/plate001
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate001.tga
+		map models/mapobjects/pad_plates/plate001
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -420,7 +420,7 @@ models/mapobjects/pad_plates/plate001
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -436,7 +436,7 @@ models/mapobjects/pad_plates/plate002
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate002.tga
+		map models/mapobjects/pad_plates/plate002
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -447,7 +447,7 @@ models/mapobjects/pad_plates/plate002
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -463,7 +463,7 @@ models/mapobjects/pad_plates/plate003
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate003.tga
+		map models/mapobjects/pad_plates/plate003
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -474,7 +474,7 @@ models/mapobjects/pad_plates/plate003
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -490,7 +490,7 @@ models/mapobjects/pad_plates/plate004
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate004.tga
+		map models/mapobjects/pad_plates/plate004
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -501,7 +501,7 @@ models/mapobjects/pad_plates/plate004
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -517,7 +517,7 @@ models/mapobjects/pad_plates/plate005
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate005.tga
+		map models/mapobjects/pad_plates/plate005
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -528,7 +528,7 @@ models/mapobjects/pad_plates/plate005
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -544,7 +544,7 @@ models/mapobjects/pad_plates/plate_pack003
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_pack003.tga
+		map models/mapobjects/pad_plates/plate_pack003
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -555,7 +555,7 @@ models/mapobjects/pad_plates/plate_pack003
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -571,7 +571,7 @@ models/mapobjects/pad_plates/plate_pack004
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_pack004.tga
+		map models/mapobjects/pad_plates/plate_pack004
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -582,7 +582,7 @@ models/mapobjects/pad_plates/plate_pack004
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -598,7 +598,7 @@ models/mapobjects/pad_plates/plate_pack005
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_pack005.tga
+		map models/mapobjects/pad_plates/plate_pack005
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -609,7 +609,7 @@ models/mapobjects/pad_plates/plate_pack005
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -625,7 +625,7 @@ models/mapobjects/pad_plates/plate_pack
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_pack.tga
+		map models/mapobjects/pad_plates/plate_pack
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -636,7 +636,7 @@ models/mapobjects/pad_plates/plate_pack
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -652,7 +652,7 @@ models/mapobjects/pad_plates/plate_under
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_under.tga
+		map models/mapobjects/pad_plates/plate_under
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -663,7 +663,7 @@ models/mapobjects/pad_plates/plate_under
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -679,7 +679,7 @@ models/mapobjects/pad_plates/plate_coffee002
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_coffee002.tga
+		map models/mapobjects/pad_plates/plate_coffee002
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -690,7 +690,7 @@ models/mapobjects/pad_plates/plate_coffee002
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -706,7 +706,7 @@ models/mapobjects/pad_plates/plate_coffee003
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_coffee003.tga
+		map models/mapobjects/pad_plates/plate_coffee003
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -717,7 +717,7 @@ models/mapobjects/pad_plates/plate_coffee003
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -733,7 +733,7 @@ models/mapobjects/pad_plates/plate_coffee004
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_coffee004.tga
+		map models/mapobjects/pad_plates/plate_coffee004
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -744,7 +744,7 @@ models/mapobjects/pad_plates/plate_coffee004
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -760,7 +760,7 @@ models/mapobjects/pad_plates/plate_coffee005
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_coffee005.tga
+		map models/mapobjects/pad_plates/plate_coffee005
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -771,7 +771,7 @@ models/mapobjects/pad_plates/plate_coffee005
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -787,7 +787,7 @@ models/mapobjects/pad_plates/plate_coffeeblue
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_coffeeblue.tga
+		map models/mapobjects/pad_plates/plate_coffeeblue
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -798,7 +798,7 @@ models/mapobjects/pad_plates/plate_coffeeblue
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -814,7 +814,7 @@ models/mapobjects/pad_plates/plate_coffeered
 	//sort 16
 
 	{
-		map models/mapobjects/pad_plates/plate_coffeered.tga
+		map models/mapobjects/pad_plates/plate_coffeered
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -825,7 +825,7 @@ models/mapobjects/pad_plates/plate_coffeered
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -841,7 +841,7 @@ models/mapobjects/pad_maple/maple
 	//sort 16
 
 	{
-		map models/mapobjects/pad_maple/maple.tga
+		map models/mapobjects/pad_maple/maple
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -852,7 +852,7 @@ models/mapobjects/pad_maple/maple
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -868,7 +868,7 @@ models/mapobjects/pad_cutlery/knifefork
 	//sort 16
 
 	{
-		map models/mapobjects/pad_cutlery/knifefork.tga
+		map models/mapobjects/pad_cutlery/knifefork
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -879,7 +879,7 @@ models/mapobjects/pad_cutlery/knifefork
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -895,7 +895,7 @@ models/mapobjects/pad_tins/coke1
 	//sort 16
 
 	{
-		map models/mapobjects/pad_tins/coke1.tga
+		map models/mapobjects/pad_tins/coke1
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -906,7 +906,7 @@ models/mapobjects/pad_tins/coke1
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -921,7 +921,7 @@ models/mapobjects/pad_tins/cola_bottom
 	//sort 16
 
 	{
-		map models/mapobjects/pad_tins/cola_bottom.tga
+		map models/mapobjects/pad_tins/cola_bottom
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -932,7 +932,7 @@ models/mapobjects/pad_tins/cola_bottom
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -947,7 +947,7 @@ models/mapobjects/pad_tins/cola_top
 	//sort 16
 
 	{
-		map models/mapobjects/pad_tins/cola_top.tga
+		map models/mapobjects/pad_tins/cola_top
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -958,7 +958,7 @@ models/mapobjects/pad_tins/cola_top
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -974,7 +974,7 @@ models/mapobjects/pad_tins/pupsi
 	//sort 16
 
 	{
-		map models/mapobjects/pad_tins/pupsi.tga
+		map models/mapobjects/pad_tins/pupsi
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -985,7 +985,7 @@ models/mapobjects/pad_tins/pupsi
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -1003,7 +1003,7 @@ models/mapobjects/pad_cutlery/pad_cup01
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup001.tga
+		map models/mapobjects/pad_cutlery/pad_cup001
 		rgbGen Vertex
 	}
 
@@ -1014,7 +1014,7 @@ models/mapobjects/pad_cutlery/pad_cup02
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup001.tga
+		map models/mapobjects/pad_cutlery/pad_cup001
 		rgbGen Vertex
 	}
 
@@ -1026,7 +1026,7 @@ models/mapobjects/pad_cutlery/pad_cup03
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup002.tga
+		map models/mapobjects/pad_cutlery/pad_cup002
 		rgbGen Vertex
 	}
 
@@ -1038,7 +1038,7 @@ models/mapobjects/pad_cutlery/pad_cup04
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup002.tga
+		map models/mapobjects/pad_cutlery/pad_cup002
 		rgbGen Vertex
 	}
 
@@ -1050,7 +1050,7 @@ models/mapobjects/pad_cutlery/pad_cup05
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup003.tga
+		map models/mapobjects/pad_cutlery/pad_cup003
 		rgbGen Vertex
 	}
 
@@ -1062,7 +1062,7 @@ models/mapobjects/pad_cutlery/pad_cup06
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup003.tga
+		map models/mapobjects/pad_cutlery/pad_cup003
 		rgbGen Vertex
 	}
 
@@ -1073,7 +1073,7 @@ models/mapobjects/pad_cutlery/pad_cup07
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup004.tga
+		map models/mapobjects/pad_cutlery/pad_cup004
 		rgbGen Vertex
 	}
 
@@ -1085,7 +1085,7 @@ models/mapobjects/pad_cutlery/pad_cup08
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup004.tga
+		map models/mapobjects/pad_cutlery/pad_cup004
 		rgbGen Vertex
 	}
 
@@ -1097,7 +1097,7 @@ models/mapobjects/pad_cutlery/pad_cup01_upd
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup001.tga
+		map models/mapobjects/pad_cutlery/pad_cup001
 		rgbGen Vertex
 	}
 
@@ -1108,7 +1108,7 @@ models/mapobjects/pad_cutlery/pad_cup02_upd
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup001.tga
+		map models/mapobjects/pad_cutlery/pad_cup001
 		rgbGen Vertex
 	}
 
@@ -1120,7 +1120,7 @@ models/mapobjects/pad_cutlery/pad_cup03_upd
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup002.tga
+		map models/mapobjects/pad_cutlery/pad_cup002
 		rgbGen Vertex
 	}
 
@@ -1132,7 +1132,7 @@ models/mapobjects/pad_cutlery/pad_cup04_upd
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup002.tga
+		map models/mapobjects/pad_cutlery/pad_cup002
 		rgbGen Vertex
 	}
 
@@ -1144,7 +1144,7 @@ models/mapobjects/pad_cutlery/pad_cup05_upd
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup003.tga
+		map models/mapobjects/pad_cutlery/pad_cup003
 		rgbGen Vertex
 	}
 
@@ -1156,7 +1156,7 @@ models/mapobjects/pad_cutlery/pad_cup06_upd
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup003.tga
+		map models/mapobjects/pad_cutlery/pad_cup003
 		rgbGen Vertex
 	}
 
@@ -1167,7 +1167,7 @@ models/mapobjects/pad_cutlery/pad_cup07_upd
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup004.tga
+		map models/mapobjects/pad_cutlery/pad_cup004
 		rgbGen Vertex
 	}
 
@@ -1179,7 +1179,7 @@ models/mapobjects/pad_cutlery/pad_cup08_upd
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	{
-		map models/mapobjects/pad_cutlery/pad_cup004.tga
+		map models/mapobjects/pad_cutlery/pad_cup004
 		rgbGen Vertex
 	}
 
@@ -1197,7 +1197,7 @@ models/mapobjects/pad_ducks/pad_duck
 	//sort 16
 
 	{
-		map models/mapobjects/pad_ducks/pad_duck.tga
+		map models/mapobjects/pad_ducks/pad_duck
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -1208,7 +1208,7 @@ models/mapobjects/pad_ducks/pad_duck
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -1227,9 +1227,9 @@ models/mapobjects/pad_fish/flame_angel
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_fish/flame_angel.tga
+	qer_editorimage models/mapobjects/pad_fish/flame_angel
 	{
-		map models/mapobjects/pad_fish/flame_angel.tga
+		map models/mapobjects/pad_fish/flame_angel
 		rgbGen lightingdiffuse
 
 	}
@@ -1242,9 +1242,9 @@ models/mapobjects/pad_fish/flame_angel_fins
 	nopicmip
 	nomipmaps
 	cull none
-                qer_editorimage models/mapobjects/pad_fish/flame_angel.tga
+                qer_editorimage models/mapobjects/pad_fish/flame_angel
 	{
-		map models/mapobjects/pad_fish/flame_angel.tga
+		map models/mapobjects/pad_fish/flame_angel
 		blendfunc GL_ONE GL_ONE
 		rgbGen lightingdiffuse
 
@@ -1257,9 +1257,9 @@ models/mapobjects/pad_fish/flame_angel02
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_fish/new_fish02.tga
+	qer_editorimage models/mapobjects/pad_fish/new_fish02
 	{
-		map models/mapobjects/pad_fish/new_fish02.tga
+		map models/mapobjects/pad_fish/new_fish02
 		rgbGen lightingdiffuse
 
 	}
@@ -1272,9 +1272,9 @@ models/mapobjects/pad_fish/flame_angel_fins02
 	nopicmip
 	nomipmaps
 	cull none
-	qer_editorimage models/mapobjects/pad_fish/new_fish02.tga
+	qer_editorimage models/mapobjects/pad_fish/new_fish02
 	{
-		map models/mapobjects/pad_fish/new_fish02.tga
+		map models/mapobjects/pad_fish/new_fish02
 		blendfunc GL_ONE GL_ONE
 		rgbGen lightingdiffuse
 
@@ -1286,9 +1286,9 @@ models/mapobjects/pad_fish/flame_angel05
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_fish/new_fish05.tga
+	qer_editorimage models/mapobjects/pad_fish/new_fish05
 	{
-		map models/mapobjects/pad_fish/new_fish05.tga
+		map models/mapobjects/pad_fish/new_fish05
 		rgbGen lightingdiffuse
 
 	}
@@ -1301,9 +1301,9 @@ models/mapobjects/pad_fish/flame_angel_fins05
         nopicmip
 	nomipmaps
 	cull none
-	qer_editorimage models/mapobjects/pad_fish/new_fish05.tga
+	qer_editorimage models/mapobjects/pad_fish/new_fish05
 	{
-		map models/mapobjects/pad_fish/new_fish05.tga
+		map models/mapobjects/pad_fish/new_fish05
 		blendfunc GL_ONE GL_ONE
 		rgbGen lightingdiffuse
 
@@ -1324,7 +1324,7 @@ models/mapobjects/pad_lamps/gooseneck
 	//sort 16
 
 	{
-		map models/mapobjects/pad_lamps/gooseneck.tga
+		map models/mapobjects/pad_lamps/gooseneck
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -1335,7 +1335,7 @@ models/mapobjects/pad_lamps/gooseneck
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -1351,7 +1351,7 @@ models/mapobjects/pad_lamps/gooseneck2
 	//sort 16
 
 	{
-		map models/mapobjects/pad_lamps/gooseneck2.tga
+		map models/mapobjects/pad_lamps/gooseneck2
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -1362,7 +1362,7 @@ models/mapobjects/pad_lamps/gooseneck2
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -1382,7 +1382,7 @@ models/mapobjects/padmousetrap/padmousetrap
         surfaceparm nolightmap
 	surfaceparm nomarks
 	{
-	map models/mapobjects/padmousetrap/padmousetrap.tga
+	map models/mapobjects/padmousetrap/padmousetrap
 	rgbGen vertex
 	}
 }
@@ -1395,48 +1395,48 @@ models/mapobjects/padmousetrap/padmousetrap
 
 models/mapobjects/pad_books/pad_openbook_rp
 {
-	qer_editorimage models/mapobjects/pad_books/pad_openbook.tga
+	qer_editorimage models/mapobjects/pad_books/pad_openbook
 	surfaceparm nolightmap
 	surfaceparm nonsolid
 	cull twosided
 	{
-		map models/mapobjects/pad_books/pad_openbook.tga
+		map models/mapobjects/pad_books/pad_openbook
 		rgbGen vertex
         }
 }
 
 models/mapobjects/pad_books/pad_openbook_rpwop
 {
-	qer_editorimage models/mapobjects/pad_books/pad_openbook_wop.tga
+	qer_editorimage models/mapobjects/pad_books/pad_openbook_wop
 	surfaceparm nolightmap
 	surfaceparm nonsolid
 	cull twosided
 	{
-		map models/mapobjects/pad_books/pad_openbook_wop.tga
+		map models/mapobjects/pad_books/pad_openbook_wop
 		rgbGen vertex
         }
 }
 
 models/mapobjects/pad_books/pad_openbook_pir1
 {
-	qer_editorimage models/mapobjects/pad_books/pad_openbook_pir1.tga
+	qer_editorimage models/mapobjects/pad_books/pad_openbook_pir1
 	surfaceparm nolightmap
 	surfaceparm nonsolid
 	cull twosided
 	{
-		map models/mapobjects/pad_books/pad_openbook_pir1.tga
+		map models/mapobjects/pad_books/pad_openbook_pir1
 		rgbGen vertex
         }
 }
 
 models/mapobjects/pad_books/pad_openbook_pir2
 {
-	qer_editorimage models/mapobjects/pad_books/pad_openbook_pir2.tga
+	qer_editorimage models/mapobjects/pad_books/pad_openbook_pir2
 	surfaceparm nolightmap
 	surfaceparm nonsolid
 	cull twosided
 	{
-		map models/mapobjects/pad_books/pad_openbook_pir2.tga
+		map models/mapobjects/pad_books/pad_openbook_pir2
 		rgbGen vertex
         }
 }
@@ -1447,7 +1447,7 @@ models/mapobjects/pad_books/glow/pad_openbook_glow
    nopicmip
    nomipmaps
    {
-      map models/mapobjects/pad_books/glow/pad_openbook_glow.tga
+      map models/mapobjects/pad_books/glow/pad_openbook_glow
       alphaFunc GE128
       rgbGen vertex
    }
@@ -1467,7 +1467,7 @@ models/mapobjects/pad_sunflower/sunhead
 	nopicmip
 	nomipmaps
 	{
-		map models/mapobjects/pad_sunflower/sunhead.tga
+		map models/mapobjects/pad_sunflower/sunhead
 		alphaFunc GE128
 		rgbGen vertex
 	}
@@ -1479,7 +1479,7 @@ models/mapobjects/pad_sunflower/sunleaf1
 	nopicmip
 	nomipmaps
 	{
-		map models/mapobjects/pad_sunflower/sunleaf1.tga
+		map models/mapobjects/pad_sunflower/sunleaf1
 		alphaFunc GE128
 		rgbGen vertex
 	}
@@ -1491,7 +1491,7 @@ models/mapobjects/pad_sunflower/sunleaf2
 	nopicmip
 	nomipmaps
 	{
-		map models/mapobjects/pad_sunflower/sunleaf2.tga
+		map models/mapobjects/pad_sunflower/sunleaf2
 		alphaFunc GE128
 		rgbGen vertex
 	}
@@ -1510,23 +1510,23 @@ models/mapobjects/pad_pc/pad_tft_screen
    	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_pc/pad_tft.tga
+	q3map_lightimage models/mapobjects/pad_pc/pad_tft
 	q3map_surfacelight 10
 	nopicmip
 
        	{
-               	animmap .3 models/mapobjects/pad_pc/screen01.tga models/mapobjects/pad_pc/screen02.tga models/mapobjects/pad_pc/screen03.tga models/mapobjects/pad_pc/screen04.tga models/mapobjects/pad_pc/screen05.tga
+               	animmap .3 models/mapobjects/pad_pc/screen01 models/mapobjects/pad_pc/screen02 models/mapobjects/pad_pc/screen03 models/mapobjects/pad_pc/screen04 models/mapobjects/pad_pc/screen05
                	rgbgen identity
        	}
 	{
-		map models/mapobjects/padtv/scanline.tga
+		map models/mapobjects/padtv/scanline
 		blendfunc blend
 		rgbGen identity
 		tcMod scroll 0 -0.035
 		tcMod scale 45 45
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         	tcGen environment
                 blendfunc GL_ONE GL_ONE
                 rgbGen identity
@@ -1550,7 +1550,7 @@ models/mapobjects/pad_nascars/padcar_orange
 	//sort 16
 
 	{
-		map models/mapobjects/pad_nascars/padcar_orange.tga
+		map models/mapobjects/pad_nascars/padcar_orange
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -1561,7 +1561,7 @@ models/mapobjects/pad_nascars/padcar_orange
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -1577,7 +1577,7 @@ models/mapobjects/pad_nascars/padcar_black
 	//sort 16
 
 	{
-		map models/mapobjects/pad_nascars/padcar_black.tga
+		map models/mapobjects/pad_nascars/padcar_black
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -1588,7 +1588,7 @@ models/mapobjects/pad_nascars/padcar_black
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -1604,7 +1604,7 @@ models/mapobjects/pad_nascars/padcar_muster
 	//sort 16
 
 	{
-		map models/mapobjects/pad_nascars/padcar_muster.tga
+		map models/mapobjects/pad_nascars/padcar_muster
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -1615,7 +1615,7 @@ models/mapobjects/pad_nascars/padcar_muster
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -1635,7 +1635,7 @@ models/mapobjects/ente/padgold_goggles
 	nopicmip
 	nomipmaps
 	{
-		map models/mapobjects/ente/padgold_head.tga
+		map models/mapobjects/ente/padgold_head
 		rgbGen Vertex
 		depthWrite
 		alphaFunc GE128
@@ -1646,10 +1646,10 @@ models/mapobjects/ente/padgold_goggles
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
-                rgbGen vertex //identity //lightingDiffuse //makes effect darker		
+                rgbGen vertex //identity //lightingDiffuse //makes effect darker
 }
 }
 
@@ -1659,7 +1659,7 @@ models/mapobjects/ente/padgold_cape
 	nopicmip
 	nomipmaps
 	{
-		map models/mapobjects/ente/padgold_body.tga
+		map models/mapobjects/ente/padgold_body
 		rgbGen Vertex
         }
 	{
@@ -1668,10 +1668,10 @@ models/mapobjects/ente/padgold_cape
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
-                rgbGen vertex //identity //lightingDiffuse //makes effect darker	
+                rgbGen vertex //identity //lightingDiffuse //makes effect darker
 }
 }
 
@@ -1684,7 +1684,7 @@ models/mapobjects/ente/padgold_body
 	//sort 16
 
 	{
-		map models/mapobjects/ente/padgold_body.tga
+		map models/mapobjects/ente/padgold_body
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -1695,7 +1695,7 @@ models/mapobjects/ente/padgold_body
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -1710,7 +1710,7 @@ models/mapobjects/ente/padgold_head
 	//sort 16
 
 	{
-		map models/mapobjects/ente/padgold_head.tga
+		map models/mapobjects/ente/padgold_head
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -1721,7 +1721,7 @@ models/mapobjects/ente/padgold_head
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -1740,7 +1740,7 @@ models/mapobjects/ente/padwinner_goggles
 {
 	cull disable
 	{
-		map models/mapobjects/ente/padwinner_head.tga
+		map models/mapobjects/ente/padwinner_head
 		rgbGen Vertex
 		depthWrite
 		alphaFunc GE128
@@ -1752,7 +1752,7 @@ models/mapobjects/ente/padwinner_cape
 	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
 	{
-		map models/mapobjects/ente/padwinner_body.tga
+		map models/mapobjects/ente/padwinner_body
 		rgbGen Vertex
 	}
 }
@@ -1767,7 +1767,7 @@ models/mapobjects/padtv/tv01
 {
 	nopicmip
 	{
-		map models/mapobjects/padtv/screen.tga
+		map models/mapobjects/padtv/screen
 		rgbGen Vertex
 	}
 	{
@@ -1777,14 +1777,14 @@ models/mapobjects/padtv/tv01
 		rgbGen identity
 	}
 	{
-		map models/mapobjects/padtv/scanline.tga
+		map models/mapobjects/padtv/scanline
 		blendfunc blend
 		rgbGen identity
 		tcMod scroll 0 -0.035
 		tcMod scale 45 45
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         	tcGen environment
                 blendfunc GL_ONE GL_ONE
                 rgbGen identity
@@ -1800,23 +1800,23 @@ models/mapobjects/padtv/tv02
    	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/padtv/tv004.tga
+	q3map_lightimage models/mapobjects/padtv/tv004
 	q3map_surfacelight 100
 	nopicmip
 
        	{
-               	animmap .4 models/mapobjects/padtv/tv001.tga models/mapobjects/padtv/tv003.tga models/mapobjects/padtv/tv001.tga models/mapobjects/padtv/tv004.tga models/mapobjects/padtv/tv006.tga models/mapobjects/padtv/tv001.tga models/mapobjects/padtv/tv005.tga
+               	animmap .4 models/mapobjects/padtv/tv001 models/mapobjects/padtv/tv003 models/mapobjects/padtv/tv001 models/mapobjects/padtv/tv004 models/mapobjects/padtv/tv006 models/mapobjects/padtv/tv001 models/mapobjects/padtv/tv005
                	rgbgen identity
        	}
 	{
-		map models/mapobjects/padtv/scanline.tga
+		map models/mapobjects/padtv/scanline
 		blendfunc blend
 		rgbGen identity
 		tcMod scroll 0 -0.035
 		tcMod scale 45 45
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         	tcGen environment
                 blendfunc GL_ONE GL_ONE
                 rgbGen identity
@@ -1836,13 +1836,13 @@ models/mapobjects/pad_ducktape/ducktape
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_ducktape/ducktape.tga
+	qer_editorimage models/mapobjects/pad_ducktape/ducktape
 	{
-		map models/mapobjects/pad_ducktape/ducktape.tga
+		map models/mapobjects/pad_ducktape/ducktape
 		rgbGen vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.2 0.2
 		tcGen environment
@@ -1859,13 +1859,13 @@ models/mapobjects/pad_sink/caps
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_sink/caps.jpg
+	qer_editorimage models/mapobjects/pad_sink/caps
 	{
-		map models/mapobjects/pad_sink/caps.jpg
+		map models/mapobjects/pad_sink/caps
 		rgbGen vertex
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.2 0.2
 		tcGen environment
@@ -1877,13 +1877,13 @@ models/mapobjects/pad_sink/tap
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_sink/tap.jpg
+	qer_editorimage models/mapobjects/pad_sink/tap
 	{
-		map models/mapobjects/pad_sink/tap.jpg
+		map models/mapobjects/pad_sink/tap
 		rgbGen vertex
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.5 0.5
 		tcGen environment
@@ -1895,13 +1895,13 @@ models/mapobjects/pad_sink/wastepipe
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_sink/sinkback.jpg
+	qer_editorimage models/mapobjects/pad_sink/sinkback
 	{
-		map models/mapobjects/pad_sink/sinkback.jpg
+		map models/mapobjects/pad_sink/sinkback
 		rgbGen vertex
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.4 0.4
 		tcGen environment
@@ -1913,14 +1913,14 @@ models/mapobjects/pad_sink/sink
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_sink/sinkback.jpg
+	qer_editorimage models/mapobjects/pad_sink/sinkback
 	{
-		map models/mapobjects/pad_sink/sinkback.jpg
+		map models/mapobjects/pad_sink/sinkback
 		rgbGen vertex
 
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.6 0.6
 		tcGen environment
@@ -1934,14 +1934,14 @@ models/mapobjects/pad_sink/sinkdoublesided
 	nopicmip
 	nomipmaps
 	cull disable
-	qer_editorimage models/mapobjects/pad_sink/sinkback.jpg
+	qer_editorimage models/mapobjects/pad_sink/sinkback
 	{
-		map models/mapobjects/pad_sink/sinkback.jpg
+		map models/mapobjects/pad_sink/sinkback
 		rgbGen vertex
 
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.6 0.6
 		tcGen environment
@@ -1959,9 +1959,9 @@ models/mapobjects/pad_clothes/prisonjacket
     cull disable
 	//deformVertexes wave 100 sin 0 0.2 3 1
 	deformVertexes wave 100 sin 3 0.2 3 0.5
-	qer_editorimage models/mapobjects/pad_clothes/prisonjacket.jpg
+	qer_editorimage models/mapobjects/pad_clothes/prisonjacket
 	{
-		map models/mapobjects/pad_clothes/prisonjacket.jpg
+		map models/mapobjects/pad_clothes/prisonjacket
 		rgbGen vertex
 	}
 }
@@ -1969,9 +1969,9 @@ models/mapobjects/pad_clothes/prisonjacket
 models/mapobjects/pad_clothes/prisonjacketfixedpoint
 {
     cull disable
-	qer_editorimage models/mapobjects/pad_clothes/prisonjacket.jpg
+	qer_editorimage models/mapobjects/pad_clothes/prisonjacket
 	{
-		map models/mapobjects/pad_clothes/prisonjacket.jpg
+		map models/mapobjects/pad_clothes/prisonjacket
 		rgbGen vertex
 	}
 }
@@ -1983,9 +1983,9 @@ models/mapobjects/pad_clothes/prisonjacketfixedpoint
 models/mapobjects/pad_clothes/sock_grey
 {
     cull disable
-	qer_editorimage models/mapobjects/pad_clothes/sock_grey.jpg
+	qer_editorimage models/mapobjects/pad_clothes/sock_grey
 	{
-		map models/mapobjects/pad_clothes/sock_grey.jpg
+		map models/mapobjects/pad_clothes/sock_grey
 		rgbGen vertex
 	}
 }
@@ -1993,9 +1993,9 @@ models/mapobjects/pad_clothes/sock_grey
 models/mapobjects/pad_clothes/sock_grey2
 {
     cull disable
-	qer_editorimage models/mapobjects/pad_clothes/sock_grey2.jpg
+	qer_editorimage models/mapobjects/pad_clothes/sock_grey2
 	{
-		map models/mapobjects/pad_clothes/sock_grey2.jpg
+		map models/mapobjects/pad_clothes/sock_grey2
 		rgbGen vertex
 	}
 }
@@ -2003,9 +2003,9 @@ models/mapobjects/pad_clothes/sock_grey2
 models/mapobjects/pad_clothes/sock_grey3
 {
     cull disable
-	qer_editorimage models/mapobjects/pad_clothes/sock_grey3.jpg
+	qer_editorimage models/mapobjects/pad_clothes/sock_grey3
 	{
-		map models/mapobjects/pad_clothes/sock_grey3.jpg
+		map models/mapobjects/pad_clothes/sock_grey3
 		rgbGen vertex
 	}
 }
@@ -2019,14 +2019,14 @@ models/mapobjects/pad_items/toothbrush_blackred
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_items/toothbrush_blackred.jpg
+	qer_editorimage models/mapobjects/pad_items/toothbrush_blackred
 	{
-		map models/mapobjects/pad_items/toothbrush_blackred.jpg
+		map models/mapobjects/pad_items/toothbrush_blackred
 		rgbGen vertex
 
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.6 0.6
 		tcGen environment
@@ -2038,14 +2038,14 @@ models/mapobjects/pad_items/toothbrush_blackblue
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_items/toothbrush_blackblue.jpg
+	qer_editorimage models/mapobjects/pad_items/toothbrush_blackblue
 	{
-		map models/mapobjects/pad_items/toothbrush_blackblue.jpg
+		map models/mapobjects/pad_items/toothbrush_blackblue
 		rgbGen vertex
 
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.6 0.6
 		tcGen environment
@@ -2058,14 +2058,14 @@ models/mapobjects/pad_items/toothbrush_blackorange
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_items/toothbrush_blackorange.jpg
+	qer_editorimage models/mapobjects/pad_items/toothbrush_blackorange
 	{
-		map models/mapobjects/pad_items/toothbrush_blackorange.jpg
+		map models/mapobjects/pad_items/toothbrush_blackorange
 		rgbGen vertex
 
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.6 0.6
 		tcGen environment
@@ -2077,14 +2077,14 @@ models/mapobjects/pad_items/toothbrush_blackpurple
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_items/toothbrush_blackpurple.jpg
+	qer_editorimage models/mapobjects/pad_items/toothbrush_blackpurple
 	{
-		map models/mapobjects/pad_items/toothbrush_blackpurple.jpg
+		map models/mapobjects/pad_items/toothbrush_blackpurple
 		rgbGen vertex
 
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.6 0.6
 		tcGen environment
@@ -2096,14 +2096,14 @@ models/mapobjects/pad_items/toothbrush_blackcyan
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_items/toothbrush_blackcyan.jpg
+	qer_editorimage models/mapobjects/pad_items/toothbrush_blackcyan
 	{
-		map models/mapobjects/pad_items/toothbrush_blackcyan.jpg
+		map models/mapobjects/pad_items/toothbrush_blackcyan
 		rgbGen vertex
 
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.6 0.6
 		tcGen environment
@@ -2116,14 +2116,14 @@ models/mapobjects/pad_items/toothbrush_blackgreen
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_items/toothbrush_blackgreen.jpg
+	qer_editorimage models/mapobjects/pad_items/toothbrush_blackgreen
 	{
-		map models/mapobjects/pad_items/toothbrush_blackgreen.jpg
+		map models/mapobjects/pad_items/toothbrush_blackgreen
 		rgbGen vertex
 
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale 0.6 0.6
 		tcGen environment
@@ -2145,7 +2145,7 @@ models/mapobjects/pad_bath/electric_toothbrush
 	//sort 16
 
 	{
-		map models/mapobjects/pad_bath/electric_toothbrush.tga
+		map models/mapobjects/pad_bath/electric_toothbrush
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -2156,7 +2156,7 @@ models/mapobjects/pad_bath/electric_toothbrush
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -2177,7 +2177,7 @@ models/mapobjects/pad_bath/deocan1
 	//sort 16
 
 	{
-		map models/mapobjects/pad_bath/deocan1.tga
+		map models/mapobjects/pad_bath/deocan1
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -2188,7 +2188,7 @@ models/mapobjects/pad_bath/deocan1
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -2209,7 +2209,7 @@ models/mapobjects/pad_bath/toothpaste
 	//sort 16
 
 	{
-		map models/mapobjects/pad_bath/toothpaste.tga
+		map models/mapobjects/pad_bath/toothpaste
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -2220,7 +2220,7 @@ models/mapobjects/pad_bath/toothpaste
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -2239,7 +2239,7 @@ models/mapobjects/pad_bath/ointment
 	//sort 16
 
 	{
-		map models/mapobjects/pad_bath/ointment.tga
+		map models/mapobjects/pad_bath/ointment
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		//alphaFunc GE128
 		rgbGen vertex // identity //vertex
@@ -2250,7 +2250,7 @@ models/mapobjects/pad_bath/ointment
 		blendfunc filter
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex //identity //lightingDiffuse //makes effect darker
@@ -2268,7 +2268,7 @@ models/mapobjects/pad_ddmix/padlibrary/bookend
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/padlibrary/bookend.tga
+		map models/mapobjects/pad_ddmix/padlibrary/bookend
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2283,7 +2283,7 @@ models/mapobjects/pad_ddmix/chess/chess_white
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/chess/chess_white.tga
+		map models/mapobjects/pad_ddmix/chess/chess_white
 		rgbGen Vertex
 	}
 	{
@@ -2292,7 +2292,7 @@ models/mapobjects/pad_ddmix/chess/chess_white
 		tcGen environment
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -2304,7 +2304,7 @@ models/mapobjects/pad_ddmix/chess/chess_black
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/chess/chess_black.tga
+		map models/mapobjects/pad_ddmix/chess/chess_black
 		rgbGen Vertex
 	}
 	{
@@ -2313,7 +2313,7 @@ models/mapobjects/pad_ddmix/chess/chess_black
 		tcGen environment
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -2325,7 +2325,7 @@ models/mapobjects/pad_ddmix/padlibrary/bookend_shader
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/padlibrary/bookend_shader.tga
+		map models/mapobjects/pad_ddmix/padlibrary/bookend_shader
 		rgbGen Vertex
 	}
 	{
@@ -2334,7 +2334,7 @@ models/mapobjects/pad_ddmix/padlibrary/bookend_shader
 		tcGen environment
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -2351,7 +2351,7 @@ models/mapobjects/pad_ddmix/padship/bottle
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/padship/bottle.tga
+		map models/mapobjects/pad_ddmix/padship/bottle
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -2363,7 +2363,7 @@ models/mapobjects/pad_ddmix/padship/bottle
 		tcGen lightmap
 	}
 	{
-		map textures/pad_gfx02/invispad.tga
+		map textures/pad_gfx02/invispad
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -2382,7 +2382,7 @@ models/mapobjects/pad_ddmix/plants/flower_pink
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/flower_pink.tga
+		map models/mapobjects/pad_ddmix/plants/flower_pink
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2394,7 +2394,7 @@ models/mapobjects/pad_ddmix/plants/tulip1
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/tulip1.tga
+		map models/mapobjects/pad_ddmix/plants/tulip1
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2407,7 +2407,7 @@ models/mapobjects/pad_ddmix/plants/water_lily
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/water_lily.tga
+		map models/mapobjects/pad_ddmix/plants/water_lily
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2419,7 +2419,7 @@ models/mapobjects/pad_ddmix/plants/fern
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/fern.tga
+		map models/mapobjects/pad_ddmix/plants/fern
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2431,7 +2431,7 @@ models/mapobjects/pad_ddmix/plants/flower_yellow
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/flower_yellow.tga
+		map models/mapobjects/pad_ddmix/plants/flower_yellow
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2444,7 +2444,7 @@ models/mapobjects/pad_ddmix/plants/waterplant1
 	nomipmaps
 	deformVertexes wave 194 sin 0 2 0 0.3
 	{
-		map models/mapobjects/pad_ddmix/plants/waterplant1.tga
+		map models/mapobjects/pad_ddmix/plants/waterplant1
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2457,7 +2457,7 @@ models/mapobjects/pad_ddmix/plants/ikebana_red
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/ikebana_red.tga
+		map models/mapobjects/pad_ddmix/plants/ikebana_red
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2470,7 +2470,7 @@ models/mapobjects/pad_ddmix/plants/ikebana_blue
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/ikebana_blue.tga
+		map models/mapobjects/pad_ddmix/plants/ikebana_blue
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2486,11 +2486,11 @@ models/mapobjects/pad_ddmix/diner/can_top
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/diner/can_top.tga
+		map models/mapobjects/pad_ddmix/diner/can_top
 		rgbGen Vertex
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
@@ -2507,12 +2507,12 @@ models/mapobjects/pad_ddmix/diner/coffee_pot
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/diner/coffee_pot.tga
+		map models/mapobjects/pad_ddmix/diner/coffee_pot
 		blendfunc add
 		rgbGen Vertex
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
@@ -2527,7 +2527,7 @@ models/mapobjects/pad_ddmix/padkitchen/towel
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/padkitchen/towel.tga
+		map models/mapobjects/pad_ddmix/padkitchen/towel
 		rgbGen Vertex
 	}
 }
@@ -2536,7 +2536,7 @@ models/mapobjects/pad_ddmix/padkitchen/towel_kitchen
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/padkitchen/towel_kitchen.tga
+		map models/mapobjects/pad_ddmix/padkitchen/towel_kitchen
 		rgbGen Vertex
 	}
 }
@@ -2545,7 +2545,7 @@ models/mapobjects/pad_ddmix/padkitchen/towel_bath_blue
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/padkitchen/towel_bath_blue.tga
+		map models/mapobjects/pad_ddmix/padkitchen/towel_bath_blue
 		rgbGen Vertex
 	}
 }
@@ -2554,7 +2554,7 @@ models/mapobjects/pad_ddmix/padkitchen/towel_bath_pink
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/padkitchen/towel_bath_pink.tga
+		map models/mapobjects/pad_ddmix/padkitchen/towel_bath_pink
 		rgbGen Vertex
 	}
 }
@@ -2571,7 +2571,7 @@ models/mapobjects/pad_ddmix/mix/matches
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/mix/matches.tga
+		map models/mapobjects/pad_ddmix/mix/matches
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2582,12 +2582,12 @@ models/mapobjects/pad_ddmix/mix/matchbook_diner
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/mix/matchbook_diner.tga
+		map models/mapobjects/pad_ddmix/mix/matchbook_diner
 		rgbGen Vertex
 		alphaFunc GE128
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
@@ -2598,12 +2598,12 @@ models/mapobjects/pad_ddmix/mix/matchbook_doomdragon
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/mix/matchbook_doomdragon.tga
+		map models/mapobjects/pad_ddmix/mix/matchbook_doomdragon
 		rgbGen Vertex
 		alphaFunc GE128
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
@@ -2614,12 +2614,12 @@ models/mapobjects/pad_ddmix/mix/matchbook_padman
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/mix/matchbook_padman.tga
+		map models/mapobjects/pad_ddmix/mix/matchbook_padman
 		rgbGen Vertex
 		alphaFunc GE128
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
@@ -2631,7 +2631,7 @@ models/mapobjects/pad_ddmix/plants/bonsai
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/bonsai.tga
+		map models/mapobjects/pad_ddmix/plants/bonsai
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2647,17 +2647,17 @@ models/mapobjects/pad_ddmix/anteroom/vase
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/anteroom/vase.tga
+		map models/mapobjects/pad_ddmix/anteroom/vase
 		blendfunc blend
 		rgbGen Vertex
 	}
 	{
-		map models/mapobjects/pad_ddmix/anteroom/vase.tga
+		map models/mapobjects/pad_ddmix/anteroom/vase
 		blendfunc add
 		rgbGen Vertex
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
@@ -2669,12 +2669,12 @@ models/mapobjects/pad_ddmix/anteroom/water_vase
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/anteroom/water_vase.tga
+		map models/mapobjects/pad_ddmix/anteroom/water_vase
 		blendfunc add
 		rgbGen Vertex
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
@@ -2690,7 +2690,7 @@ models/mapobjects/pad_ddmix/jail/snowman
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/jail/snowman.tga
+		map models/mapobjects/pad_ddmix/jail/snowman
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2706,7 +2706,7 @@ models/mapobjects/pad_ddmix/diner/tunnellamp
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/diner/tunnellamp.tga
+		map models/mapobjects/pad_ddmix/diner/tunnellamp
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2722,7 +2722,7 @@ models/mapobjects/pad_ddmix/diner/light
 	nomipmaps
 	q3map_surfacelight 1000
 	{
-		map models/mapobjects/pad_ddmix/diner/light.tga
+		map models/mapobjects/pad_ddmix/diner/light
 		rgbGen identity
 		tcGen lightmap
 	}
@@ -2734,7 +2734,7 @@ models/mapobjects/pad_ddmix/plants/cane
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/cane.tga
+		map models/mapobjects/pad_ddmix/plants/cane
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2749,7 +2749,7 @@ models/mapobjects/pad_ddmix/anteroom/injection
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/anteroom/injection.tga
+		map models/mapobjects/pad_ddmix/anteroom/injection
 		rgbGen Vertex
 	}
 	{
@@ -2758,7 +2758,7 @@ models/mapobjects/pad_ddmix/anteroom/injection
 		tcGen environment
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -2775,7 +2775,7 @@ models/mapobjects/pad_ddmix/attic/kaspad
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/attic/kaspad.tga
+		map models/mapobjects/pad_ddmix/attic/kaspad
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2790,7 +2790,7 @@ models/mapobjects/pad_ddmix/trashcan/lamp_house_day
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/lamp_house_day.tga
+		map models/mapobjects/pad_ddmix/trashcan/lamp_house_day
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2800,10 +2800,10 @@ models/mapobjects/pad_ddmix/trashcan/lamp_house_glass_day
 {
 	surfaceparm nolightmap
 	{
-		map models/mapobjects/pad_ddmix/trashcan/lamp_house_glass_day.tga
+		map models/mapobjects/pad_ddmix/trashcan/lamp_house_glass_day
 	}
 	{
-		map models/mapobjects/pad_ddmix/trashcan/reflection.tga
+		map models/mapobjects/pad_ddmix/trashcan/reflection
 		blendfunc add
 		tcGen environment
 	}
@@ -2814,7 +2814,7 @@ models/mapobjects/pad_ddmix/trashcan/lamp_house_night
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/lamp_house_night.tga
+		map models/mapobjects/pad_ddmix/trashcan/lamp_house_night
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -2822,12 +2822,12 @@ models/mapobjects/pad_ddmix/trashcan/lamp_house_night
 
 models/mapobjects/pad_ddmix/trashcan/lamp_house_glass_night
 {
-	q3map_lightimage models/mapobjects/pad_ddmix/trashcan/lamp_house_glass_night.tga
+	q3map_lightimage models/mapobjects/pad_ddmix/trashcan/lamp_house_glass_night
 	q3map_surfacelight 50000
 	{
 		map $lightmap
 		rgbGen identity
-		map models/mapobjects/pad_ddmix/trashcan/lamp_house_glass_night.tga
+		map models/mapobjects/pad_ddmix/trashcan/lamp_house_glass_night
 	}
 }
 
@@ -2836,7 +2836,7 @@ models/mapobjects/pad_ddmix/trashcan/lamp_house_lightrays
 	surfaceparm nolightmap
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/lamp_house_lightrays.tga
+		map models/mapobjects/pad_ddmix/trashcan/lamp_house_lightrays
 		blendfunc add
 	}
 }
@@ -2845,7 +2845,7 @@ models/mapobjects/pad_ddmix/trashcan/lamp_sewer_dirty
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/lamp_sewer_dirty.tga
+		map models/mapobjects/pad_ddmix/trashcan/lamp_sewer_dirty
 	}
 }
 
@@ -2853,27 +2853,27 @@ models/mapobjects/pad_ddmix/trashcan/lamp_sewer_unlit
 {
 	surfaceparm nolightmap
 	{
-		map models/mapobjects/pad_ddmix/trashcan/lamp_sewer_unlit.tga
+		map models/mapobjects/pad_ddmix/trashcan/lamp_sewer_unlit
 	}
 }
 
 models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit
 {
 	surfaceparm nolightmap
-	q3map_lightimage models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit.tga
+	q3map_lightimage models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit
 	q3map_surfacelight 50000
 	{
-		map models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit.tga
+		map models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit
 	}
 }
 
 models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit2
 {
 	surfaceparm nolightmap
-	q3map_lightimage models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit.tga
+	q3map_lightimage models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit
 	q3map_surfacelight 25000
 	{
-		map models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit.tga
+		map models/mapobjects/pad_ddmix/trashcan/lamp_sewer_lit
 	}
 }
 
@@ -2887,12 +2887,12 @@ models/mapobjects/pad_ddmix/diner/glass01
 	sort additive
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_highlight.tga
+		map models/mapobjects/pad_ddmix/diner/glass_highlight
 		blendfunc add
 		tcGen environment
 	}
@@ -2904,12 +2904,12 @@ models/mapobjects/pad_ddmix/diner/glass_highlight_small
 	sort additive
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_highlight_small.tga
+		map models/mapobjects/pad_ddmix/diner/glass_highlight_small
 		blendfunc add
 		tcGen environment
 	}
@@ -2921,17 +2921,17 @@ models/mapobjects/pad_ddmix/diner/glass_rings
 	sort additive
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_rings.tga
+		map models/mapobjects/pad_ddmix/diner/glass_rings
 		blendfunc blend
 		rgbGen Vertex
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_highlight.tga
+		map models/mapobjects/pad_ddmix/diner/glass_highlight
 		blendfunc add
 		tcGen environment
 	}
@@ -2942,23 +2942,23 @@ models/mapobjects/pad_ddmix/diner/glass_betty
 	surfaceparm trans
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_betty.tga
+		map models/mapobjects/pad_ddmix/diner/glass_betty
 		blendfunc blend
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_betty.tga
+		map models/mapobjects/pad_ddmix/diner/glass_betty
 		blendfunc blend
 		rgbGen Vertex
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_highlight.tga
+		map models/mapobjects/pad_ddmix/diner/glass_highlight
 		blendfunc add
 		tcGen environment
 	}
@@ -2970,19 +2970,19 @@ models/mapobjects/pad_ddmix/diner/glass_sunrise
 	sort additive
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_sunrise.tga
+		map models/mapobjects/pad_ddmix/diner/glass_sunrise
 		blendfunc blend
 		rgbGen Vertex
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_highlight.tga
+		map models/mapobjects/pad_ddmix/diner/glass_highlight
 		blendfunc add
 		tcGen environment
 	}
@@ -2994,19 +2994,19 @@ models/mapobjects/pad_ddmix/diner/glass_midnight
 	surfaceparm trans
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_midnight.tga
+		map models/mapobjects/pad_ddmix/diner/glass_midnight
 		blendfunc blend
 		rgbGen Vertex
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass01.tga
+		map models/mapobjects/pad_ddmix/diner/glass01
 		blendfunc add
 		tcGen environment
 	}
 	{
-		map models/mapobjects/pad_ddmix/diner/glass_highlight.tga
+		map models/mapobjects/pad_ddmix/diner/glass_highlight
 		blendfunc add
 		tcGen environment
 	}
@@ -3020,11 +3020,11 @@ models/mapobjects/pad_ddmix/cabin/telescope
 {
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/cabin/telescope.tga
+		map models/mapobjects/pad_ddmix/cabin/telescope
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3035,12 +3035,12 @@ models/mapobjects/pad_ddmix/cabin/occulars
 {
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/cabin/occulars.tga
+		map models/mapobjects/pad_ddmix/cabin/occulars
 		tcMod scale 0.8 0.8
 		tcGen environment
 	}
 	{
-		map models/mapobjects/pad_ddmix/cabin/occulars2.tga
+		map models/mapobjects/pad_ddmix/cabin/occulars2
 		blendfunc blend
 		rgbGen Vertex
 		alphaFunc GE128
@@ -3058,7 +3058,7 @@ models/mapobjects/pad_ddmix/effects/FireBigA
 	surfaceparm trans
 	cull disable
 	{
-		animmap 10 models/mapobjects/pad_ddmix/effects/FireBigA.tga models/mapobjects/pad_ddmix/effects/FireBigB.tga models/mapobjects/pad_ddmix/effects/FireBigC.tga models/mapobjects/pad_ddmix/effects/FireBigD.tga models/mapobjects/pad_ddmix/effects/FireBigE.tga models/mapobjects/pad_ddmix/effects/FireBigF.tga models/mapobjects/pad_ddmix/effects/FireBigG.tga models/mapobjects/pad_ddmix/effects/FireBigH.tga
+		animmap 10 models/mapobjects/pad_ddmix/effects/FireBigA models/mapobjects/pad_ddmix/effects/FireBigB models/mapobjects/pad_ddmix/effects/FireBigC models/mapobjects/pad_ddmix/effects/FireBigD models/mapobjects/pad_ddmix/effects/FireBigE models/mapobjects/pad_ddmix/effects/FireBigF models/mapobjects/pad_ddmix/effects/FireBigG models/mapobjects/pad_ddmix/effects/FireBigH
 		blendfunc add
 		rgbGen wave inversesawtooth 1 3 1 3
 	}
@@ -3072,18 +3072,18 @@ models/mapobjects/pad_ddmix/ghostpad/ghostpad
 {
 	surfaceparm trans
 	{
-		map models/mapobjects/pad_ddmix/ghostpad/ghostpad.tga
+		map models/mapobjects/pad_ddmix/ghostpad/ghostpad
 		blendfunc blend
 		rgbGen Vertex
 		depthWrite
 	}
 	{
-		map models/mapobjects/pad_ddmix/ghostpad/ghostpad.tga
+		map models/mapobjects/pad_ddmix/ghostpad/ghostpad
 		blendfunc add
 		rgbGen Vertex
 	}
 	{
-		map models/mapobjects/pad_ddmix/ghostpad/ghostpad.tga
+		map models/mapobjects/pad_ddmix/ghostpad/ghostpad
 		blendfunc add
 		rgbGen Vertex
 	}
@@ -3096,11 +3096,11 @@ models/mapobjects/pad_ddmix/ghostpad/ghostpad
 models/mapobjects/pad_ddmix/anteroom/medical_case
 {
 	{
-		map models/mapobjects/pad_ddmix/anteroom/medical_case.tga
+		map models/mapobjects/pad_ddmix/anteroom/medical_case
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3110,11 +3110,11 @@ models/mapobjects/pad_ddmix/anteroom/medical_case
 models/mapobjects/pad_ddmix/anteroom/black_case
 {
 	{
-		map models/mapobjects/pad_ddmix/anteroom/black_case.tga
+		map models/mapobjects/pad_ddmix/anteroom/black_case
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3124,11 +3124,11 @@ models/mapobjects/pad_ddmix/anteroom/black_case
 models/mapobjects/pad_ddmix/anteroom/metal_suitcase
 {
 	{
-		map models/mapobjects/pad_ddmix/anteroom/metal_suitcase.tga
+		map models/mapobjects/pad_ddmix/anteroom/metal_suitcase
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3138,11 +3138,11 @@ models/mapobjects/pad_ddmix/anteroom/metal_suitcase
 models/mapobjects/pad_ddmix/anteroom/silver_case
 {
 	{
-		map models/mapobjects/pad_ddmix/anteroom/silver_case.tga
+		map models/mapobjects/pad_ddmix/anteroom/silver_case
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3158,7 +3158,7 @@ models/mapobjects/pad_ddmix/padship/shiplamp_light
 	cull disable
 	q3map_surfacelight 60
 	{
-		map models/mapobjects/pad_ddmix/padship/shiplamp_light.tga
+		map models/mapobjects/pad_ddmix/padship/shiplamp_light
 	}
 }
 
@@ -3170,11 +3170,11 @@ models/mapobjects/pad_ddmix/padship/valve
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/padship/valve.tga
+		map models/mapobjects/pad_ddmix/padship/valve
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3189,11 +3189,11 @@ models/mapobjects/pad_ddmix/attic/pumper
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/attic/pumper.tga
+		map models/mapobjects/pad_ddmix/attic/pumper
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3204,11 +3204,11 @@ models/mapobjects/pad_ddmix/attic/tubes
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/attic/tubes.tga
+		map models/mapobjects/pad_ddmix/attic/tubes
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3225,7 +3225,7 @@ models/mapobjects/pad_ddmix/trashcan/tree1_twigs
 	cull disable
 	//deformVertexes wave 194 sin 0 2 0 0.3
 	{
-		map models/mapobjects/pad_ddmix/trashcan/tree1_twigs.tga
+		map models/mapobjects/pad_ddmix/trashcan/tree1_twigs
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3237,7 +3237,7 @@ models/mapobjects/pad_ddmix/trashcan/tree1_leaves
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/tree1_leaves.tga
+		map models/mapobjects/pad_ddmix/trashcan/tree1_leaves
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3248,7 +3248,7 @@ models/mapobjects/pad_ddmix/trashcan/tree2_leaves
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/tree2_leaves.tga
+		map models/mapobjects/pad_ddmix/trashcan/tree2_leaves
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3259,7 +3259,7 @@ models/mapobjects/pad_ddmix/trashcan/tree3_twigs
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/tree3_twigs.tga
+		map models/mapobjects/pad_ddmix/trashcan/tree3_twigs
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3270,7 +3270,7 @@ models/mapobjects/pad_ddmix/trashcan/tree4_leaves
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/tree4_leaves.tga
+		map models/mapobjects/pad_ddmix/trashcan/tree4_leaves
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3281,7 +3281,7 @@ models/mapobjects/pad_ddmix/trashcan/grass
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/grass.tga
+		map models/mapobjects/pad_ddmix/trashcan/grass
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3292,7 +3292,7 @@ models/mapobjects/pad_ddmix/trashcan/bush
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/trashcan/bush.tga
+		map models/mapobjects/pad_ddmix/trashcan/bush
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3307,7 +3307,7 @@ models/mapobjects/pad_ddmix/castle/padking
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/castle/padking.tga
+		map models/mapobjects/pad_ddmix/castle/padking
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3323,7 +3323,7 @@ models/mapobjects/pad_ddmix/castle/turul
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/castle/turul.tga
+		map models/mapobjects/pad_ddmix/castle/turul
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3338,7 +3338,7 @@ models/mapobjects/pad_ddmix/castle/knightshield
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/castle/knightshield.tga
+		map models/mapobjects/pad_ddmix/castle/knightshield
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3355,7 +3355,7 @@ models/mapobjects/pad_cloister/groundplant
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_cloister/groundplant.tga
+		map models/mapobjects/pad_cloister/groundplant
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3370,7 +3370,7 @@ models/mapobjects/pad_cloister/cloister_lamp
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_cloister/cloister_lamp.tga
+		map models/mapobjects/pad_cloister/cloister_lamp
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3387,7 +3387,7 @@ models/mapobjects/pad_cloister/fern_brown
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_cloister/fern_brown.tga
+		map models/mapobjects/pad_cloister/fern_brown
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3403,7 +3403,7 @@ models/mapobjects/pad_cloister/cane_brown
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_cloister/cane_brown.tga
+		map models/mapobjects/pad_cloister/cane_brown
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3416,11 +3416,11 @@ models/mapobjects/pad_cloister/cane_brown
 models/mapobjects/pad_train/toilet_ceramic
 {
 	{
-		map models/mapobjects/pad_train/ttoilet.tga
+		map models/mapobjects/pad_train/ttoilet
 		rgbGen vertex
 	}
 	{
-		map textures/pad_gfx02/ceramic.tga
+		map textures/pad_gfx02/ceramic
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3430,11 +3430,11 @@ models/mapobjects/pad_train/toilet_ceramic
 models/mapobjects/pad_train/toilet_plastic_shiny
 {
 	{
-		map models/mapobjects/pad_train/ttoilet.tga
+		map models/mapobjects/pad_train/ttoilet
 		rgbGen vertex
 	}
 	{
-		map textures/pad_gfx02/plastic_shiny.tga
+		map textures/pad_gfx02/plastic_shiny
 		blendfunc add
 		rgbGen vertex
 		tcGen environment
@@ -3444,7 +3444,7 @@ models/mapobjects/pad_train/toilet_plastic_shiny
 models/mapobjects/pad_train/toilet_plastic_matte
 {
 	{
-		map models/mapobjects/pad_train/ttoilet.tga
+		map models/mapobjects/pad_train/ttoilet
 		rgbGen vertex
 	}
 }
@@ -3452,11 +3452,11 @@ models/mapobjects/pad_train/toilet_plastic_matte
 models/mapobjects/pad_train/toilet_metal
 {
 	{
-		map models/mapobjects/pad_train/ttoilet.tga
+		map models/mapobjects/pad_train/ttoilet
 		rgbGen vertex
 	}
 	{
-		map textures/pad_gfx02/metal_test.tga
+		map textures/pad_gfx02/metal_test
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3466,11 +3466,11 @@ models/mapobjects/pad_train/toilet_metal
 models/mapobjects/pad_train/tdoorhandle
 {
 	{
-		map models/mapobjects/pad_train/tdoorhandle.tga
+		map models/mapobjects/pad_train/tdoorhandle
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3480,11 +3480,11 @@ models/mapobjects/pad_train/tdoorhandle
 models/mapobjects/pad_train/ehammer_metal
 {
 	{
-		map models/mapobjects/pad_train/ehammer.tga
+		map models/mapobjects/pad_train/ehammer
 		rgbGen Vertex
 	}
 	{
-		map textures/pad_gfx02/metal_test.tga
+		map textures/pad_gfx02/metal_test
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3494,35 +3494,35 @@ models/mapobjects/pad_train/ehammer_metal
 models/mapobjects/ente/deadalien
 {
 	{
-		map models/mapobjects/ente/deadalien.tga
+		map models/mapobjects/ente/deadalien
 		rgbGen identity
 	}
         {
-                map textures/pad_gfx02/tinpad3.tga
+                map textures/pad_gfx02/tinpad3
 		blendfunc add
                 rgbGen Vertex
 		tcGen environment
         }
         nomipmaps
         {
-		map models/mapobjects/ente/deadalien_light.tga
+		map models/mapobjects/ente/deadalien_light
 		rgbGen identity
 		blendFunc filter
 	}
 }
 models/mapobjects/ente/deadalien_glass
 {
-	surfaceparm trans	
+	surfaceparm trans
 	cull none
 	surfaceparm nolightmap
         {
-		map models/mapobjects/ente/blendomatic.tga
+		map models/mapobjects/ente/blendomatic
 		rgbGen const ( 0.0 0.2 0.6 )
 		blendFunc blend
                 tcGen environment
 	}
         {
-		map textures/pad_gfx/glass_dark.tga
+		map textures/pad_gfx/glass_dark
                 tcgen environment
 		blendFunc add
 		rgbGen identity
@@ -3532,11 +3532,11 @@ models/mapobjects/ente/deadalien_glass
 models/mapobjects/pad_train/soapdispenser
 {
 	{
-		map models/mapobjects/pad_train/soapdispenser.tga
+		map models/mapobjects/pad_train/soapdispenser
 		rgbGen identity
 	}
         {
-                map textures/pad_gfx02/tinpad4.tga
+                map textures/pad_gfx02/tinpad4
 		blendfunc add
                 rgbGen Vertex
 		tcGen environment
@@ -3545,11 +3545,11 @@ models/mapobjects/pad_train/soapdispenser
 models/mapobjects/pad_train/soapdispenser_window
 {
   {
-		map models/mapobjects/pad_train/soapdispenser.tga
+		map models/mapobjects/pad_train/soapdispenser
 		rgbGen identity
 	}
   {
-    map textures/pad_gfx/glass_bright.tga
+    map textures/pad_gfx/glass_bright
 		blendfunc add
     rgbGen Vertex
 		tcGen environment
@@ -3560,18 +3560,18 @@ models/mapobjects/pad_train/ptoweldispenser
 {
   cull none
   {
-    map models/mapobjects/pad_train/ptoweldispenser.tga
+    map models/mapobjects/pad_train/ptoweldispenser
     rgbGen identity
   }
 }
 models/mapobjects/pad_train/ptoweldispenser_shiny
 {
 	{
-		map models/mapobjects/pad_train/ptoweldispenser.tga
+		map models/mapobjects/pad_train/ptoweldispenser
 		rgbGen identity
 	}
   {
-    map textures/pad_gfx02/tinpad4.tga
+    map textures/pad_gfx02/tinpad4
 		blendfunc add
     rgbGen Vertex
 		tcGen environment
@@ -3588,7 +3588,7 @@ models/mapobjects/pad_actionfigures/plastic
 	surfaceparm trans
 	cull disable
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc gl_one gl_one_minus_src_color
 		rgbGen identity
 		tcGen environment
@@ -3598,7 +3598,7 @@ models/mapobjects/pad_actionfigures/plastic
 models/mapobjects/pad_actionfigures/fig_pumper
 {
 	{
-		map models/weapons2/pumper/pumper.tga
+		map models/weapons2/pumper/pumper
 		rgbGen Vertex
 	}
 }
@@ -3606,7 +3606,7 @@ models/mapobjects/pad_actionfigures/fig_pumper
 models/mapobjects/pad_actionfigures/fig_pumpertubes
 {
 	{
-		map models/weapons2/pumper/tubes.tga
+		map models/weapons2/pumper/tubes
 		rgbGen Vertex
 	}
 }
@@ -3614,7 +3614,7 @@ models/mapobjects/pad_actionfigures/fig_pumpertubes
 models/mapobjects/pad_actionfigures/fig_splasher
 {
 	{
-		map models/weapons2/splasher/splasher.tga
+		map models/weapons2/splasher/splasher
 		rgbGen Vertex
 	}
 }
@@ -3622,7 +3622,7 @@ models/mapobjects/pad_actionfigures/fig_splasher
 models/mapobjects/pad_actionfigures/fig_frontface
 {
 	{
-		map models/weapons2/splasher/new_frontface.tga
+		map models/weapons2/splasher/new_frontface
 		rgbGen Vertex
 	}
 }
@@ -3630,7 +3630,7 @@ models/mapobjects/pad_actionfigures/fig_frontface
 models/mapobjects/pad_actionfigures/fig_splasherwater
 {
 	{
-		map textures/pad_gfx02/padmapplas.jpg
+		map textures/pad_gfx02/padmapplas
 		blendfunc GL_ONE GL_ZERO
 		tcMod turb 0 .6 0 .2
 		tcmod scale .4 .4
@@ -3638,7 +3638,7 @@ models/mapobjects/pad_actionfigures/fig_splasherwater
 		//rgbGen lightingdiffuse //identity
 	}
 	{
-		map textures/pad_gfx02/padmapblue2.jpg
+		map textures/pad_gfx02/padmapblue2
 		blendfunc GL_ONE GL_ONE
 		tcMod turb 0 .7 0 .3
 		tcmod scale .2 .2
@@ -3646,7 +3646,7 @@ models/mapobjects/pad_actionfigures/fig_splasherwater
 		//rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/padmapblue.jpg
+		map textures/pad_gfx02/padmapblue
 		blendFunc GL_ONE GL_ONE
 		tcGen environment
 		tcMod scroll -.3 0
@@ -3664,7 +3664,7 @@ models/mapobjects/pad_actionfigures/fig_splasherwater
 models/mapobjects/pad_actionfigures/padgrlhd
 {
 	{
-		map models/wop_players/padgirl/padgrlhd.tga
+		map models/wop_players/padgirl/padgrlhd
 		rgbGen Vertex
 	}
 }
@@ -3672,7 +3672,7 @@ models/mapobjects/pad_actionfigures/padgrlhd
 models/mapobjects/pad_actionfigures/padgrlbd
 {
 	{
-		map models/wop_players/padgirl/padgrlbd.tga
+		map models/wop_players/padgirl/padgrlbd
 		rgbGen Vertex
 	}
 }
@@ -3685,7 +3685,7 @@ models/mapobjects/pad_actionfigures/padgrlbd
 models/mapobjects/pad_actionfigures/lilhead
 {
 	{
-		map models/wop_players/padlilly/lilhead.tga
+		map models/wop_players/padlilly/lilhead
 		rgbGen Vertex
 	}
 }
@@ -3693,7 +3693,7 @@ models/mapobjects/pad_actionfigures/lilhead
 models/mapobjects/pad_actionfigures/lilbody
 {
 	{
-		map models/wop_players/padlilly/lilbody.tga
+		map models/wop_players/padlilly/lilbody
 		rgbGen Vertex
 	}
 }
@@ -3706,7 +3706,7 @@ models/mapobjects/pad_actionfigures/lilbody
 models/mapobjects/pad_westernset/colt
 {
 	{
-		map models/mapobjects/pad_westernset/colt.tga
+		map models/mapobjects/pad_westernset/colt
 		rgbGen Vertex
 	}
 	{
@@ -3715,7 +3715,7 @@ models/mapobjects/pad_westernset/colt
 		tcGen environment
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3726,7 +3726,7 @@ models/mapobjects/pad_westernset/camera_screens
 {
 	nomipmaps
 	{
-		map models/mapobjects/pad_westernset/camera_screens.tga
+		map models/mapobjects/pad_westernset/camera_screens
 		tcMod scale 0.8 0.8
 		tcGen environment
 	}
@@ -3735,7 +3735,7 @@ models/mapobjects/pad_westernset/camera_screens
 models/mapobjects/pad_westernset/directors_chair_wood
 {
 	{
-		map models/mapobjects/pad_westernset/directors_chair_wood.tga
+		map models/mapobjects/pad_westernset/directors_chair_wood
 		rgbGen Vertex
 	}
 	{
@@ -3744,7 +3744,7 @@ models/mapobjects/pad_westernset/directors_chair_wood
 		tcGen environment
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen Vertex
 		tcGen environment
@@ -3756,7 +3756,7 @@ models/mapobjects/pad_westernset/directors_chair_cloth
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_westernset/directors_chair_cloth.tga
+		map models/mapobjects/pad_westernset/directors_chair_cloth
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3767,7 +3767,7 @@ models/mapobjects/pad_westernset/actors_chair_cloth
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_westernset/actors_chair_cloth.tga
+		map models/mapobjects/pad_westernset/actors_chair_cloth
 		rgbGen Vertex
 		alphaFunc GE128
 	}
@@ -3777,7 +3777,7 @@ models/mapobjects/pad_westernset/spotlight
 {
 	cull disable
 	{
-		map models/mapobjects/pad_westernset/spotlight.tga
+		map models/mapobjects/pad_westernset/spotlight
 		rgbGen Vertex
 	}
 }
@@ -3787,7 +3787,7 @@ models/mapobjects/pad_westernset/spotlight_front
 	cull disable
 	q3map_surfacelight 60
 	{
-		map models/mapobjects/pad_westernset/spotlight_front.tga
+		map models/mapobjects/pad_westernset/spotlight_front
 	}
 }
 
@@ -3797,11 +3797,11 @@ models/mapobjects/pad_westernset/sheriff_badge
 	cull none
 
 	{
-		map models/mapobjects/pad_westernset/sheriff_badge.tga
+		map models/mapobjects/pad_westernset/sheriff_badge
 		rgbGen vertex
         }
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen vertex
@@ -3817,7 +3817,7 @@ models/mapobjects/pad_fruits/citrus_leaf
 	surfaceparm alphashadow
 	cull disable
 	{
-		map models/mapobjects/pad_fruits/citrus.tga
+		map models/mapobjects/pad_fruits/citrus
 		rgbGen vertex
 		alphaFunc GE128
 	}
@@ -3832,22 +3832,22 @@ models/mapobjects/pad_statues/statue_super_head
 {
   cull none
   {
-//    map models/wop_players/padman/default_head.tga
-    map models/mapobjects/ente/padwinner_head.tga	//head still needs reference to old padwinner statue texture for correct alignment ~Kai-Li 
+//    map models/wop_players/padman/default_head
+    map models/mapobjects/ente/padwinner_head	//head still needs reference to old padwinner statue texture for correct alignment ~Kai-Li
   }
 }
 
 models/mapobjects/pad_statues/statue_super_hands
 {
   {
-    map models/wop_players/padman/default_head.tga
+    map models/wop_players/padman/default_head
   }
 }
 
 models/mapobjects/pad_statues/statue_super_shoes
 {
   {
-    map models/wop_players/padman/default_head.tga
+    map models/wop_players/padman/default_head
   }
 }
 
@@ -3855,7 +3855,7 @@ models/mapobjects/pad_statues/statue_super_shades
 {
   cull none
   {
-    map models/wop_players/padman/default_head.tga
+    map models/wop_players/padman/default_head
   }
 }
 
@@ -3863,7 +3863,7 @@ models/mapobjects/pad_statues/statue_super_shades
 models/mapobjects/pad_statues/statue_super_neck
 {
   {
-    map models/wop_players/padman/default_body.tga
+    map models/wop_players/padman/default_body
   }
 }
 
@@ -3871,28 +3871,28 @@ models/mapobjects/pad_statues/statue_super_cape
 {
   cull none
   {
-    map models/wop_players/padman/default_body.tga
+    map models/wop_players/padman/default_body
   }
-} 
+}
 
 models/mapobjects/pad_statues/statue_super_suit
 {
   {
-    map models/wop_players/padman/default_body.tga
+    map models/wop_players/padman/default_body
   }
 }
 
 models/mapobjects/pad_statues/statue_super_buckle
 {
   {
-    map models/wop_players/padman/default_head.tga
+    map models/wop_players/padman/default_head
   }
 }
 
 models/mapobjects/pad_statues/statue_super_button
 {
   {
-    map models/wop_players/padman/default_head.tga
+    map models/wop_players/padman/default_head
   }
 }
 
@@ -3909,7 +3909,7 @@ models/mapobjects/pad_ddmix/plants/fern_singleplayer
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/fern_singleplayer.tga
+		map models/mapobjects/pad_ddmix/plants/fern_singleplayer
 		rgbGen exactVertex
 		alphaFunc GE128
 	}
@@ -3923,7 +3923,7 @@ models/mapobjects/pad_ddmix/plants/bonsai_singleplayer
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/bonsai_singleplayer.tga
+		map models/mapobjects/pad_ddmix/plants/bonsai_singleplayer
 		rgbGen exactVertex
 		alphaFunc GE128
 	}
@@ -3936,7 +3936,7 @@ models/mapobjects/pad_ddmix/padkitchen/towel01_singleplayer
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/padkitchen/towel01_singleplayer.tga
+		map models/mapobjects/pad_ddmix/padkitchen/towel01_singleplayer
 		rgbGen exactVertex
 	}
 }
@@ -3947,7 +3947,7 @@ models/mapobjects/pad_ddmix/padkitchen/towel02_singleplayer
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/padkitchen/towel02_singleplayer.tga
+		map models/mapobjects/pad_ddmix/padkitchen/towel02_singleplayer
 		rgbGen exactVertex
 	}
 }
@@ -3959,7 +3959,7 @@ models/mapobjects/pad_ddmix/castle/kshield_singleplayer
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/castle/kshield_singleplayer.tga
+		map models/mapobjects/pad_ddmix/castle/kshield_singleplayer
 		rgbGen exactVertex
 		alphaFunc GE128
 	}
@@ -3971,7 +3971,7 @@ models/mapobjects/pad_ddmix/castle/padking_singleplayer
 {
 	cull disable
 	{
-		map models/mapobjects/pad_ddmix/castle/padking_singleplayer.tga
+		map models/mapobjects/pad_ddmix/castle/padking_singleplayer
 		rgbGen exactVertex
 		alphaFunc GE128
 	}
@@ -3983,11 +3983,11 @@ models/mapobjects/pad_ddmix/castle/padking_singleplayer
 models/mapobjects/pad_clothes/sock01_singleplayer
 {
     cull disable
-	qer_editorimage models/mapobjects/pad_clothes/sock01_singleplayer.jpg
+	qer_editorimage models/mapobjects/pad_clothes/sock01_singleplayer
 	{
-		map models/mapobjects/pad_clothes/sock01_singleplayer.jpg
+		map models/mapobjects/pad_clothes/sock01_singleplayer
 		rgbGen exactVertex
-	}	
+	}
 }
 
 //SOCK02
@@ -3995,11 +3995,11 @@ models/mapobjects/pad_clothes/sock01_singleplayer
 models/mapobjects/pad_clothes/sock02_singleplayer
 {
     cull disable
-	qer_editorimage models/mapobjects/pad_clothes/sock02_singleplayer.jpg
+	qer_editorimage models/mapobjects/pad_clothes/sock02_singleplayer
 	{
-		map models/mapobjects/pad_clothes/sock02_singleplayer.jpg
+		map models/mapobjects/pad_clothes/sock02_singleplayer
 		rgbGen exactVertex
-	}	
+	}
 }
 
 //TULPi1
@@ -4010,7 +4010,7 @@ models/mapobjects/pad_ddmix/plants/tulip1_singleplayer
 	cull disable
 	nomipmaps
 	{
-		map models/mapobjects/pad_ddmix/plants/tulip1_singleplayer.tga
+		map models/mapobjects/pad_ddmix/plants/tulip1_singleplayer
 		rgbGen exactVertex
 		alphaFunc GE128
 	}
@@ -4025,9 +4025,9 @@ models/mapobjects/pad_sunflower/sunhead_single
 {
 	cull none
 	nopicmip
-	nomipmaps 
+	nomipmaps
 	{
-		map models/mapobjects/pad_sunflower/sunhead_single.tga
+		map models/mapobjects/pad_sunflower/sunhead_single
 		alphaFunc GE128
 		rgbGen exactvertex
 	}
@@ -4037,9 +4037,9 @@ models/mapobjects/pad_sunflower/sunleaf1_single
 {
 	cull none
 	nopicmip
-	nomipmaps 
+	nomipmaps
 	{
-		map models/mapobjects/pad_sunflower/sunleaf1_single.tga
+		map models/mapobjects/pad_sunflower/sunleaf1_single
 		alphaFunc GE128
 		rgbGen exactvertex
 	}
@@ -4049,9 +4049,9 @@ models/mapobjects/pad_sunflower/sunleaf2_single
 {
 	cull none
 	nopicmip
-	nomipmaps 
+	nomipmaps
 	{
-		map models/mapobjects/pad_sunflower/sunleaf2_single.tga
+		map models/mapobjects/pad_sunflower/sunleaf2_single
 		alphaFunc GE128
 		rgbGen exactvertex
 	}
@@ -4063,23 +4063,23 @@ models/mapobjects/ente/padshop_tft_screen
    	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_pc/pad_tft.tga
+	q3map_lightimage models/mapobjects/pad_pc/pad_tft
 	q3map_surfacelight 10
 	nopicmip
 
        	{
-               	animmap .3 models/mapobjects/ente/screen01.tga models/mapobjects/ente/screen02.tga models/mapobjects/ente/screen03.tga models/mapobjects/ente/screen04.tga models/mapobjects/ente/screen05.tga
+               	animmap .3 models/mapobjects/ente/screen01 models/mapobjects/ente/screen02 models/mapobjects/ente/screen03 models/mapobjects/ente/screen04 models/mapobjects/ente/screen05
                	rgbgen identity
        	}
 	{
-		map models/mapobjects/padtv/scanline.tga
+		map models/mapobjects/padtv/scanline
 		blendfunc blend
 		rgbGen identity
 		tcMod scroll 0 -0.035
 		tcMod scale 45 45
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         	tcGen environment
                 blendfunc GL_ONE GL_ONE
                 rgbGen identity

--- a/wop/scripts.pk3dir/scripts/pad_pirate.shader
+++ b/wop/scripts.pk3dir/scripts/pad_pirate.shader
@@ -1,11 +1,11 @@
 textures/pad_pirate/doornthree
 {
-        qer_editorimage textures/pad_pirate/doornthree.tga
+        qer_editorimage textures/pad_pirate/doornthree
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_pirate/orange02.tga
+        q3map_lightimage textures/pad_pirate/orange02
 	q3map_sun	1.000000 0.635081 0.272618 280 45 45
 	q3map_surfacelight 230
  {
@@ -21,18 +21,18 @@ textures/pad_pirate/doornthree
 
 textures/pad_pirate/deep-six
 {
-        qer_editorimage textures/pad_pirate/deep-six.tga
+        qer_editorimage textures/pad_pirate/deep-six
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_pirate/blue.tga
+        q3map_lightimage textures/pad_pirate/blue
 	q3map_sun	0.266383 0.274632 0.358662 130 65 55
 	q3map_surfacelight 170
 
         skyparms env/deep-six512 - -
 //       {
-//		map textures/pad_pirate/deep-six.tga
+//		map textures/pad_pirate/deep-six
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -43,14 +43,14 @@ textures/pad_pirate/padflagg
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_pirate/padflagg.tga
+                map textures/pad_pirate/padflagg
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -68,7 +68,7 @@ textures/pad_pirate/padflagg
 
 textures/pad_pirate/busch_p
 {
-        qer_editorimage textures/pad_pirate/busch_p.tga
+        qer_editorimage textures/pad_pirate/busch_p
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -76,7 +76,7 @@ textures/pad_pirate/busch_p
 	cull none
         nopicmip
 	{
-		map textures/pad_pirate/busch_p.tga
+		map textures/pad_pirate/busch_p
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -93,14 +93,14 @@ textures/pad_pirate/busch_p
 
 textures/pad_pirate/falcon
 {
-        qer_editorimage textures/pad_pirate/falcon.tga
+        qer_editorimage textures/pad_pirate/falcon
     	surfaceparm trans
 	surfaceparm playerclip
    	surfaceparm nonsolid
 	cull none
         nopicmip
 	{
-		map textures/pad_pirate/falcon.tga
+		map textures/pad_pirate/falcon
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -116,32 +116,32 @@ textures/pad_pirate/falcon
 
 textures/pad_pirate/flame1
 {
-	deformVertexes autoSprite2 
+	deformVertexes autoSprite2
 	surfaceparm trans
 	surfaceparm nomarks
 	surfaceparm nolightmap
 	cull none
 	q3map_surfacelight 50
-	qer_editorimage textures/pad_pirate/flame1.tga
-	
+	qer_editorimage textures/pad_pirate/flame1
+
 
 	{
-		animMap 3 textures/pad_pirate/flame1.tga textures/pad_pirate/flame2.tga textures/pad_pirate/flame3.tga textures/pad_pirate/flame2.tga
+		animMap 3 textures/pad_pirate/flame1 textures/pad_pirate/flame2 textures/pad_pirate/flame3 textures/pad_pirate/flame2
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 10
-		
-	}	
+
+	}
 	{
-		animMap 3 textures/pad_pirate/flame2.tga textures/pad_pirate/flame3.tga textures/pad_pirate/flame2.tga textures/pad_pirate/flame1.tga
+		animMap 3 textures/pad_pirate/flame2 textures/pad_pirate/flame3 textures/pad_pirate/flame2 textures/pad_pirate/flame1
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave sawtooth 0 1 0 10
-	}	
+	}
 
 
 	{
-		map textures/pad_pirate/flameball.tga
+		map textures/pad_pirate/flameball
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+		rgbGen wave sin .6 .2 0 .6
 	}
 
 }
@@ -151,13 +151,13 @@ textures/pad_pirate/feder01
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_pirate/feder01.tga
+                map textures/pad_pirate/feder01
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -177,13 +177,13 @@ textures/pad_pirate/feder02
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_pirate/feder02.tga
+                map textures/pad_pirate/feder02
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -203,13 +203,13 @@ textures/pad_pirate/feder03
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_pirate/feder03.tga
+                map textures/pad_pirate/feder03
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -226,19 +226,19 @@ textures/pad_pirate/feder03
 
 textures/pad_pirate/klinge00
 {
-	qer_editorimage textures/pad_pirate/klinge00.tga
+	qer_editorimage textures/pad_pirate/klinge00
 	{
-		map textures/pad_pirate/klinge00.tga
+		map textures/pad_pirate/klinge00
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -247,19 +247,19 @@ textures/pad_pirate/klinge00
 
 textures/pad_pirate/klinge01
 {
-	qer_editorimage textures/pad_pirate/klinge01.tga
+	qer_editorimage textures/pad_pirate/klinge01
 	{
-		map textures/pad_pirate/klinge01.tga
+		map textures/pad_pirate/klinge01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -268,7 +268,7 @@ textures/pad_pirate/klinge01
 
 textures/pad_pirate/annebonny2
 {
-        qer_editorimage textures/pad_pirate/annebonny2.tga
+        qer_editorimage textures/pad_pirate/annebonny2
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -276,7 +276,7 @@ textures/pad_pirate/annebonny2
 	cull none
         nopicmip
 	{
-		map textures/pad_pirate/annebonny2.tga
+		map textures/pad_pirate/annebonny2
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -292,7 +292,7 @@ textures/pad_pirate/annebonny2
 
 textures/pad_pirate/letter01
 {
-        qer_editorimage textures/pad_pirate/letter01.tga
+        qer_editorimage textures/pad_pirate/letter01
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -300,7 +300,7 @@ textures/pad_pirate/letter01
 	cull none
         nopicmip
 	{
-		map textures/pad_pirate/letter01.tga
+		map textures/pad_pirate/letter01
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -317,7 +317,7 @@ textures/pad_pirate/letter01
 
 textures/pad_pirate/letter02
 {
-        qer_editorimage textures/pad_pirate/letter02.tga
+        qer_editorimage textures/pad_pirate/letter02
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -325,7 +325,7 @@ textures/pad_pirate/letter02
 	cull none
         nopicmip
 	{
-		map textures/pad_pirate/letter02.tga
+		map textures/pad_pirate/letter02
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -341,19 +341,19 @@ textures/pad_pirate/letter02
 
 textures/pad_pirate/gold
 {
-	qer_editorimage textures/pad_pirate/gold.tga
+	qer_editorimage textures/pad_pirate/gold
 	{
-		map textures/pad_pirate/gold.tga
+		map textures/pad_pirate/gold
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -361,7 +361,7 @@ textures/pad_pirate/gold
 
 textures/pad_pirate/bubbles2_1
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -371,7 +371,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.093287 -41.198784 641.500214 sawtooth 0 1 1.000725 0.195925
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 20.229958
 AlphaGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
 rgbGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
@@ -382,7 +382,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_2
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -392,7 +392,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.769913 -21.519264 589.001572 sawtooth 0 1 0.622631 0.252309
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 2.200842
 AlphaGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
 rgbGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
@@ -403,7 +403,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_3
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -413,7 +413,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.625161 -6.980746 507.586830 sawtooth 0 1 1.213530 0.445164
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 19.405041
 AlphaGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
 rgbGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
@@ -424,7 +424,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_4
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -434,7 +434,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.668365 -12.663155 559.066895 sawtooth 0 1 1.085688 0.300365
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 11.414990
 AlphaGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
 rgbGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
@@ -445,7 +445,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_5
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -455,7 +455,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.763139 -30.482132 651.611313 sawtooth 0 1 0.288759 0.189146
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 1.619465
 AlphaGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
 rgbGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
@@ -466,7 +466,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_6
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -476,7 +476,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.834942 -10.679131 530.490509 sawtooth 0 1 1.237915 0.365962
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate -2.907956
 AlphaGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
 rgbGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
@@ -487,7 +487,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_7
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -497,7 +497,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.454388 -41.883984 627.730408 sawtooth 0 1 0.402287 0.207241
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 3.890042
 AlphaGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
 rgbGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
@@ -508,7 +508,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_8
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -518,7 +518,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.112141 -36.627399 616.117142 sawtooth 0 1 0.784623 0.218790
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 24.587999
 AlphaGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
 rgbGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
@@ -529,7 +529,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_9
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -539,7 +539,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 13.988351 -11.087501 603.268707 sawtooth 0 1 1.044519 0.235235
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 12.468795
 AlphaGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
 rgbGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
@@ -550,7 +550,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_10
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -560,7 +560,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 10.265741 7.714635 731.291351 sawtooth 0 1 0.524331 0.144779
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 12.796563
 AlphaGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
 rgbGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
@@ -571,7 +571,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_11
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -581,7 +581,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 25.100649 4.780672 586.159500 sawtooth 0 1 0.907308 0.255448
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate 16.214331
 AlphaGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
 rgbGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
@@ -592,7 +592,7 @@ blendfunc add
 
 textures/pad_pirate/bubbles2_12
 {
-qer_editorimage textures/pad_pirate/bubbles2.tga
+qer_editorimage textures/pad_pirate/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -602,7 +602,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 12.983425 -1.691125 495.949432 sawtooth 0 1 0.845538 0.495670
 {
-clampmap textures/pad_pirate/bubbles2.tga
+clampmap textures/pad_pirate/bubbles2
 tcMod rotate -2.724845
 AlphaGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
 rgbGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
@@ -614,7 +614,7 @@ blendfunc add
 
 textures/pad_pirate/coral
 {
-	qer_editorimage textures/pad_pirate/coral.tga
+	qer_editorimage textures/pad_pirate/coral
 	deformVertexes wave 194 sin 0 2 0 .2
 	deformVertexes wave 30 sin 0 1 0 .3
 	deformVertexes wave 194 sin 0 1 0 .1
@@ -623,7 +623,7 @@ textures/pad_pirate/coral
 	cull none
 
 	{
-		map textures/pad_pirate/coral.tga
+		map textures/pad_pirate/coral
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -638,36 +638,36 @@ textures/pad_pirate/coral
 }
 
 
-\\textures/pad_pirate/pglass01b 
+\\textures/pad_pirate/pglass01b
 {
 	q3map_nolightmap
 	q3map_onlyvertexlighting
     {
-        map textures/pad_pirate/pglass01b.tga
+        map textures/pad_pirate/pglass01b
         blendFunc GL_ONE GL_ONE
         rgbgen exactVertex
     }
 }
 
 
-\\textures/pad_pirate/pglass02b 
+\\textures/pad_pirate/pglass02b
 {
 	q3map_nolightmap
 	q3map_onlyvertexlighting
     {
-        map textures/pad_pirate/pglass02b.tga
+        map textures/pad_pirate/pglass02b
         blendFunc GL_ONE GL_ONE
         rgbgen exactVertex
     }
 }
 
 
-\\textures/pad_pirate/pglass03b 
+\\textures/pad_pirate/pglass03b
 {
 	q3map_nolightmap
 	q3map_onlyvertexlighting
     {
-        map textures/pad_pirate/pglass03b.tga
+        map textures/pad_pirate/pglass03b
         blendFunc GL_ONE GL_ONE
         rgbgen exactVertex
     }
@@ -676,14 +676,14 @@ textures/pad_pirate/coral
 
 textures/pad_pirate/pglass03
 {
-	qer_editorimage textures/pad_pirate/pglass03.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_pirate/pglass03
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_pirate/pglass03.tga
+		map textures/pad_pirate/pglass03
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -692,20 +692,20 @@ textures/pad_pirate/pglass03
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_pirate/pglass01
 {
-	qer_editorimage textures/pad_pirate/pglass01.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_pirate/pglass01
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_pirate/pglass01.tga
+		map textures/pad_pirate/pglass01
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -714,20 +714,20 @@ textures/pad_pirate/pglass01
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_pirate/pglass02
 {
-	qer_editorimage textures/pad_pirate/pglass02.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_pirate/pglass02
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_pirate/pglass02.tga
+		map textures/pad_pirate/pglass02
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -736,21 +736,21 @@ textures/pad_pirate/pglass02
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 
 textures/pad_pirate/pglass04
 {
-	qer_editorimage textures/pad_pirate/pglass04.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_pirate/pglass04
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_pirate/pglass04.tga
+		map textures/pad_pirate/pglass04
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -759,20 +759,20 @@ textures/pad_pirate/pglass04
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_pirate/pglass05
 {
-	qer_editorimage textures/pad_pirate/pglass05.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_pirate/pglass05
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_pirate/pglass05.tga
+		map textures/pad_pirate/pglass05
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -781,20 +781,20 @@ textures/pad_pirate/pglass05
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_pirate/pglass06
 {
-	qer_editorimage textures/pad_pirate/pglass06.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_pirate/pglass06
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_pirate/pglass06.tga
+		map textures/pad_pirate/pglass06
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -803,20 +803,20 @@ textures/pad_pirate/pglass06
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_pirate/pglass07
 {
-	qer_editorimage textures/pad_pirate/pglass07.tga
-        surfaceparm trans	
+	qer_editorimage textures/pad_pirate/pglass07
+        surfaceparm trans
 	cull none
 	surfaceparm nolightmap
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_pirate/pglass07.tga
+		map textures/pad_pirate/pglass07
                 blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
@@ -825,12 +825,12 @@ textures/pad_pirate/pglass07
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 textures/pad_pirate/longsail02
 {
-        qer_editorimage textures/pad_pirate/longsail02.tga
+        qer_editorimage textures/pad_pirate/longsail02
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -838,7 +838,7 @@ textures/pad_pirate/longsail02
 	cull none
         nopicmip
 	{
-		map textures/pad_pirate/longsail02.tga
+		map textures/pad_pirate/longsail02
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -861,11 +861,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/blanken01b.tga
+map textures/pad_pirate/blanken01b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_pirate/wood_line
 {
@@ -875,21 +875,21 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood_line.tga
+map textures/pad_pirate/wood_line
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_pirate/kreideship
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_pirate/kreideship.tga
+		map textures/pad_pirate/kreideship
                		blendFunc add
 		rgbGen vertex
 	}
@@ -904,25 +904,25 @@ textures/pad_pirate/kupfer001
 		map $lightmap
 	}
 	{
-		map textures/pad_pirate/kupfer001.tga
+		map textures/pad_pirate/kupfer001
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_pirate/kupfer001.tga
+		map textures/pad_pirate/kupfer001
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}   
+}
 
 
 textures/pad_pirate/kupfer002
@@ -933,25 +933,25 @@ textures/pad_pirate/kupfer002
 		map $lightmap
 	}
 	{
-		map textures/pad_pirate/kupfer002.tga
+		map textures/pad_pirate/kupfer002
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_pirate/kupfer002.tga
+		map textures/pad_pirate/kupfer002
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}   
+}
 
 
 textures/pad_pirate/kupfer003
@@ -962,30 +962,30 @@ textures/pad_pirate/kupfer003
 		map $lightmap
 	}
 	{
-		map textures/pad_pirate/kupfer003.tga
+		map textures/pad_pirate/kupfer003
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_pirate/kupfer003.tga
+		map textures/pad_pirate/kupfer003
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}   
+}
 
 
 textures/pad_pirate/pladde
 {
-        qer_editorimage textures/pad_pirate/pladde.tga
+        qer_editorimage textures/pad_pirate/pladde
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -993,7 +993,7 @@ textures/pad_pirate/pladde
 	cull none
         nopicmip
 	{
-		map textures/pad_pirate/pladde.tga
+		map textures/pad_pirate/pladde
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1010,19 +1010,19 @@ textures/pad_pirate/pladde
 
 textures/pad_pirate/becher1
 {
-	qer_editorimage textures/pad_pirate/becher1.tga
+	qer_editorimage textures/pad_pirate/becher1
 	{
-		map textures/pad_pirate/becher1.tga
+		map textures/pad_pirate/becher1
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1031,19 +1031,19 @@ textures/pad_pirate/becher1
 
 textures/pad_pirate/becher2
 {
-	qer_editorimage textures/pad_pirate/becher2.tga
+	qer_editorimage textures/pad_pirate/becher2
 	{
-		map textures/pad_pirate/becher2.tga
+		map textures/pad_pirate/becher2
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1052,19 +1052,19 @@ textures/pad_pirate/becher2
 
 textures/pad_pirate/klinge00
 {
-	qer_editorimage textures/pad_pirate/klinge00.tga
+	qer_editorimage textures/pad_pirate/klinge00
 	{
-		map textures/pad_pirate/klinge00.tga
+		map textures/pad_pirate/klinge00
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1072,19 +1072,19 @@ textures/pad_pirate/klinge00
 
 textures/pad_pirate/klinge01
 {
-	qer_editorimage textures/pad_pirate/klinge01.tga
+	qer_editorimage textures/pad_pirate/klinge01
 	{
-		map textures/pad_pirate/klinge01.tga
+		map textures/pad_pirate/klinge01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1093,19 +1093,19 @@ textures/pad_pirate/klinge01
 
 textures/pad_pirate/telescope01
 {
-	qer_editorimage textures/pad_pirate/telescope01.tga
+	qer_editorimage textures/pad_pirate/telescope01
 	{
-		map textures/pad_pirate/telescope01.tga
+		map textures/pad_pirate/telescope01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1120,7 +1120,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/blanken01.tga
+map textures/pad_pirate/blanken01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1135,7 +1135,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/blanken01b.tga
+map textures/pad_pirate/blanken01b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1149,7 +1149,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/boarddoor.tga
+map textures/pad_pirate/boarddoor
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1165,7 +1165,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/doorship04.tga
+map textures/pad_pirate/doorship04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1180,7 +1180,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/doorshipkant.tga
+map textures/pad_pirate/doorshipkant
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1195,7 +1195,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/mop.tga
+map textures/pad_pirate/mop
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1210,7 +1210,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/p_sugar.tga
+map textures/pad_pirate/p_sugar
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1224,7 +1224,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/planke01.tga
+map textures/pad_pirate/planke01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1238,7 +1238,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/planke02.tga
+map textures/pad_pirate/planke02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1252,7 +1252,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/planke03.tga
+map textures/pad_pirate/planke03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1267,7 +1267,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/planken02.tga
+map textures/pad_pirate/planken02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1281,7 +1281,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/segel.tga
+map textures/pad_pirate/segel
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1295,7 +1295,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/seil.tga
+map textures/pad_pirate/seil
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1309,7 +1309,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipbalken.tga
+map textures/pad_pirate/shipbalken
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1324,7 +1324,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipbalken02b.tga
+map textures/pad_pirate/shipbalken02b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1338,7 +1338,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipbalkenb.tga
+map textures/pad_pirate/shipbalkenb
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1353,7 +1353,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipluke2.tga
+map textures/pad_pirate/shipluke2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1367,7 +1367,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipmast.tga
+map textures/pad_pirate/shipmast
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1382,7 +1382,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipplanke_blank.tga
+map textures/pad_pirate/shipplanke_blank
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1397,7 +1397,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipplanke_blank3.tga
+map textures/pad_pirate/shipplanke_blank3
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1412,7 +1412,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipplanke_wall02.tga
+map textures/pad_pirate/shipplanke_wall02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1427,7 +1427,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipplanke_wall04.tga
+map textures/pad_pirate/shipplanke_wall04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1442,7 +1442,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipplanke_wall05b.tga
+map textures/pad_pirate/shipplanke_wall05b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1456,7 +1456,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/shipplanke_wall08.tga
+map textures/pad_pirate/shipplanke_wall08
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1470,7 +1470,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/stufen.tga
+map textures/pad_pirate/stufen
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1484,7 +1484,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/sugar.tga
+map textures/pad_pirate/sugar
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1498,7 +1498,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/teppich01.tga
+map textures/pad_pirate/teppich01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1513,7 +1513,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/trepside.tga
+map textures/pad_pirate/trepside
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1527,7 +1527,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/truhe001.tga
+map textures/pad_pirate/truhe001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1541,7 +1541,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/truhe001b.tga
+map textures/pad_pirate/truhe001b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1556,7 +1556,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/truhe002_big.tga
+map textures/pad_pirate/truhe002_big
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1570,7 +1570,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/truhe002b.tga
+map textures/pad_pirate/truhe002b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1584,7 +1584,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/truhelatten001.tga
+map textures/pad_pirate/truhelatten001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1598,7 +1598,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/truhelatten001b.tga
+map textures/pad_pirate/truhelatten001b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1612,7 +1612,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/truhenplatte.tga
+map textures/pad_pirate/truhenplatte
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1626,7 +1626,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood_canon.tga
+map textures/pad_pirate/wood_canon
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1641,7 +1641,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood_line.tga
+map textures/pad_pirate/wood_line
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1655,7 +1655,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood017black.tga
+map textures/pad_pirate/wood017black
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1669,7 +1669,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood017Sblueb.tga
+map textures/pad_pirate/wood017Sblueb
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1684,7 +1684,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood017Sgreenb.tga
+map textures/pad_pirate/wood017Sgreenb
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1698,7 +1698,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood017Sredb.tga
+map textures/pad_pirate/wood017Sredb
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1712,7 +1712,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood017yellow.tga
+map textures/pad_pirate/wood017yellow
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1726,7 +1726,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood093cb.tga
+map textures/pad_pirate/wood093cb
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1741,7 +1741,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/woodlatten01b.tga
+map textures/pad_pirate/woodlatten01b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1755,7 +1755,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/woodlattenblue02.tga
+map textures/pad_pirate/woodlattenblue02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1770,7 +1770,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/woodlattenred02.tga
+map textures/pad_pirate/woodlattenred02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1784,7 +1784,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/woodywood.tga
+map textures/pad_pirate/woodywood
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1798,7 +1798,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/woodzier008cc.tga
+map textures/pad_pirate/woodzier008cc
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1812,7 +1812,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wreling04b.tga
+map textures/pad_pirate/wreling04b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1826,7 +1826,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/wood038fleck.tga
+map textures/pad_pirate/wood038fleck
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1841,7 +1841,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/canon1024.tga
+map textures/pad_pirate/canon1024
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1855,7 +1855,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pirate/canon512.tga
+map textures/pad_pirate/canon512
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1867,13 +1867,13 @@ textures/pad_pirate/waterdecke
 {
 	tessSize 64
 	deformVertexes normal 1 1
-	qer_editorimage textures/pad_pirate/holzdecke.tga
+	qer_editorimage textures/pad_pirate/holzdecke
         {
-		map textures/pad_pirate/holzdecke.tga
-                rgbGen identity    
+		map textures/pad_pirate/holzdecke
+                rgbGen identity
         }
         {
-		map textures/pad_pirate/waterreflection.tga
+		map textures/pad_pirate/waterreflection
                 Blendfunc add
 		tcgen environment
 		rgbgen wave sin .2 0 0 0
@@ -1893,11 +1893,11 @@ textures/pad_pirate/candleflare
     deformVertexes autoSprite
     surfaceparm trans
     surfaceparm nomarks
-    surfaceparm nonsolid		
+    surfaceparm nonsolid
     surfaceparm nolightmap
     cull none
           {
-            clampmap textures/pad_pirate/candleflare.tga
+            clampmap textures/pad_pirate/candleflare
             blendFunc GL_ONE GL_ONE
           }
 }
@@ -1905,20 +1905,20 @@ textures/pad_pirate/candleflare
 
 textures/pad_pirate/bechercurve
 {
-          qer_editorimage textures/pad_pirate/becher1.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/becher1
+           surfaceparm nonsolid
 	{
-		map textures/pad_pirate/becher1.tga
+		map textures/pad_pirate/becher1
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1927,20 +1927,20 @@ textures/pad_pirate/bechercurve
 
 textures/pad_pirate/bechercurve2
 {
-          qer_editorimage textures/pad_pirate/becher2.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/becher2
+           surfaceparm nonsolid
 	{
-		map textures/pad_pirate/becher2.tga
+		map textures/pad_pirate/becher2
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1949,14 +1949,14 @@ textures/pad_pirate/bechercurve2
 
 textures/pad_pirate/bonnycurve
 {
-          qer_editorimage textures/pad_pirate/bonnyflag.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/bonnyflag
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/bonnyflag.tga
+		map textures/pad_pirate/bonnyflag
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1965,20 +1965,20 @@ textures/pad_pirate/bonnycurve
 
 textures/pad_pirate/gramopcurve
 {
-          qer_editorimage textures/pad_pirate/gramop04.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/gramop04
+           surfaceparm nonsolid
 	{
-		map textures/pad_pirate/gramop04.tga
+		map textures/pad_pirate/gramop04
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1986,14 +1986,14 @@ textures/pad_pirate/gramopcurve
 
 textures/pad_pirate/griffcurve
 {
-          qer_editorimage textures/pad_pirate/griff01.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/griff01
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/griff01.tga
+		map textures/pad_pirate/griff01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2002,14 +2002,14 @@ textures/pad_pirate/griffcurve
 
 textures/pad_pirate/kerzecurve1
 {
-          qer_editorimage textures/pad_pirate/kerze01.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/kerze01
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/kerze01.tga
+		map textures/pad_pirate/kerze01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2018,14 +2018,14 @@ textures/pad_pirate/kerzecurve1
 
 textures/pad_pirate/kerzecurve2
 {
-          qer_editorimage textures/pad_pirate/kerze02.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/kerze02
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/kerze02.tga
+		map textures/pad_pirate/kerze02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2034,14 +2034,14 @@ textures/pad_pirate/kerzecurve2
 
 textures/pad_pirate/klingecurve1
 {
-          qer_editorimage textures/pad_pirate/klinge00.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/klinge00
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/klinge00.tga
+		map textures/pad_pirate/klinge00
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2050,20 +2050,20 @@ textures/pad_pirate/klingecurve1
 
 textures/pad_pirate/klingecurve2
 {
-          qer_editorimage textures/pad_pirate/klinge01.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/klinge01
+           surfaceparm nonsolid
 	{
-		map textures/pad_pirate/klinge01.tga
+		map textures/pad_pirate/klinge01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2072,14 +2072,14 @@ textures/pad_pirate/klingecurve2
 
 textures/pad_pirate/mopcurve
 {
-          qer_editorimage textures/pad_pirate/mop.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/mop
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/mop.tga
+		map textures/pad_pirate/mop
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2088,14 +2088,14 @@ textures/pad_pirate/mopcurve
 
 textures/pad_pirate/oldfloorbluecurve
 {
-          qer_editorimage textures/pad_pirate/oldfloorrandblue.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/oldfloorrandblue
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/oldfloorrandblue.tga
+		map textures/pad_pirate/oldfloorrandblue
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2104,14 +2104,14 @@ textures/pad_pirate/oldfloorbluecurve
 
 textures/pad_pirate/oldfloorgreencurve
 {
-          qer_editorimage textures/pad_pirate/oldfloorrandgreen.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/oldfloorrandgreen
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/oldfloorrandgreen.tga
+		map textures/pad_pirate/oldfloorrandgreen
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2119,14 +2119,14 @@ textures/pad_pirate/oldfloorgreencurve
 
 textures/pad_pirate/sugarcurve
 {
-          qer_editorimage textures/pad_pirate/p_sugar.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/p_sugar
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/p_sugar.tga
+		map textures/pad_pirate/p_sugar
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2135,14 +2135,14 @@ textures/pad_pirate/sugarcurve
 
 textures/pad_pirate/plankecurve01
 {
-          qer_editorimage textures/pad_pirate/planke01.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/planke01
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/planke01.tga
+		map textures/pad_pirate/planke01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2151,14 +2151,14 @@ textures/pad_pirate/plankecurve01
 
 textures/pad_pirate/plankecurve02
 {
-          qer_editorimage textures/pad_pirate/planke02.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/planke02
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/planke02.tga
+		map textures/pad_pirate/planke02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2167,14 +2167,14 @@ textures/pad_pirate/plankecurve02
 
 textures/pad_pirate/plankecurve03
 {
-          qer_editorimage textures/pad_pirate/planke03.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/planke03
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/planke03.tga
+		map textures/pad_pirate/planke03
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2182,14 +2182,14 @@ textures/pad_pirate/plankecurve03
 
 textures/pad_pirate/segecurve
 {
-          qer_editorimage textures/pad_pirate/segel.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/segel
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/segel.tga
+		map textures/pad_pirate/segel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2198,14 +2198,14 @@ textures/pad_pirate/segecurve
 
 textures/pad_pirate/seicurve
 {
-          qer_editorimage textures/pad_pirate/seil.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/seil
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/seil.tga
+		map textures/pad_pirate/seil
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2214,14 +2214,14 @@ textures/pad_pirate/seicurve
 
 textures/pad_pirate/seilycurve
 {
-          qer_editorimage textures/pad_pirate/seilycurve.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/seilycurve
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/seilycurve.tga
+		map textures/pad_pirate/seilycurve
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2230,14 +2230,14 @@ textures/pad_pirate/seilycurve
 
 textures/pad_pirate/stonecurve01
 {
-          qer_editorimage textures/pad_pirate/stone_bl.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/stone_bl
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/stone_bl.tga
+		map textures/pad_pirate/stone_bl
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2246,14 +2246,14 @@ textures/pad_pirate/stonecurve01
 
 textures/pad_pirate/stonecurve02
 {
-          qer_editorimage textures/pad_pirate/stone_or.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/stone_or
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/stone_or.tga
+		map textures/pad_pirate/stone_or
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2262,14 +2262,14 @@ textures/pad_pirate/stonecurve02
 
 textures/pad_wallout/stonecurve03
 {
-          qer_editorimage textures/pad_wallout/wall_stone005d.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wallout/wall_stone005d
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wallout/wall_stone005d.tga
+		map textures/pad_wallout/wall_stone005d
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2278,14 +2278,14 @@ textures/pad_wallout/stonecurve03
 
 textures/pad_wallout/stonecurve04
 {
-          qer_editorimage textures/pad_wallout/wall_stone006c.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wallout/wall_stone006c
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wallout/wall_stone006c.tga
+		map textures/pad_wallout/wall_stone006c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2294,14 +2294,14 @@ textures/pad_wallout/stonecurve04
 
 textures/pad_wallout/stonecurve05
 {
-          qer_editorimage textures/pad_wallout/wall_stone051.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wallout/wall_stone051
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wallout/wall_stone051.tga
+		map textures/pad_wallout/wall_stone051
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2310,14 +2310,14 @@ textures/pad_wallout/stonecurve05
 
 textures/pad_pirate/korkycurve
 {
-          qer_editorimage textures/pad_pirate/kork.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/kork
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/kork.tga
+		map textures/pad_pirate/kork
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2326,20 +2326,20 @@ textures/pad_pirate/korkycurve
 
 textures/pad_pirate/telescopecurve01
 {
-          qer_editorimage textures/pad_pirate/telescope01.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/telescope01
+           surfaceparm nonsolid
 	{
-		map textures/pad_pirate/lelescope01.tga
+		map textures/pad_pirate/lelescope01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2348,14 +2348,14 @@ textures/pad_pirate/telescopecurve01
 
 textures/pad_pirate/telescopecurve03
 {
-          qer_editorimage textures/pad_pirate/telescope3.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_pirate/telescope3
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_pirate/telescope3.tga
+		map textures/pad_pirate/telescope3
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2364,14 +2364,14 @@ textures/pad_pirate/telescopecurve03
 
 textures/pad_garden/poolstoncurve
 {
-          qer_editorimage textures/pad_garden/poolstone03.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_garden/poolstone03
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/poolstone03.tga
+		map textures/pad_garden/poolstone03
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2380,124 +2380,124 @@ textures/pad_garden/poolstoncurve
 
 textures/pad_gfx02/metalcurve08
 {
-          qer_editorimage textures/pad_gfx02/metal08.tga
-          surfaceparm nonsolid		
+          qer_editorimage textures/pad_gfx02/metal08
+          surfaceparm nonsolid
         {
 		rgbGen identity
 		map $lightmap
 	}
 	{
-		map textures/pad_gfx02/metal08.tga
+		map textures/pad_gfx02/metal08
 		blendFunc GL_DST_COLOR GL_SRC_ALPHA
 		rgbGen identity
 		alphaGen lightingSpecular
 	}
         {
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
 	}
-       
+
         {
-		map textures/pad_gfx02/metal08.tga
+		map textures/pad_gfx02/metal08
 		//blendFunc GL_ONE GL_ONE
                 blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-}  
+}
 
 
 textures/pad_wood/woo48stoncurve
 {
-          qer_editorimage textures/pad_wood/wood048.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wood/wood048
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wood/wood048.tga
+		map textures/pad_wood/wood048
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_wood/woo39stoncurve
 {
-          qer_editorimage textures/pad_wood/wood039.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wood/wood039
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wood/wood039.tga
+		map textures/pad_wood/wood039
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_wood/woo37stoncurve
 {
-          qer_editorimage textures/pad_wood/wood037.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wood/wood037
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wood/wood037.tga
+		map textures/pad_wood/wood037
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_wood/woo34stoncurve
 {
-          qer_editorimage textures/pad_wood/wood034.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wood/wood034
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wood/wood034.tga
+		map textures/pad_wood/wood034
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_wood/woo26stoncurve
 {
-          qer_editorimage textures/pad_wood/wood026.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wood/wood026
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wood/wood026.tga
+		map textures/pad_wood/wood026
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 
 textures/pad_garden/rostcurve
 {
-          qer_editorimage textures/pad_garden/rostrough.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_garden/rostrough
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/rostrough.tga
+		map textures/pad_garden/rostrough
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2506,14 +2506,14 @@ textures/pad_garden/rostcurve
 
 textures/pad_wallin/canoncurve
 {
-          qer_editorimage textures/pad_wallin/wallcol26.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_wallin/wallcol26
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_wallin/wallcol26.tga
+		map textures/pad_wallin/wallcol26
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2522,14 +2522,14 @@ textures/pad_wallin/canoncurve
 
 textures/pad_objects/shiplampcurve
 {
-          qer_editorimage textures/pad_objects/shiplampcurve.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_objects/shiplampcurve
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_objects/ofen2.tga
+		map textures/pad_objects/ofen2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2538,14 +2538,14 @@ textures/pad_objects/shiplampcurve
 
 textures/pad_metal/wallycurve
 {
-          qer_editorimage textures/pad_metal/wallycurve.tga
-           surfaceparm nonsolid		
+          qer_editorimage textures/pad_metal/wallycurve
+           surfaceparm nonsolid
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_metal/wallrast_a.tga
+		map textures/pad_metal/wallrast_a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}

--- a/wop/scripts.pk3dir/scripts/pad_shop.shader
+++ b/wop/scripts.pk3dir/scripts/pad_shop.shader
@@ -3,25 +3,25 @@ textures/pad_shop/light_blue
     q3map_surfacelight 1000
     surfaceparm nolightmap
     {
-        map textures/pad_shop/light_blue.tga
+        map textures/pad_shop/light_blue
     }
 }
 
 textures/pad_shop/lampi001
 {
-	qer_editorimage textures/pad_shop/lampi001.tga
+	qer_editorimage textures/pad_shop/lampi001
 	surfaceparm metalsteps
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/lampi001.tga
+		map textures/pad_shop/lampi001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -30,7 +30,7 @@ textures/pad_shop/lampi001
 
 textures/pad_shop/marslava
 {
-	qer_editorimage textures/pad_shop/marslava.tga
+	qer_editorimage textures/pad_shop/marslava
 	q3map_globaltexture
 	surfaceparm trans
 	//surfaceparm nonsolid
@@ -43,9 +43,9 @@ textures/pad_shop/marslava
 	tesssize 128
 	cull disable
 	deformVertexes wave 100 sin 3 2 .1 0.1
-	
+
 	{
-		map textures/pad_shop/marslava.tga
+		map textures/pad_shop/marslava
 		tcMod turb 0 .2 0 .1
 	}
 }
@@ -56,7 +56,7 @@ textures/pad_shop/planetstone
 q3map_nonplanar
 q3map_shadeangle 60 l
 q3map_surfacelight 4
-qer_editorimage textures/pad_shop/planetstone.tga
+qer_editorimage textures/pad_shop/planetstone
 surfaceparm nomarks
 surfaceparm sandsteps
 {
@@ -64,11 +64,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_shop/planetstone.tga
+map textures/pad_shop/planetstone
 blendFunc filter
 }
 {
-map textures/pad_shop/planetstone02.tga
+map textures/pad_shop/planetstone02
 blendfunc GL_ONE GL_ONE
 }
 }
@@ -77,14 +77,14 @@ textures/pad_shop/punk
 {
 q3map_nonplanar
 q3map_shadeangle 60 l
-qer_editorimage textures/pad_shop/punk.tga
+qer_editorimage textures/pad_shop/punk
 surfaceparm sandsteps
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_shop/punk.tga
+map textures/pad_shop/punk
 blendFunc filter
 }
 }
@@ -92,7 +92,7 @@ blendFunc filter
 
 textures/pad_shop/closed
 {
-        qer_editorimage textures/pad_shop/closed.tga
+        qer_editorimage textures/pad_shop/closed
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -100,7 +100,7 @@ textures/pad_shop/closed
 	cull none
         nopicmip
 	{
-		map textures/pad_shop/closed.tga
+		map textures/pad_shop/closed
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -117,7 +117,7 @@ textures/pad_shop/closed
 
 textures/pad_shop/d_midbars3
 {
-        qer_editorimage textures/pad_shop/d_midbars3.tga
+        qer_editorimage textures/pad_shop/d_midbars3
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -125,7 +125,7 @@ textures/pad_shop/d_midbars3
 	cull none
         nopicmip
 	{
-		map textures/pad_shop/d_midbars3.tga
+		map textures/pad_shop/d_midbars3
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -142,7 +142,7 @@ textures/pad_shop/d_midbars3
 
 textures/pad_shop/d_brnsmal1
 {
-        qer_editorimage textures/pad_shop/d_brnsmal1.tga
+        qer_editorimage textures/pad_shop/d_brnsmal1
     	surfaceparm trans
 	surfaceparm alphashadow
 	surfaceparm playerclip
@@ -150,7 +150,7 @@ textures/pad_shop/d_brnsmal1
 	cull none
         nopicmip
 	{
-		map textures/pad_shop/d_brnsmal1.tga
+		map textures/pad_shop/d_brnsmal1
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -167,7 +167,7 @@ textures/pad_shop/d_brnsmal1
 
 textures/pad_shop/d_tekgren5
 {
-	qer_editorimage textures/pad_shop/d_tekgren5.tga
+	qer_editorimage textures/pad_shop/d_tekgren5
 	q3map_surfacelight 10
 //	light 1
 	surfaceparm nomarks
@@ -176,12 +176,12 @@ textures/pad_shop/d_tekgren5
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_tekgren5.tga
+		map textures/pad_shop/d_tekgren5
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_tekgren5_light.tga
+		map textures/pad_shop/d_tekgren5_light
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -191,7 +191,7 @@ textures/pad_shop/d_tekgren5
 
 textures/pad_shop/d_flat2
 {
-	qer_editorimage textures/pad_shop/d_flat2.tga
+	qer_editorimage textures/pad_shop/d_flat2
 	q3map_surfacelight 5
 //	light 1
 	surfaceparm nomarks
@@ -200,12 +200,12 @@ textures/pad_shop/d_flat2
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_flat2.tga
+		map textures/pad_shop/d_flat2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_flat2_light.tga
+		map textures/pad_shop/d_flat2_light
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -214,7 +214,7 @@ textures/pad_shop/d_flat2
 
 textures/pad_shop/d_sw1gray
 {
-	qer_editorimage textures/pad_shop/d_sw1gray.tga
+	qer_editorimage textures/pad_shop/d_sw1gray
 	q3map_surfacelight 5
 //	light 1
 	surfaceparm nomarks
@@ -223,12 +223,12 @@ textures/pad_shop/d_sw1gray
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_sw1gray.tga
+		map textures/pad_shop/d_sw1gray
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_sw1gray_light.tga
+		map textures/pad_shop/d_sw1gray_light
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -237,7 +237,7 @@ textures/pad_shop/d_sw1gray
 
 textures/pad_shop/d_tekgren3
 {
-	qer_editorimage textures/pad_shop/d_tekgren3.tga
+	qer_editorimage textures/pad_shop/d_tekgren3
 	q3map_surfacelight 5
 //	light 1
 	surfaceparm nomarks
@@ -246,12 +246,12 @@ textures/pad_shop/d_tekgren3
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_tekgren3.tga
+		map textures/pad_shop/d_tekgren3
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_tekgren3_light.tga
+		map textures/pad_shop/d_tekgren3_light
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -260,13 +260,13 @@ textures/pad_shop/d_tekgren3
 
 textures/pad_shop/d_trooper
 {
-	qer_editorimage textures/pad_shop/d_trooper.tga
+	qer_editorimage textures/pad_shop/d_trooper
               surfaceparm nonsolid
 	cull disable
 	deformvertexes autosprite
 
 {
-	map textures/pad_shop/d_trooper.tga
+	map textures/pad_shop/d_trooper
 	blendFunc blend
       alphaFunc GE128
 	depthWrite
@@ -277,13 +277,13 @@ textures/pad_shop/d_trooper
 
 textures/pad_shop/d_imp
 {
-	qer_editorimage textures/pad_shop/d_imp.tga
+	qer_editorimage textures/pad_shop/d_imp
               surfaceparm nonsolid
 	cull disable
 	deformvertexes autosprite
 
 {
-	map textures/pad_shop/d_imp.tga
+	map textures/pad_shop/d_imp
 	blendFunc blend
       alphaFunc GE128
 	depthWrite
@@ -294,13 +294,13 @@ textures/pad_shop/d_imp
 
 textures/pad_shop/d_chainsaw_small
 {
-	qer_editorimage textures/pad_shop/d_chainsaw_small.tga
+	qer_editorimage textures/pad_shop/d_chainsaw_small
               surfaceparm nonsolid
 	cull disable
 	deformvertexes autosprite
 
 {
-	map textures/pad_shop/d_chainsaw_small.tga
+	map textures/pad_shop/d_chainsaw_small
 	blendFunc blend
       alphaFunc GE128
 	depthWrite
@@ -311,7 +311,7 @@ textures/pad_shop/d_chainsaw_small
 
 textures/pad_shop/d_sky1
 {
-	qer_editorimage textures/pad_shop/d_sky1.tga
+	qer_editorimage textures/pad_shop/d_sky1
 	q3map_surfacelight 10
 //	light 1
 	surfaceparm nomarks
@@ -320,12 +320,12 @@ textures/pad_shop/d_sky1
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_sky1.tga
+		map textures/pad_shop/d_sky1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/d_sky1_light.tga
+		map textures/pad_shop/d_sky1_light
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -334,18 +334,18 @@ textures/pad_shop/d_sky1
 
 textures/pad_shop/pc-ground-zero512
 {
-        qer_editorimage textures/pad_shop/pc-ground-zero512.tga
+        qer_editorimage textures/pad_shop/pc-ground-zero512
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_shop/blue.tga
+        q3map_lightimage textures/pad_shop/blue
 	q3map_sun	0.266383 0.274632 0.358662 20 50 55
 	q3map_surfacelight 300
 
         skyparms env/pc-ground-zero512 - -
 //       {
-//		map textures/pad_petesky/pc-ground-zero512.tga
+//		map textures/pad_petesky/pc-ground-zero512
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -359,7 +359,7 @@ textures/pad_shop/terrain_0
 	q3map_novertexshadows
 	q3map_forcesunlight
 	{
-		map textures/pad_shop/planetstone.tga
+		map textures/pad_shop/planetstone
 		rgbGen vertex
 		tcmod scale 0.352 0.352
 	}
@@ -371,7 +371,7 @@ textures/pad_shop/terrain_1
 	q3map_novertexshadows
 	q3map_forcesunlight
 	{
-		map textures/pad_shop/planetstoneb.tga
+		map textures/pad_shop/planetstoneb
 		rgbGen vertex
 		tcmod scale 0.352 0.352
 	}
@@ -383,13 +383,13 @@ textures/pad_shop/terrain_0to1
 	q3map_novertexshadows
 	q3map_forcesunlight
 	{
-		map textures/pad_shop/planetstone.tga
+		map textures/pad_shop/planetstone
 		rgbGen vertex
 		alphaGen vertex
 		tcmod scale 0.352 0.352
 	}
 	{
-		map textures/pad_shop/planetstoneb.tga
+		map textures/pad_shop/planetstoneb
 		rgbGen vertex
 		alphaGen vertex
 		tcmod scale 0.352 0.352
@@ -403,7 +403,7 @@ textures/pad_shop/terrain_vertex
 	q3map_novertexshadows
 	q3map_forcesunlight
 	{
-		map textures/pad_shop/planetstone.tga
+		map textures/pad_shop/planetstone
 		rgbGen vertex
 		tcmod scale 0.352 0.352
 	}
@@ -412,7 +412,7 @@ textures/pad_shop/terrain_vertex
 
 textures/pad_shop/sparks
 {
-	qer_editorimage textures/pad_shop/sparks.tga
+	qer_editorimage textures/pad_shop/sparks
         deformVertexes move 2 3 1.5  sin 0 5 0 0.3
 	surfaceparm nolightmap
 	surfaceparm nomarks
@@ -421,12 +421,12 @@ textures/pad_shop/sparks
 	cull disable
 	qer_trans 0.5
 	{
-		map textures/pad_shop/sparks.tga
+		map textures/pad_shop/sparks
 		blendFunc add
 		rgbGen identity
 		tcMod scroll -0.1 0.6
 		tcMod turb 0.1 0.25 0 -0.1
-	} 
+	}
 }
 
 
@@ -435,13 +435,13 @@ textures/pad_shop/padnight
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm sky
-        q3map_lightimage textures/pad_shop/red.tga
+        q3map_lightimage textures/pad_shop/red
 	q3map_sun	1 1 1 100 -58 58
 	q3map_surfacelight 100
 
         skyparms env/mercury512 - -
        {
-		map textures/pad_shop/skystuff.tga
+		map textures/pad_shop/skystuff
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll 0.07 0.09
 		tcMod scale 3 2
@@ -451,7 +451,7 @@ textures/pad_shop/padnight
 
 textures/pad_shop/lavafall
 {
-	qer_editorimage textures/pad_shop/marslavafa.tga
+	qer_editorimage textures/pad_shop/marslavafa
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -461,14 +461,14 @@ textures/pad_shop/lavafall
                 q3map_surfacelight 140
 	q3map_globaltexture
 	{
-		map textures/pad_shop/marslava.tga
+		map textures/pad_shop/marslava
 		blendfunc add
 		tcMod scale 0.5 0.5
 		tcMod turb 0.20 0.02 0 0.3
 		tcMod scroll 0 -0.1
 	}
 	{
-		map textures/pad_shop/marslavafa.tga
+		map textures/pad_shop/marslavafa
 		blendfunc filter
 		tcMod scale 0.5 0.5
 		tcMod turb 0.25 0.03 0 0.5
@@ -479,12 +479,12 @@ textures/pad_shop/lavafall
 
 textures/pad_shop/tuerchen
 {
-        surfaceparm trans	
+        surfaceparm trans
 	cull none
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_shop/tuerchen.tga
+		map textures/pad_shop/tuerchen
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -494,7 +494,7 @@ textures/pad_shop/tuerchen
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
@@ -506,11 +506,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_shop/blueborder.tga
+map textures/pad_shop/blueborder
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_shop/blueborder2
@@ -521,11 +521,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_shop/blueborder2.tga
+map textures/pad_shop/blueborder2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_shop/blueborder3
@@ -536,11 +536,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_shop/blueborder3.tga
+map textures/pad_shop/blueborder3
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 textures/pad_shop/pappe
@@ -551,11 +551,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_shop/pappe.tga
+map textures/pad_shop/pappe
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_shop/venti04b
 {
@@ -565,11 +565,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_shop/venti04b.tga
+map textures/pad_shop/venti04b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_shop/wood002
 {
@@ -579,11 +579,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_shop/wood002.tga
+map textures/pad_shop/wood002
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_shop/muelltonne
 {
@@ -593,11 +593,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_shop/muelltonne.tga
+map textures/pad_shop/muelltonne
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 
 
@@ -606,41 +606,41 @@ textures/pad_shop/alienmoni
               surfaceparm trans
 	q3map_nolightmap
 	q3map_surfacelight 40
-	qer_editorimage textures/pad_shop/alienmoni01.tga
-	
-
-	{
-		animMap 3 textures/pad_shop/alienmoni01.tga textures/pad_shop/alienmoni02.tga textures/pad_shop/alienmoni03.tga textures/pad_shop/alienmoni04.tga textures/pad_shop/alienmoni05.tga textures/pad_shop/alienmoni06.tga textures/pad_shop/alienmoni09.tga textures/pad_shop/alienmoni09.tga
-		blendFunc GL_ONE GL_ONE
-
-		
-	}	
-	{
-		animMap 3 textures/pad_shop/alienmoni01.tga textures/pad_shop/alienmoni02.tga textures/pad_shop/alienmoni03.tga textures/pad_shop/alienmoni04.tga textures/pad_shop/alienmoni05.tga textures/pad_shop/alienmoni06.tga textures/pad_shop/alienmoni09.tga textures/pad_shop/alienmoni09.tga
-		blendFunc GL_ONE GL_ONE
-
-	}	
+	qer_editorimage textures/pad_shop/alienmoni01
 
 
 	{
-		map textures/pad_shop/alienmoniball.tga
+		animMap 3 textures/pad_shop/alienmoni01 textures/pad_shop/alienmoni02 textures/pad_shop/alienmoni03 textures/pad_shop/alienmoni04 textures/pad_shop/alienmoni05 textures/pad_shop/alienmoni06 textures/pad_shop/alienmoni09 textures/pad_shop/alienmoni09
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+
+
+	}
+	{
+		animMap 3 textures/pad_shop/alienmoni01 textures/pad_shop/alienmoni02 textures/pad_shop/alienmoni03 textures/pad_shop/alienmoni04 textures/pad_shop/alienmoni05 textures/pad_shop/alienmoni06 textures/pad_shop/alienmoni09 textures/pad_shop/alienmoni09
+		blendFunc GL_ONE GL_ONE
+
+	}
+
+
+	{
+		map textures/pad_shop/alienmoniball
+		blendFunc GL_ONE GL_ONE
+		rgbGen wave sin .6 .2 0 .6
               }
 	{
-		map textures/pad_shop/line01.tga
+		map textures/pad_shop/line01
 		blendfunc add
 		rgbGen identity
 		tcmod scroll 0 -1
               }
 	{
-		map textures/pad_shop/line02.tga
+		map textures/pad_shop/line02
 		blendfunc add
 		rgbGen identity
 		tcmod scroll 0.2 0
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -649,16 +649,16 @@ textures/pad_shop/alienmoni
 
 textures/pad_shop/impscreen
 {
-	qer_editorimage	textures/pad_shop/impscreen.tga
+	qer_editorimage	textures/pad_shop/impscreen
               surfaceparm trans
 	q3map_nolightmap
 	q3map_surfacelight 40
     {
-        map textures/pad_shop/impscreen.tga
+        map textures/pad_shop/impscreen
         blendFunc GL_ONE GL_ONE
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -667,16 +667,16 @@ textures/pad_shop/impscreen
 
 textures/pad_shop/greenscreen02
 {
-	qer_editorimage	textures/pad_shop/greenscreen02.tga
+	qer_editorimage	textures/pad_shop/greenscreen02
               surfaceparm trans
 	q3map_nolightmap
 	q3map_surfacelight 40
     {
-        map textures/pad_shop/greenscreen02.tga
+        map textures/pad_shop/greenscreen02
         blendFunc GL_ONE GL_ONE
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -686,16 +686,16 @@ textures/pad_shop/greenscreen02
 
 textures/pad_shop/greenscreen03
 {
-	qer_editorimage	textures/pad_shop/greenscreen03.tga
+	qer_editorimage	textures/pad_shop/greenscreen03
               surfaceparm trans
 	q3map_nolightmap
 	q3map_surfacelight 40
     {
-        map textures/pad_shop/greenscreen03.tga
+        map textures/pad_shop/greenscreen03
         blendFunc GL_ONE GL_ONE
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -705,16 +705,16 @@ textures/pad_shop/greenscreen03
 
 textures/pad_shop/greenscreen04
 {
-	qer_editorimage	textures/pad_shop/greenscreen04.tga
+	qer_editorimage	textures/pad_shop/greenscreen04
               surfaceparm trans
 	q3map_nolightmap
 	q3map_surfacelight 40
     {
-        map textures/pad_shop/greenscreen04.tga
+        map textures/pad_shop/greenscreen04
         blendFunc GL_ONE GL_ONE
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -723,16 +723,16 @@ textures/pad_shop/greenscreen04
 
 textures/pad_shop/greenscreen05
 {
-	qer_editorimage	textures/pad_shop/greenscreen05.tga
+	qer_editorimage	textures/pad_shop/greenscreen05
               surfaceparm trans
 	q3map_nolightmap
 	q3map_surfacelight 40
     {
-        map textures/pad_shop/greenscreen05.tga
+        map textures/pad_shop/greenscreen05
         blendFunc GL_ONE GL_ONE
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -742,15 +742,15 @@ textures/pad_shop/greenscreen05
 
 textures/pad_shop/greenscreen06
 {
-	qer_editorimage	textures/pad_shop/greenscreen06.tga
-	deformVertexes autoSprite2 
+	qer_editorimage	textures/pad_shop/greenscreen06
+	deformVertexes autoSprite2
 	surfaceparm trans
 	surfaceparm nomarks
 	surfaceparm nolightmap
 	cull none
 	q3map_surfacelight 40
     {
-        map textures/pad_shop/greenscreen06.tga
+        map textures/pad_shop/greenscreen06
         blendFunc GL_ONE GL_ONE
         rgbGen wave inverseSawtooth 0 1 0 10
 	}
@@ -760,17 +760,17 @@ textures/pad_shop/greenscreen06
 
 textures/pad_shop/greenline
 {
-	qer_editorimage	textures/pad_shop/greenline.tga
+	qer_editorimage	textures/pad_shop/greenline
               surfaceparm trans
 	q3map_nolightmap
 	q3map_surfacelight 40
     {
-        map textures/pad_shop/greenline.tga
+        map textures/pad_shop/greenline
         tcmod scroll 0 -0.3
         blendFunc GL_ONE GL_ONE
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -780,8 +780,8 @@ textures/pad_shop/greenline
 
 textures/pad_shop/yellight1
 {
-	qer_editorimage textures/pad_shop/yellight1.tga
-	q3map_lightimage textures/pad_shop/yellight2.tga
+	qer_editorimage textures/pad_shop/yellight1
+	q3map_lightimage textures/pad_shop/yellight2
 	surfaceparm nomarks
               q3map_flareShader flareShader
 	q3map_lightRGB 102 204 255
@@ -791,12 +791,12 @@ textures/pad_shop/yellight1
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/yellight1.tga
+		map textures/pad_shop/yellight1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-	{	
-		map textures/pad_shop/yellight2.tga
+	{
+		map textures/pad_shop/yellight2
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -805,19 +805,19 @@ textures/pad_shop/yellight1
 
 textures/pad_shop/game_ball
 {
-	qer_editorimage textures/pad_shop/game_ball.tga
-	
+	qer_editorimage textures/pad_shop/game_ball
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_ball.tga
+		map textures/pad_shop/game_ball
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -827,19 +827,19 @@ textures/pad_shop/game_ball
 
 textures/pad_shop/game_ballb
 {
-	qer_editorimage textures/pad_shop/game_ballb.tga
-	
+	qer_editorimage textures/pad_shop/game_ballb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_ballb.tga
+		map textures/pad_shop/game_ballb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -849,19 +849,19 @@ textures/pad_shop/game_ballb
 
 textures/pad_shop/game_bird
 {
-	qer_editorimage textures/pad_shop/game_bird.tga
-	
+	qer_editorimage textures/pad_shop/game_bird
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_bird.tga
+		map textures/pad_shop/game_bird
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -871,19 +871,19 @@ textures/pad_shop/game_bird
 
 textures/pad_shop/game_birdb
 {
-	qer_editorimage textures/pad_shop/game_birdb.tga
-	
+	qer_editorimage textures/pad_shop/game_birdb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_birdb.tga
+		map textures/pad_shop/game_birdb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -893,19 +893,19 @@ textures/pad_shop/game_birdb
 
 textures/pad_shop/game_boom2
 {
-	qer_editorimage textures/pad_shop/game_boom2.tga
-	
+	qer_editorimage textures/pad_shop/game_boom2
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_boom2.tga
+		map textures/pad_shop/game_boom2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -915,19 +915,19 @@ textures/pad_shop/game_boom2
 
 textures/pad_shop/game_darkboy
 {
-	qer_editorimage textures/pad_shop/game_darkboy.tga
-	
+	qer_editorimage textures/pad_shop/game_darkboy
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_darkboy.tga
+		map textures/pad_shop/game_darkboy
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -937,19 +937,19 @@ textures/pad_shop/game_darkboy
 
 textures/pad_shop/game_darkboyb
 {
-	qer_editorimage textures/pad_shop/game_darkboyb.tga
-	
+	qer_editorimage textures/pad_shop/game_darkboyb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_darkboyb.tga
+		map textures/pad_shop/game_darkboyb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -959,19 +959,19 @@ textures/pad_shop/game_darkboyb
 
 textures/pad_shop/game_duckz
 {
-	qer_editorimage textures/pad_shop/game_duckz.tga
-	
+	qer_editorimage textures/pad_shop/game_duckz
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_duckz.tga
+		map textures/pad_shop/game_duckz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -980,19 +980,19 @@ textures/pad_shop/game_duckz
 
 textures/pad_shop/game_duckzb
 {
-	qer_editorimage textures/pad_shop/game_duckzb.tga
-	
+	qer_editorimage textures/pad_shop/game_duckzb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_duckzb.tga
+		map textures/pad_shop/game_duckzb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1002,19 +1002,19 @@ textures/pad_shop/game_duckzb
 
 textures/pad_shop/game_killd
 {
-	qer_editorimage textures/pad_shop/game_killd.tga
-	
+	qer_editorimage textures/pad_shop/game_killd
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_killd.tga
+		map textures/pad_shop/game_killd
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1024,19 +1024,19 @@ textures/pad_shop/game_killd
 
 textures/pad_shop/game_killdb
 {
-	qer_editorimage textures/pad_shop/game_killdb.tga
-	
+	qer_editorimage textures/pad_shop/game_killdb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_killdb.tga
+		map textures/pad_shop/game_killdb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1046,19 +1046,19 @@ textures/pad_shop/game_killdb
 
 textures/pad_shop/game_lilly
 {
-	qer_editorimage textures/pad_shop/game_lilly.tga
-	
+	qer_editorimage textures/pad_shop/game_lilly
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_lilly.tga
+		map textures/pad_shop/game_lilly
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1068,19 +1068,19 @@ textures/pad_shop/game_lilly
 
 textures/pad_shop/game_lillyb
 {
-	qer_editorimage textures/pad_shop/game_lillyb.tga
-	
+	qer_editorimage textures/pad_shop/game_lillyb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_lillyb.tga
+		map textures/pad_shop/game_lillyb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1090,19 +1090,19 @@ textures/pad_shop/game_lillyb
 
 textures/pad_shop/game_missing
 {
-	qer_editorimage textures/pad_shop/game_missing.tga
-	
+	qer_editorimage textures/pad_shop/game_missing
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_missing.tga
+		map textures/pad_shop/game_missing
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1112,19 +1112,19 @@ textures/pad_shop/game_missing
 
 textures/pad_shop/game_missingb
 {
-	qer_editorimage textures/pad_shop/game_missingb.tga
-	
+	qer_editorimage textures/pad_shop/game_missingb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_missingb.tga
+		map textures/pad_shop/game_missingb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1134,19 +1134,19 @@ textures/pad_shop/game_missingb
 
 textures/pad_shop/game_nolf1c
 {
-	qer_editorimage textures/pad_shop/game_nolf1c.tga
-	
+	qer_editorimage textures/pad_shop/game_nolf1c
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_nolf1c.tga
+		map textures/pad_shop/game_nolf1c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1156,19 +1156,19 @@ textures/pad_shop/game_nolf1c
 
 textures/pad_shop/game_nopad
 {
-	qer_editorimage textures/pad_shop/game_nopad.tga
-	
+	qer_editorimage textures/pad_shop/game_nopad
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_nopad.tga
+		map textures/pad_shop/game_nopad
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1178,19 +1178,19 @@ textures/pad_shop/game_nopad
 
 textures/pad_shop/game_nopadb
 {
-	qer_editorimage textures/pad_shop/game_nopadb.tga
-	
+	qer_editorimage textures/pad_shop/game_nopadb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_nopadb.tga
+		map textures/pad_shop/game_nopadb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1200,19 +1200,19 @@ textures/pad_shop/game_nopadb
 
 textures/pad_shop/game_nopadc
 {
-	qer_editorimage textures/pad_shop/game_nopadc.tga
-	
+	qer_editorimage textures/pad_shop/game_nopadc
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_nopadc.tga
+		map textures/pad_shop/game_nopadc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1222,19 +1222,19 @@ textures/pad_shop/game_nopadc
 
 textures/pad_shop/game_padcry2
 {
-	qer_editorimage textures/pad_shop/game_padcry2.tga
-	
+	qer_editorimage textures/pad_shop/game_padcry2
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_padcry2.tga
+		map textures/pad_shop/game_padcry2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1244,19 +1244,19 @@ textures/pad_shop/game_padcry2
 
 textures/pad_shop/game_padcry2b
 {
-	qer_editorimage textures/pad_shop/game_padcry2b.tga
-	
+	qer_editorimage textures/pad_shop/game_padcry2b
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_padcry2b.tga
+		map textures/pad_shop/game_padcry2b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1266,19 +1266,19 @@ textures/pad_shop/game_padcry2b
 
 textures/pad_shop/game_pims1
 {
-	qer_editorimage textures/pad_shop/game_pims1.tga
-	
+	qer_editorimage textures/pad_shop/game_pims1
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_pims1.tga
+		map textures/pad_shop/game_pims1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1288,19 +1288,19 @@ textures/pad_shop/game_pims1
 
 textures/pad_shop/game_pims2
 {
-	qer_editorimage textures/pad_shop/game_pims2.tga
-	
+	qer_editorimage textures/pad_shop/game_pims2
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_pims2.tga
+		map textures/pad_shop/game_pims2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1310,19 +1310,19 @@ textures/pad_shop/game_pims2
 
 textures/pad_shop/game_planet
 {
-	qer_editorimage textures/pad_shop/game_planet.tga
-	
+	qer_editorimage textures/pad_shop/game_planet
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_planet.tga
+		map textures/pad_shop/game_planet
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1332,19 +1332,19 @@ textures/pad_shop/game_planet
 
 textures/pad_shop/game_planetb
 {
-	qer_editorimage textures/pad_shop/game_planetb.tga
-	
+	qer_editorimage textures/pad_shop/game_planetb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_planetb.tga
+		map textures/pad_shop/game_planetb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1354,19 +1354,19 @@ textures/pad_shop/game_planetb
 
 textures/pad_shop/game_ptrek
 {
-	qer_editorimage textures/pad_shop/game_ptrek.tga
-	
+	qer_editorimage textures/pad_shop/game_ptrek
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_ptrek.tga
+		map textures/pad_shop/game_ptrek
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1376,19 +1376,19 @@ textures/pad_shop/game_ptrek
 
 textures/pad_shop/game_ptrekb
 {
-	qer_editorimage textures/pad_shop/game_ptrekb.tga
-	
+	qer_editorimage textures/pad_shop/game_ptrekb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_ptrekb.tga
+		map textures/pad_shop/game_ptrekb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1398,19 +1398,19 @@ textures/pad_shop/game_ptrekb
 
 textures/pad_shop/game_punk
 {
-	qer_editorimage textures/pad_shop/game_punk.tga
-	
+	qer_editorimage textures/pad_shop/game_punk
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_punk.tga
+		map textures/pad_shop/game_punk
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1420,19 +1420,19 @@ textures/pad_shop/game_punk
 
 textures/pad_shop/game_punkb
 {
-	qer_editorimage textures/pad_shop/game_punkb.tga
-	
+	qer_editorimage textures/pad_shop/game_punkb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_punkb.tga
+		map textures/pad_shop/game_punkb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1442,19 +1442,19 @@ textures/pad_shop/game_punkb
 
 textures/pad_shop/game_redpadz
 {
-	qer_editorimage textures/pad_shop/game_redpadz.tga
-	
+	qer_editorimage textures/pad_shop/game_redpadz
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_redpadz.tga
+		map textures/pad_shop/game_redpadz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1464,19 +1464,19 @@ textures/pad_shop/game_redpadz
 
 textures/pad_shop/game_redpadzb
 {
-	qer_editorimage textures/pad_shop/game_redpadzb.tga
-	
+	qer_editorimage textures/pad_shop/game_redpadzb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_redpadzb.tga
+		map textures/pad_shop/game_redpadzb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1486,19 +1486,19 @@ textures/pad_shop/game_redpadzb
 
 textures/pad_shop/game_spiderwalk
 {
-	qer_editorimage textures/pad_shop/game_spiderwalk.tga
-	
+	qer_editorimage textures/pad_shop/game_spiderwalk
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_spiderwalk.tga
+		map textures/pad_shop/game_spiderwalk
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1508,19 +1508,19 @@ textures/pad_shop/game_spiderwalk
 
 textures/pad_shop/game_spiderwalkb
 {
-	qer_editorimage textures/pad_shop/game_spiderwalkb.tga
-	
+	qer_editorimage textures/pad_shop/game_spiderwalkb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_spiderwalkb.tga
+		map textures/pad_shop/game_spiderwalkb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1530,19 +1530,19 @@ textures/pad_shop/game_spiderwalkb
 
 textures/pad_shop/game_wop02
 {
-	qer_editorimage textures/pad_shop/game_wop02.tga
-	
+	qer_editorimage textures/pad_shop/game_wop02
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_wop02.tga
+		map textures/pad_shop/game_wop02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1552,19 +1552,19 @@ textures/pad_shop/game_wop02
 
 textures/pad_shop/game_wop2
 {
-	qer_editorimage textures/pad_shop/game_wop2.tga
-	
+	qer_editorimage textures/pad_shop/game_wop2
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_wop2.tga
+		map textures/pad_shop/game_wop2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1574,19 +1574,19 @@ textures/pad_shop/game_wop2
 
 textures/pad_shop/game_xman
 {
-	qer_editorimage textures/pad_shop/game_xman.tga
-	
+	qer_editorimage textures/pad_shop/game_xman
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_xman.tga
+		map textures/pad_shop/game_xman
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1596,19 +1596,19 @@ textures/pad_shop/game_xman
 
 textures/pad_shop/game_l4p
 {
-	qer_editorimage textures/pad_shop/game_l4p.tga
-	
+	qer_editorimage textures/pad_shop/game_l4p
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_l4p.tga
+		map textures/pad_shop/game_l4p
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1618,19 +1618,19 @@ textures/pad_shop/game_l4p
 
 textures/pad_shop/game_l4pb
 {
-	qer_editorimage textures/pad_shop/game_l4pb.tga
-	
+	qer_editorimage textures/pad_shop/game_l4pb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_l4pb.tga
+		map textures/pad_shop/game_l4pb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1640,19 +1640,19 @@ textures/pad_shop/game_l4pb
 
 textures/pad_shop/game_padwar
 {
-	qer_editorimage textures/pad_shop/game_padwar.tga
-	
+	qer_editorimage textures/pad_shop/game_padwar
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_padwar.tga
+		map textures/pad_shop/game_padwar
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity
@@ -1661,19 +1661,19 @@ textures/pad_shop/game_padwar
 
 textures/pad_shop/game_padwarb
 {
-	qer_editorimage textures/pad_shop/game_padwarb.tga
-	
+	qer_editorimage textures/pad_shop/game_padwarb
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_shop/game_padwarb.tga
+		map textures/pad_shop/game_padwarb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbgen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		tcgen environment
 		blendfunc add
 		rgbgen identity

--- a/wop/scripts.pk3dir/scripts/pad_steps.shader
+++ b/wop/scripts.pk3dir/scripts/pad_steps.shader
@@ -8,7 +8,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/border_a.tga
+map textures/pad_metal/border_a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -22,7 +22,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/borderalu_a.tga
+map textures/pad_metal/borderalu_a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -36,7 +36,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/borderfloor_a.tga
+map textures/pad_metal/borderfloor_a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -50,7 +50,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/ground_a.tga
+map textures/pad_metal/ground_a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -64,7 +64,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/ground_b.tga
+map textures/pad_metal/ground_b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -79,7 +79,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/ground_c.tga
+map textures/pad_metal/ground_c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -93,7 +93,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/testlvlbase.tga
+map textures/pad_metal/testlvlbase
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -107,7 +107,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/wallmet_d.tga
+map textures/pad_metal/wallmet_d
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -121,7 +121,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/wallmet_b.tga
+map textures/pad_metal/wallmet_b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -135,7 +135,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/wallsteal_a.tga
+map textures/pad_metal/wallsteal_a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -149,7 +149,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/yb1.tga
+map textures/pad_metal/yb1
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -163,7 +163,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_metal/yb2.tga
+map textures/pad_metal/yb2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -179,7 +179,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_floorin/metalfloor001.tga
+map textures/pad_floorin/metalfloor001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -193,7 +193,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_floorin/floor034.tga
+map textures/pad_floorin/floor034
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -207,7 +207,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_floorin/floor034b.tga
+map textures/pad_floorin/floor034b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -224,7 +224,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_floorout/guli2.tga
+map textures/pad_floorout/guli2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -238,7 +238,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_floorout/gas1.tga
+map textures/pad_floorout/gas1
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -254,7 +254,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_maps/burgfloor001.tga
+map textures/pad_maps/burgfloor001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -268,7 +268,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_maps/schrank01d.tga
+map textures/pad_maps/schrank01d
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -285,7 +285,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/nature05.tga
+map textures/pad_nature/nature05
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -300,7 +300,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/nature07.tga
+map textures/pad_nature/nature07
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -314,7 +314,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/nature15.tga
+map textures/pad_nature/nature15
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -328,7 +328,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/sand001.tga
+map textures/pad_nature/sand001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -343,7 +343,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/sand001b.tga
+map textures/pad_nature/sand001b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -358,7 +358,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/sand002a.tga
+map textures/pad_nature/sand002a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -372,7 +372,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/sand003.tga
+map textures/pad_nature/sand003
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -386,7 +386,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/sand003a.tga
+map textures/pad_nature/sand003a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -400,7 +400,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/sand005.tga
+map textures/pad_nature/sand005
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -415,7 +415,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/sand007.tga
+map textures/pad_nature/sand007
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -430,7 +430,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/sand08.tga
+map textures/pad_nature/sand08
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -444,7 +444,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/stone06.tga
+map textures/pad_nature/stone06
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -458,7 +458,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_nature/stone07.tga
+map textures/pad_nature/stone07
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -474,7 +474,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_objects/obj009.tga
+map textures/pad_objects/obj009
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -488,7 +488,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_objects/ofen2.tga
+map textures/pad_objects/ofen2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -502,7 +502,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_objects/heiz01.tga
+map textures/pad_objects/heiz01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -516,7 +516,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_objects/heizung.tga
+map textures/pad_objects/heizung
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -531,7 +531,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_objects/obj074.tga
+map textures/pad_objects/obj074
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -548,7 +548,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_objects02/metalu.tga
+map textures/pad_objects02/metalu
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -562,7 +562,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_objects02/pflaster.tga
+map textures/pad_objects02/pflaster
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -580,7 +580,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pete/mp-tree-stumpb.tga
+map textures/pad_pete/mp-tree-stumpb
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -595,7 +595,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pete/mp-wood2b.tga
+map textures/pad_pete/mp-wood2b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -610,7 +610,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pete/mp-wood7.tga
+map textures/pad_pete/mp-wood7
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -624,7 +624,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_pete/mp-wood9.tga
+map textures/pad_pete/mp-wood9
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -640,7 +640,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile01.tga
+map textures/pad_textile/textile01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -654,7 +654,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile01b.tga
+map textures/pad_textile/textile01b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -669,7 +669,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile02c.tga
+map textures/pad_textile/textile02c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -684,7 +684,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile03.tga
+map textures/pad_textile/textile03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -698,7 +698,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile03b.tga
+map textures/pad_textile/textile03b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -713,7 +713,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile03e.tga
+map textures/pad_textile/textile03e
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -727,7 +727,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile04.tga
+map textures/pad_textile/textile04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -741,7 +741,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile04c.tga
+map textures/pad_textile/textile04c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -756,7 +756,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile05.tga
+map textures/pad_textile/textile05
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -771,7 +771,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile05d.tga
+map textures/pad_textile/textile05d
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -786,7 +786,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile05f.tga
+map textures/pad_textile/textile05f
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -801,7 +801,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile07.tga
+map textures/pad_textile/textile07
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -815,7 +815,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile08.tga
+map textures/pad_textile/textile08
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -829,7 +829,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile10.tga
+map textures/pad_textile/textile10
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -843,7 +843,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile11.tga
+map textures/pad_textile/textile11
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -857,7 +857,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile12.tga
+map textures/pad_textile/textile12
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -871,7 +871,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile13c.tga
+map textures/pad_textile/textile13c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -885,7 +885,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile14.tga
+map textures/pad_textile/textile14
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -899,7 +899,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile16b.tga
+map textures/pad_textile/textile16b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -914,7 +914,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile17.tga
+map textures/pad_textile/textile17
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -928,7 +928,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile18c.tga
+map textures/pad_textile/textile18c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -942,7 +942,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile18g.tga
+map textures/pad_textile/textile18g
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -956,7 +956,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/textile19.tga
+map textures/pad_textile/textile19
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -971,7 +971,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/leather001.tga
+map textures/pad_textile/leather001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -986,7 +986,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_textile/leather002.tga
+map textures/pad_textile/leather002
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1003,7 +1003,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wallin/wall_defect.tga
+map textures/pad_wallin/wall_defect
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1019,7 +1019,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wallout/rost001.tga
+map textures/pad_wallout/rost001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1033,7 +1033,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wallout/rost001small.tga
+map textures/pad_wallout/rost001small
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1048,7 +1048,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wallout/rost002small.tga
+map textures/pad_wallout/rost002small
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1063,7 +1063,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wallout/rost003small.tga
+map textures/pad_wallout/rost003small
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1078,7 +1078,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wallout/rost004small.tga
+map textures/pad_wallout/rost004small
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1092,7 +1092,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wallout/rost005_256.tga
+map textures/pad_wallout/rost005_256
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1106,7 +1106,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wallout/rost005_512.tga
+map textures/pad_wallout/rost005_512
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1121,7 +1121,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wallout/wall_rost01.tga
+map textures/pad_wallout/wall_rost01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1138,7 +1138,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodfloor/2parq13.tga
+map textures/pad_woodfloor/2parq13
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1153,7 +1153,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodfloor/2parq51.tga
+map textures/pad_woodfloor/2parq51
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1168,7 +1168,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodfloor/2parq61.tga
+map textures/pad_woodfloor/2parq61
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1182,7 +1182,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodfloor/2parq62.tga
+map textures/pad_woodfloor/2parq62
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1196,7 +1196,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodfloor/2parq75.tga
+map textures/pad_woodfloor/2parq75
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1214,7 +1214,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/oldwood001.tga
+map textures/pad_wood/oldwood001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1228,7 +1228,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/oldwood002.tga
+map textures/pad_wood/oldwood002
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1242,7 +1242,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/oldwood003.tga
+map textures/pad_wood/oldwood003
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1256,7 +1256,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/oldwood004.tga
+map textures/pad_wood/oldwood004
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1271,7 +1271,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/planke10.tga
+map textures/pad_wood/planke10
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1285,7 +1285,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/span128.tga
+map textures/pad_wood/span128
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1299,7 +1299,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood002_small.tga
+map textures/pad_wood/wood002_small
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1313,7 +1313,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood002black.tga
+map textures/pad_wood/wood002black
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1327,7 +1327,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood002blue.tga
+map textures/pad_wood/wood002blue
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1341,7 +1341,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood002brown.tga
+map textures/pad_wood/wood002brown
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1355,7 +1355,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood002brown1.tga
+map textures/pad_wood/wood002brown1
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1369,7 +1369,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood002green.tga
+map textures/pad_wood/wood002green
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1383,7 +1383,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood002purple.tga
+map textures/pad_wood/wood002purple
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1397,7 +1397,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood002red.tga
+map textures/pad_wood/wood002red
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1411,7 +1411,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood003.tga
+map textures/pad_wood/wood003
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1425,7 +1425,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood004.tga
+map textures/pad_wood/wood004
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1439,7 +1439,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood004brown.tga
+map textures/pad_wood/wood004brown
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1453,7 +1453,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood004brownbig.tga
+map textures/pad_wood/wood004brownbig
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1467,7 +1467,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood006.tga
+map textures/pad_wood/wood006
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1481,7 +1481,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood006b.tga
+map textures/pad_wood/wood006b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1495,7 +1495,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood006brown.tga
+map textures/pad_wood/wood006brown
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1509,7 +1509,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood008.tga
+map textures/pad_wood/wood008
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1523,7 +1523,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood008darker.tga
+map textures/pad_wood/wood008darker
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1537,7 +1537,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood008normal.tga
+map textures/pad_wood/wood008normal
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1551,7 +1551,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood010.tga
+map textures/pad_wood/wood010
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1566,7 +1566,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood012.tga
+map textures/pad_wood/wood012
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1580,7 +1580,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood014.tga
+map textures/pad_wood/wood014
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1594,7 +1594,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood016.tga
+map textures/pad_wood/wood016
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1608,7 +1608,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood017.tga
+map textures/pad_wood/wood017
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1622,7 +1622,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood017S.tga
+map textures/pad_wood/wood017S
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1636,7 +1636,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood017Sbrown.tga
+map textures/pad_wood/wood017Sbrown
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1650,7 +1650,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood017Sgreen.tga
+map textures/pad_wood/wood017Sgreen
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1664,7 +1664,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood017Sred.tga
+map textures/pad_wood/wood017Sred
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1678,7 +1678,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood017Sbrown.tga
+map textures/pad_wood/wood017Sbrown
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1692,7 +1692,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood018.tga
+map textures/pad_wood/wood018
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1706,7 +1706,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood019.tga
+map textures/pad_wood/wood019
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1720,7 +1720,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood020big.tga
+map textures/pad_wood/wood020big
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1734,7 +1734,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood020blackbig.tga
+map textures/pad_wood/wood020blackbig
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1748,7 +1748,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood020blacksmall.tga
+map textures/pad_wood/wood020blacksmall
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1763,7 +1763,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood026.tga
+map textures/pad_wood/wood026
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1777,7 +1777,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood028.tga
+map textures/pad_wood/wood028
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1791,7 +1791,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood032.tga
+map textures/pad_wood/wood032
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1805,7 +1805,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood033.tga
+map textures/pad_wood/wood033
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1819,7 +1819,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood034.tga
+map textures/pad_wood/wood034
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1833,7 +1833,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood035.tga
+map textures/pad_wood/wood035
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1848,7 +1848,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood037.tga
+map textures/pad_wood/wood037
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1862,7 +1862,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood038.tga
+map textures/pad_wood/wood038
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1876,7 +1876,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood039.tga
+map textures/pad_wood/wood039
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1890,7 +1890,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood040.tga
+map textures/pad_wood/wood040
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1904,7 +1904,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood043.tga
+map textures/pad_wood/wood043
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1918,7 +1918,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood045.tga
+map textures/pad_wood/wood045
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1932,7 +1932,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood045blu.tga
+map textures/pad_wood/wood045blu
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1946,7 +1946,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood046.tga
+map textures/pad_wood/wood046
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1960,7 +1960,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood047.tga
+map textures/pad_wood/wood047
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1974,7 +1974,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood048.tga
+map textures/pad_wood/wood048
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1988,7 +1988,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood049.tga
+map textures/pad_wood/wood049
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2002,7 +2002,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood051.tga
+map textures/pad_wood/wood051
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2017,7 +2017,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood066.tga
+map textures/pad_wood/wood066
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2032,7 +2032,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood068.tga
+map textures/pad_wood/wood068
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2047,7 +2047,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood074.tga
+map textures/pad_wood/wood074
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2061,7 +2061,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood076.tga
+map textures/pad_wood/wood076
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2075,7 +2075,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood077.tga
+map textures/pad_wood/wood077
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2089,7 +2089,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood078.tga
+map textures/pad_wood/wood078
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2103,7 +2103,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood091.tga
+map textures/pad_wood/wood091
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2117,7 +2117,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood092.tga
+map textures/pad_wood/wood092
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2131,7 +2131,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood093.tga
+map textures/pad_wood/wood093
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2144,7 +2144,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood093b.tga
+map textures/pad_wood/wood093b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2158,7 +2158,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood093c.tga
+map textures/pad_wood/wood093c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2172,7 +2172,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood095.tga
+map textures/pad_wood/wood095
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2186,7 +2186,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood096b.tga
+map textures/pad_wood/wood096b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2201,7 +2201,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood4a.tga
+map textures/pad_wood/wood4a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2216,7 +2216,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood4ahell.tga
+map textures/pad_wood/wood4ahell
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2231,7 +2231,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_wood/wood4arot.tga
+map textures/pad_wood/wood4arot
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2249,7 +2249,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest_head003.tga
+map textures/pad_woodobjects/chest_head003
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2264,7 +2264,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest_side.tga
+map textures/pad_woodobjects/chest_side
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2278,7 +2278,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest_side_1.tga
+map textures/pad_woodobjects/chest_side_1
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2292,7 +2292,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest_side_2.tga
+map textures/pad_woodobjects/chest_side_2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2306,7 +2306,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest002.tga
+map textures/pad_woodobjects/chest002
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2320,7 +2320,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest002b.tga
+map textures/pad_woodobjects/chest002b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2334,7 +2334,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest003.tga
+map textures/pad_woodobjects/chest003
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2348,7 +2348,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest004.tga
+map textures/pad_woodobjects/chest004
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2362,7 +2362,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest004b.tga
+map textures/pad_woodobjects/chest004b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2376,7 +2376,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest01_2.tga
+map textures/pad_woodobjects/chest01_2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2390,7 +2390,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest01_2_1.tga
+map textures/pad_woodobjects/chest01_2_1
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2404,7 +2404,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest01_2_2.tga
+map textures/pad_woodobjects/chest01_2_2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2419,7 +2419,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest01_3_1.tga
+map textures/pad_woodobjects/chest01_3_1
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2433,7 +2433,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest01_3_2.tga
+map textures/pad_woodobjects/chest01_3_2
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2448,7 +2448,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest01_5.tga
+map textures/pad_woodobjects/chest01_5
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2463,7 +2463,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest01_6.tga
+map textures/pad_woodobjects/chest01_6
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2479,7 +2479,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/chest01_7.tga
+map textures/pad_woodobjects/chest01_7
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2494,7 +2494,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/strokematch.tga
+map textures/pad_woodobjects/strokematch
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2509,7 +2509,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/tablewood.tga
+map textures/pad_woodobjects/tablewood
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2524,7 +2524,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_woodobjects/wood19s.tga
+map textures/pad_woodobjects/wood19s
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2541,7 +2541,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/Barrel01_256x128.tga
+map textures/pad_western/Barrel01_256x128
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2556,7 +2556,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/Barrel01_256x128_blue.tga
+map textures/pad_western/Barrel01_256x128_blue
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2571,7 +2571,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/Barrel01_256x128_red.tga
+map textures/pad_western/Barrel01_256x128_red
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2586,7 +2586,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/Barrel02_256x256.tga
+map textures/pad_western/Barrel02_256x256
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2601,7 +2601,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/wood_roof128c.tga
+map textures/pad_western/wood_roof128c
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2616,7 +2616,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/wood_trimh64e.tga
+map textures/pad_western/wood_trimh64e
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2631,7 +2631,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/wood_trimv64d.tga
+map textures/pad_western/wood_trimv64d
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2646,7 +2646,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/wood_trimv128b.tga
+map textures/pad_western/wood_trimv128b
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2661,7 +2661,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/woodgrain128a.tga
+map textures/pad_western/woodgrain128a
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2676,7 +2676,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/woodv256d.tga
+map textures/pad_western/woodv256d
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -2691,7 +2691,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_western/westernsand.tga
+map textures/pad_western/westernsand
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }

--- a/wop/scripts.pk3dir/scripts/pad_tex02.shader
+++ b/wop/scripts.pk3dir/scripts/pad_tex02.shader
@@ -1,8 +1,8 @@
 textures/pad_tex02/padjump_high
 {
-	qer_editorimage textures/pad_tex02/padjump_high.tga
+	qer_editorimage textures/pad_tex02/padjump_high
 	{
-		map textures/pad_tex02/padjump_high.tga
+		map textures/pad_tex02/padjump_high
 		rgbGen identity
 	}
 	{
@@ -11,17 +11,17 @@ textures/pad_tex02/padjump_high
 		blendfunc gl_dst_color gl_zero
 	}
 	{
-		map textures/pad_tex02/padjump_light03.tga
-		blendfunc gl_one gl_one	
+		map textures/pad_tex02/padjump_light03
+		blendfunc gl_one gl_one
 		rgbgen wave inversesawtooth 0 1 0 1
 	}
 }
 
 textures/pad_tex02/padjump_highred
 {
-	qer_editorimage textures/pad_tex02/padjump_highred.tga
+	qer_editorimage textures/pad_tex02/padjump_highred
 	{
-		map textures/pad_tex02/padjump_highred.tga
+		map textures/pad_tex02/padjump_highred
 		rgbGen identity
 	}
 	{
@@ -30,8 +30,8 @@ textures/pad_tex02/padjump_highred
 		blendfunc gl_dst_color gl_zero
 	}
 	{
-		map textures/pad_tex02/padjump_light01.tga
-		blendfunc gl_one gl_one	
+		map textures/pad_tex02/padjump_light01
+		blendfunc gl_one gl_one
 		rgbgen wave inversesawtooth 0 1 0 1
 	}
 }
@@ -42,7 +42,7 @@ textures/pad_tex02/telepad
 	surfaceparm nonsolid
 	cull twosided
 	{
-		map textures/pad_tex02/telepad.tga
+		map textures/pad_tex02/telepad
 		tcGen environment
                 tcMod turb 0 0.25 0 0.5
                 tcmod scroll 1 1
@@ -53,26 +53,26 @@ textures/pad_tex02/telepad
 textures/pad_tex02/padjump_fly
 {
 
-	
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 
-	{ 
-		map textures/pad_tex02/padjump_fly.tga
+	{
+		map textures/pad_tex02/padjump_fly
 		rgbGen identity
 		blendfunc gl_dst_color gl_zero
 	}
 
-	{	
-		map textures/pad_tex02/padjump_light02b.tga
-		blendfunc gl_one gl_one	
-		rgbgen wave inversesawtooth 0 1 0 1	
+	{
+		map textures/pad_tex02/padjump_light02b
+		blendfunc gl_one gl_one
+		rgbgen wave inversesawtooth 0 1 0 1
 	}
 
-	{ 
-		animmap 4 textures/pad_tex02/padjump_start.tga textures/pad_tex02/launchpad_arrow2.tga textures/pad_tex02/launchpad_arrow2.tga textures/pad_tex02/launchpad_arrow2.tga
+	{
+		animmap 4 textures/pad_tex02/padjump_start textures/pad_tex02/launchpad_arrow2 textures/pad_tex02/launchpad_arrow2 textures/pad_tex02/launchpad_arrow2
 		blendfunc gl_one gl_one
 		tcmod scroll 0 2
 	}
@@ -81,27 +81,27 @@ textures/pad_tex02/padjump_fly
 
 textures/pad_tex02/padjump_flyred
 {
-	
+
 	{
 		map $lightmap
 		rgbGen identity
 	}
 
-	{ 
-		map textures/pad_tex02/padjump_flyred.tga
+	{
+		map textures/pad_tex02/padjump_flyred
 		rgbGen identity
 		blendfunc gl_dst_color gl_zero
 	}
 
-	{	
-		map textures/pad_tex02/padjump_light02.tga
-		blendfunc gl_one gl_one	
-		rgbgen wave inversesawtooth 0 1 0 1	
+	{
+		map textures/pad_tex02/padjump_light02
+		blendfunc gl_one gl_one
+		rgbgen wave inversesawtooth 0 1 0 1
 	}
 
 
-	{ 
-		animmap 4 textures/pad_tex02/padjump_start.tga textures/pad_tex02/launchpad_arrow2.tga textures/pad_tex02/launchpad_arrow2.tga textures/pad_tex02/launchpad_arrow2.tga
+	{
+		animmap 4 textures/pad_tex02/padjump_start textures/pad_tex02/launchpad_arrow2 textures/pad_tex02/launchpad_arrow2 textures/pad_tex02/launchpad_arrow2
 		blendfunc gl_one gl_one
 		tcmod scroll 0 2
 	}
@@ -112,55 +112,55 @@ textures/pad_tex02/padani
 {
 
 
-	
+
 	surfaceparm nodamage
 	q3map_surfacelight 200
 
-	
+
 	{
-		map textures/pad_tex02/padani.tga
+		map textures/pad_tex02/padani
 		rgbGen identity
 	}
-	
+
 	{
 		map $lightmap
 		blendfunc gl_dst_color gl_zero
 		rgbGen identity
 	}
-	
+
 	{
-		animMap 2 textures/pad_tex02/padani_log.tga textures/pad_tex02/padani_log02.tga textures/pad_tex02/padani_log03.tga
+		animMap 2 textures/pad_tex02/padani_log textures/pad_tex02/padani_log02 textures/pad_tex02/padani_log03
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 2
 	}
-	
+
 }
 
 textures/pad_tex02/padani_blue
 {
 
-	
+
 	surfaceparm nodamage
 	q3map_surfacelight 200
 
-	
+
 	{
-		map textures/pad_tex02/padani_blue.tga
+		map textures/pad_tex02/padani_blue
 		rgbGen identity
 	}
-	
+
 	{
 		map $lightmap
 		blendfunc gl_dst_color gl_zero
 		rgbGen identity
 	}
-	
+
 	{
-		animMap 2 textures/pad_tex02/padani_log.tga textures/pad_tex02/padani_log02.tga textures/pad_tex02/padani_log03.tga
+		animMap 2 textures/pad_tex02/padani_log textures/pad_tex02/padani_log02 textures/pad_tex02/padani_log03
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 2
 	}
-	
+
 }
 
 
@@ -169,81 +169,81 @@ textures/pad_tex02/padani_red
 {
 
 
-	
+
 	surfaceparm nodamage
 	q3map_surfacelight 200
 
-	
+
 	{
-		map textures/pad_tex02/padani_red.tga
+		map textures/pad_tex02/padani_red
 		rgbGen identity
 	}
-	
+
 	{
 		map $lightmap
 		blendfunc gl_dst_color gl_zero
 		rgbGen identity
 	}
-	
+
 	{
-		animMap 2 textures/pad_tex02/padani_log.tga textures/pad_tex02/padani_log02.tga textures/pad_tex02/padani_log03.tga
+		animMap 2 textures/pad_tex02/padani_log textures/pad_tex02/padani_log02 textures/pad_tex02/padani_log03
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 2
 	}
-	
+
 }
 
 textures/pad_tex02/padlolly_red
 {
 
-	qer_editorimage textures/pad_tex02/padani_red.tga	
+	qer_editorimage textures/pad_tex02/padani_red
 	surfaceparm nodamage
 	q3map_surfacelight 200
 
-	
+
 	{
-		map textures/pad_tex02/padani_red.tga
+		map textures/pad_tex02/padani_red
 		rgbGen identity
 	}
-	
+
 	{
 		map $lightmap
 		blendfunc gl_dst_color gl_zero
 		rgbGen identity
 	}
-	
+
 	{
-		animMap 2 textures/pad_tex02/padani_flaglog01.tga textures/pad_tex02/padani_flaglog03.tga
+		animMap 2 textures/pad_tex02/padani_flaglog01 textures/pad_tex02/padani_flaglog03
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 2
 	}
-	
+
 }
 
 textures/pad_tex02/padlolly_blue
 {
-	qer_editorimage textures/pad_tex02/padani_blue.tga	
+	qer_editorimage textures/pad_tex02/padani_blue
 	surfaceparm nodamage
 	q3map_surfacelight 200
 
-	
+
 	{
-		map textures/pad_tex02/padani_blue.tga
+		map textures/pad_tex02/padani_blue
 		rgbGen identity
 	}
-	
+
 	{
 		map $lightmap
 		blendfunc gl_dst_color gl_zero
 		rgbGen identity
 	}
-	
+
 	{
-		animMap 2 textures/pad_tex02/padani_flaglog04.tga textures/pad_tex02/padani_flaglog02.tga
+		animMap 2 textures/pad_tex02/padani_flaglog04 textures/pad_tex02/padani_flaglog02
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 2
 	}
-	
+
 }
 
 
@@ -252,19 +252,19 @@ textures/pad_tex02/padbox3
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm sky
-        q3map_lightimage textures/pad_tex02/padbox_yel.tga
+        q3map_lightimage textures/pad_tex02/padbox_yel
 	q3map_sun	1 1 1 180 -58 90
 	q3map_surfacelight 200
 
         skyparms env/padbox3 - -
        {
-		map textures/pad_tex02/skystuff3.tga
+		map textures/pad_tex02/skystuff3
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll 0.01 0.03
 		tcMod scale 1 2
 	}
  {
-		map textures/pad_tex02/skystuff3b.tga
+		map textures/pad_tex02/skystuff3b
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll -0.01 -0.03
 		tcMod scale 1 2
@@ -277,13 +277,13 @@ textures/pad_tex02/padbox4
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm sky
-        q3map_lightimage textures/pad_tex02/padbox_blu.tga
+        q3map_lightimage textures/pad_tex02/padbox_blu
 	q3map_sun	1 1 1 180 -58 90
 	q3map_surfacelight 200
 
         skyparms env/padbox4 - -
        {
-		map textures/pad_tex02/skystuff4.tga
+		map textures/pad_tex02/skystuff4
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll 0.02 0.04
 		tcMod scale 1 2
@@ -296,19 +296,19 @@ textures/pad_tex02/padbox5
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm sky
-        q3map_lightimage textures/pad_tex02/padbox_ora.tga
+        q3map_lightimage textures/pad_tex02/padbox_ora
 	q3map_sun	1 1 1 190 -58 90
 	q3map_surfacelight 200
 
         skyparms env/padbox5 - -
        {
-		map textures/pad_tex02/skystuff2.tga
+		map textures/pad_tex02/skystuff2
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll 0.02 0.04
 		tcMod scale 1 2
 	}
  {
-		map textures/pad_tex02/skystuff2b.tga
+		map textures/pad_tex02/skystuff2b
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll -0.01 -0.03
 		tcMod scale 1 2
@@ -321,19 +321,19 @@ textures/pad_tex02/padbox6
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm sky
-        q3map_lightimage textures/pad_tex02/padbox_yel.tga
+        q3map_lightimage textures/pad_tex02/padbox_yel
 	q3map_sun	1 1 1 180 -58 90
 	q3map_surfacelight 200
 
         skyparms env/padbox6 - -
        {
-		map textures/pad_tex02/skystuff6.tga
+		map textures/pad_tex02/skystuff6
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll 0.01 0.03
 		tcMod scale 1 2
 	}
  {
-		map textures/pad_tex02/skystuff6b.tga
+		map textures/pad_tex02/skystuff6b
 		blendfunc GL_ONE GL_ONE
 		tcMod scroll -0.01 -0.03
 		tcMod scale 1 2
@@ -349,11 +349,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_maps/schrank01d.tga
+map textures/pad_maps/schrank01d
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_maps/burgfloor001
 {
@@ -363,22 +363,22 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_maps/burgfloor001.tga
+map textures/pad_maps/burgfloor001
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_maps/woptrailer
 {
 
-    qer_editorimage textures/pad_maps/pad_movie.tga
+    qer_editorimage textures/pad_maps/pad_movie
     surfaceparm trans
     surfaceparm nolightmap
     cull disable
 
         {
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
         tcGen environment
         rgbGen identity
 	}
@@ -388,13 +388,13 @@ textures/pad_maps/woptrailer
 		blendFunc add
         rgbGen identity
 	}
-       
+
 }
 
 
 textures/pad_maps/padlamp01
 {
-	qer_editorimage textures/pad_maps/padlamp01.tga
+	qer_editorimage textures/pad_maps/padlamp01
 	q3map_surfacelight 1000
               q3map_flareShader flareShader
 	//	light 1
@@ -404,12 +404,12 @@ textures/pad_maps/padlamp01
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/padlamp01.tga
+		map textures/pad_maps/padlamp01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/padlamp_flash.tga
+		map textures/pad_maps/padlamp_flash
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -418,7 +418,7 @@ textures/pad_maps/padlamp01
 
 textures/pad_maps/padlamp02
 {
-	qer_editorimage textures/pad_maps/padlamp02.tga
+	qer_editorimage textures/pad_maps/padlamp02
 	q3map_surfacelight 1000
               q3map_flareShader flareShader
 	//	light 1
@@ -428,12 +428,12 @@ textures/pad_maps/padlamp02
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/padlamp02.tga
+		map textures/pad_maps/padlamp02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/padlamp_flash.tga
+		map textures/pad_maps/padlamp_flash
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -442,7 +442,7 @@ textures/pad_maps/padlamp02
 
 textures/pad_maps/padlamp03
 {
-	qer_editorimage textures/pad_maps/padlamp03.tga
+	qer_editorimage textures/pad_maps/padlamp03
 	q3map_surfacelight 1000
               q3map_flareShader flareShader
 	//	light 1
@@ -452,12 +452,12 @@ textures/pad_maps/padlamp03
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/padlamp03.tga
+		map textures/pad_maps/padlamp03
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/padlamp_flash.tga
+		map textures/pad_maps/padlamp_flash
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -466,7 +466,7 @@ textures/pad_maps/padlamp03
 
 textures/pad_maps/weaplight_blue
 {
-	qer_editorimage textures/pad_maps/weaplight_blue.tga
+	qer_editorimage textures/pad_maps/weaplight_blue
 	q3map_surfacelight 150
 	//	light 1
 	surfaceparm nomarks
@@ -475,12 +475,12 @@ textures/pad_maps/weaplight_blue
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/weaplight_blue.tga
+		map textures/pad_maps/weaplight_blue
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/weaplamp_flash.tga
+		map textures/pad_maps/weaplamp_flash
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -489,7 +489,7 @@ textures/pad_maps/weaplight_blue
 
 textures/pad_maps/weaplight_red
 {
-	qer_editorimage textures/pad_maps/weaplight_red.tga
+	qer_editorimage textures/pad_maps/weaplight_red
 	q3map_surfacelight 150
 	//	light 1
 	surfaceparm nomarks
@@ -498,12 +498,12 @@ textures/pad_maps/weaplight_red
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/weaplight_red.tga
+		map textures/pad_maps/weaplight_red
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_maps/weaplamp_flash.tga
+		map textures/pad_maps/weaplamp_flash
 		//tcMod scale 0.5 0.5
 		blendfunc GL_ONE GL_ONE
 	}
@@ -516,7 +516,7 @@ textures/pad_maps/blobpad02
 	surfaceparm nonsolid
 	cull twosided
 	{
-		map textures/pad_maps/blobpad02.tga
+		map textures/pad_maps/blobpad02
 		tcGen environment
                 tcMod turb 0 0.25 0 0.5
                 tcmod scroll 1 1
@@ -533,40 +533,40 @@ textures/pad_tex02/jumploop1
 	cull none
 	surfaceparm nonsolid
               surfaceparm trans
-	q3map_lightimage textures/pad_tex02/jumploop1.tga	
+	q3map_lightimage textures/pad_tex02/jumploop1
 	q3map_surfacelight 100
 
 	{
-		map textures/pad_tex02/jumploop2.tga
+		map textures/pad_tex02/jumploop2
 		blendFunc add
                 	rgbgen wave triangle 1.8 2 0 7
                 	tcMod scroll 0 0.5
 	}
 	{
-		map textures/pad_tex02/jumploop2.tga
+		map textures/pad_tex02/jumploop2
 		blendFunc add
                 	rgbgen wave triangle 1 1.1 1 5
                 	tcMod scale  -1 1.5
                 	tcMod scroll 0 1.1
 	}
 	{
-		map textures/pad_tex02/jumploop1.tga
+		map textures/pad_tex02/jumploop1
 		blendFunc add
                 	rgbgen wave triangle 2 1.4 3 7.7
                 	tcMod scroll 0 1.5
 	}
-	
+
 }
 
 
 textures/pad_tex02/padbase
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_tex02/padbase.tga
+		map textures/pad_tex02/padbase
                		blendFunc add
 		rgbGen vertex
 	}
@@ -574,13 +574,13 @@ textures/pad_tex02/padbase
 
 
 textures/pad_tex02/num01
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_tex02/num01.tga
+		map textures/pad_tex02/num01
                		blendFunc add
 		rgbGen vertex
 	}
@@ -588,13 +588,13 @@ textures/pad_tex02/num01
 
 
 textures/pad_tex02/num02
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_tex02/num02.tga
+		map textures/pad_tex02/num02
                		blendFunc add
 		rgbGen vertex
 	}
@@ -602,13 +602,13 @@ textures/pad_tex02/num02
 
 
 textures/pad_tex02/num03
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_tex02/num03.tga
+		map textures/pad_tex02/num03
                		blendFunc add
 		rgbGen vertex
 	}
@@ -616,13 +616,13 @@ textures/pad_tex02/num03
 
 
 textures/pad_tex02/num04
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_tex02/num04.tga
+		map textures/pad_tex02/num04
                		blendFunc add
 		rgbGen vertex
 	}
@@ -630,13 +630,13 @@ textures/pad_tex02/num04
 
 
 textures/pad_tex02/num05
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_tex02/num05.tga
+		map textures/pad_tex02/num05
                		blendFunc add
 		rgbGen vertex
 	}
@@ -644,13 +644,13 @@ textures/pad_tex02/num05
 
 
 textures/pad_tex02/num06
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_tex02/num06.tga
+		map textures/pad_tex02/num06
                		blendFunc add
 		rgbGen vertex
 	}
@@ -658,13 +658,13 @@ textures/pad_tex02/num06
 
 
 textures/pad_tex02/arrow01
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_tex02/arrow01.tga
+		map textures/pad_tex02/arrow01
                		blendFunc add
 		rgbGen vertex
 	}
@@ -672,13 +672,13 @@ textures/pad_tex02/arrow01
 
 
 textures/pad_tex02/arrow02
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_tex02/arrow02.tga
+		map textures/pad_tex02/arrow02
                		blendFunc add
 		rgbGen vertex
 	}
@@ -690,14 +690,14 @@ textures/pad_tex02/blueflag
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_tex02/blueflag.tga
+                map textures/pad_tex02/blueflag
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -717,14 +717,14 @@ textures/pad_tex02/redflag
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_tex02/redflag.tga
+                map textures/pad_tex02/redflag
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex

--- a/wop/scripts.pk3dir/scripts/pad_trash.shader
+++ b/wop/scripts.pk3dir/scripts/pad_trash.shader
@@ -1,336 +1,336 @@
 textures/pad_trash/kb_fenster_02day
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f01.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f01
 	{
-		map textures/pad_trash/kb_fenster_b01.tga
+		map textures/pad_trash/kb_fenster_b01
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map textures/pad_trash/kb_fenster_f01.tga
+		map textures/pad_trash/kb_fenster_f01
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_trash/kb_fenster_02nite
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f01.tga
-	q3map_lightimage textures/pad_trash/kb_fenster_g01.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f01
+	q3map_lightimage textures/pad_trash/kb_fenster_g01
 	q3map_surfacelight 150
 	q3map_backsplash 0 0
 	{
-		map textures/pad_trash/kb_fenster_b01.tga
+		map textures/pad_trash/kb_fenster_b01
 	}
 	{
-		map textures/pad_trash/kb_fenster_f01.tga
+		map textures/pad_trash/kb_fenster_f01
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 	{
-		map textures/pad_trash/kb_fenster_g01.tga
+		map textures/pad_trash/kb_fenster_g01
 		blendfunc add
 	}
 }
 
 textures/pad_trash/kb_fenster_03day
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f02.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f02
 	{
-		map textures/pad_trash/kb_fenster_b02.tga
+		map textures/pad_trash/kb_fenster_b02
 	}
 	{
-		map textures/pad_gfx/glass_bright.tga
+		map textures/pad_gfx/glass_bright
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map textures/pad_trash/kb_fenster_f02.tga
+		map textures/pad_trash/kb_fenster_f02
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_trash/kb_fenster_03nite
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f02.tga
-	q3map_lightimage textures/pad_trash/kb_fenster_g02.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f02
+	q3map_lightimage textures/pad_trash/kb_fenster_g02
 	q3map_surfacelight 150
 	q3map_backsplash 0 0
 	{
-		map textures/pad_trash/kb_fenster_b02.tga
+		map textures/pad_trash/kb_fenster_b02
 	}
 	{
-		map textures/pad_trash/kb_fenster_f02.tga
+		map textures/pad_trash/kb_fenster_f02
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 	{
-		map textures/pad_trash/kb_fenster_g02.tga
+		map textures/pad_trash/kb_fenster_g02
 		blendfunc add
 	}
 }
 
 textures/pad_trash/kb_fenster_04day
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f01.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f01
 	{
-		map textures/pad_trash/kb_fenster_b03.tga
+		map textures/pad_trash/kb_fenster_b03
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map textures/pad_trash/kb_fenster_f01.tga
+		map textures/pad_trash/kb_fenster_f01
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_trash/kb_fenster_04nite
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f01.tga
-	q3map_lightimage textures/pad_trash/kb_fenster_g03.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f01
+	q3map_lightimage textures/pad_trash/kb_fenster_g03
 	q3map_surfacelight 100
 	q3map_backsplash 0 0
 	{
-		map textures/pad_trash/kb_fenster_b03.tga
+		map textures/pad_trash/kb_fenster_b03
 	}
 	{
-		map textures/pad_trash/kb_fenster_f01.tga
+		map textures/pad_trash/kb_fenster_f01
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 	{
-		map textures/pad_trash/kb_fenster_g03.tga
+		map textures/pad_trash/kb_fenster_g03
 		blendfunc add
 	}
 }
 
 textures/pad_trash/kb_fenster_05day
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f02.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f02
 	{
-		map textures/pad_trash/kb_fenster_b04.tga
+		map textures/pad_trash/kb_fenster_b04
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map textures/pad_trash/kb_fenster_f02.tga
+		map textures/pad_trash/kb_fenster_f02
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_trash/kb_fenster_05nite
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f02.tga
-	q3map_lightimage textures/pad_trash/kb_fenster_g04.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f02
+	q3map_lightimage textures/pad_trash/kb_fenster_g04
 	q3map_surfacelight 100
 	q3map_backsplash 0 0
 	{
-		map textures/pad_trash/kb_fenster_b04.tga
+		map textures/pad_trash/kb_fenster_b04
 	}
 	{
-		map textures/pad_trash/kb_fenster_f02.tga
+		map textures/pad_trash/kb_fenster_f02
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 	{
-		map textures/pad_trash/kb_fenster_g04.tga
+		map textures/pad_trash/kb_fenster_g04
 		blendfunc add
 	}
 }
 
 textures/pad_trash/kb_fenster_06day
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f03.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f03
 	{
-		map textures/pad_trash/kb_fenster_b05.tga
+		map textures/pad_trash/kb_fenster_b05
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map textures/pad_trash/kb_fenster_f03.tga
+		map textures/pad_trash/kb_fenster_f03
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_trash/kb_fenster_06nite
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f03.tga
-	q3map_lightimage textures/pad_trash/kb_fenster_g05.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f03
+	q3map_lightimage textures/pad_trash/kb_fenster_g05
 	q3map_surfacelight 120
 	q3map_backsplash 0 0
 	{
-		map textures/pad_trash/kb_fenster_b05.tga
+		map textures/pad_trash/kb_fenster_b05
 	}
 	{
-		map textures/pad_trash/kb_fenster_f03.tga
+		map textures/pad_trash/kb_fenster_f03
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 	{
-		map textures/pad_trash/kb_fenster_g05.tga
+		map textures/pad_trash/kb_fenster_g05
 		blendfunc add
 	}
 }
 
 textures/pad_trash/kb_fenster_10day
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f10.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f10
 	{
-		map textures/pad_trash/kb_fenster_b10.tga
+		map textures/pad_trash/kb_fenster_b10
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map textures/pad_trash/kb_fenster_f10.tga
+		map textures/pad_trash/kb_fenster_f10
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 }
 
 textures/pad_trash/kb_fenster_10nite
 {
-	qer_editorimage textures/pad_trash/kb_fenster_f10.tga
-	q3map_lightimage textures/pad_trash/kb_fenster_g05.tga
+	qer_editorimage textures/pad_trash/kb_fenster_f10
+	q3map_lightimage textures/pad_trash/kb_fenster_g05
 	q3map_surfacelight 300
 	q3map_backsplash 0 0
 	{
-		map textures/pad_trash/kb_fenster_b10.tga
+		map textures/pad_trash/kb_fenster_b10
 	}
 	{
-		map textures/pad_trash/kb_fenster_f10.tga
+		map textures/pad_trash/kb_fenster_f10
 		depthWrite
 		alphaFunc GE128
 		//rgbGen vertex
 		//blendfunc blend
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 	{
-		map textures/pad_trash/kb_fenster_g10.tga
+		map textures/pad_trash/kb_fenster_g10
 		blendfunc add
 	}
 }
 
 textures/pad_trash/kb_flame
 {
-	qer_editorimage textures/pad_pirate/flame1.tga
+	qer_editorimage textures/pad_pirate/flame1
 	surfaceparm nolightmap
 	surfaceparm nomarks
 	surfaceparm trans
@@ -338,25 +338,25 @@ textures/pad_trash/kb_flame
 	deformVertexes autosprite2
 	q3map_surfacelight 50
 	{
-		animmap 3 textures/pad_pirate/flame1.tga textures/pad_pirate/flame2.tga textures/pad_pirate/flame3.tga textures/pad_pirate/flame2.tga 
+		animmap 3 textures/pad_pirate/flame1 textures/pad_pirate/flame2 textures/pad_pirate/flame3 textures/pad_pirate/flame2
 		blendfunc add
-		rgbGen wave inversesawtooth 0 1 0 10 
+		rgbGen wave inversesawtooth 0 1 0 10
 	}
 	{
-		animmap 3 textures/pad_pirate/flame2.tga textures/pad_pirate/flame3.tga textures/pad_pirate/flame2.tga textures/pad_pirate/flame1.tga 
+		animmap 3 textures/pad_pirate/flame2 textures/pad_pirate/flame3 textures/pad_pirate/flame2 textures/pad_pirate/flame1
 		blendfunc add
-		rgbGen wave sawtooth 0 1 0 10 
+		rgbGen wave sawtooth 0 1 0 10
 	}
 	{
-		map textures/pad_pirate/flameball.tga
+		map textures/pad_pirate/flameball
 		blendfunc add
-		rgbGen wave sin 0.6 0.2 0 0.6 
+		rgbGen wave sin 0.6 0.2 0 0.6
 	}
 }
 
 textures/pad_trash/kb_flatterband
 {
-	qer_editorimage textures/pad_trash/kb_pylone1.tga
+	qer_editorimage textures/pad_trash/kb_pylone1
 	surfaceparm nomarks
 	surfaceparm noimpact
 	surfaceparm nonsolid
@@ -369,7 +369,7 @@ textures/pad_trash/kb_flatterband
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_pylone1.tga
+		map textures/pad_trash/kb_pylone1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -377,21 +377,21 @@ textures/pad_trash/kb_flatterband
 
 textures/pad_trash/kb_maschendrahtzaun
 {
-	qer_editorimage textures/pad_jail/jail2_maschendrahtzaun.tga
+	qer_editorimage textures/pad_jail/jail2_maschendrahtzaun
 	surfaceparm alphashadow
 	surfaceparm trans
 	surfaceparm nomarks
 	cull disable
 	nopicmip
 	{
-		map textures/pad_jail/jail2_maschendrahtzaun.tga
+		map textures/pad_jail/jail2_maschendrahtzaun
 		tcmod scale 2 2
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -407,13 +407,13 @@ textures/pad_trash/kb_bauzaun
 	cull disable
 	nopicmip
 	{
-		map textures/pad_trash/kb_bauzaun.tga
+		map textures/pad_trash/kb_bauzaun
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -422,20 +422,20 @@ textures/pad_trash/kb_bauzaun
 
 textures/pad_trash/kb_grate
 {
-	qer_editorimage textures/pad_trash/kb_grate.tga
+	qer_editorimage textures/pad_trash/kb_grate
 	surfaceparm alphashadow
 	surfaceparm trans
 	surfaceparm nomarks
 	cull disable
 	nopicmip
 	{
-		map textures/pad_trash/kb_grate.tga
+		map textures/pad_trash/kb_grate
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -450,13 +450,13 @@ textures/pad_trash/kb_verzierung
 	cull disable
 	nopicmip
 	{
-		map textures/pad_trash/kb_verzierung.tga
+		map textures/pad_trash/kb_verzierung
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -471,13 +471,13 @@ textures/pad_trash/kb_verzierung2
 	cull disable
 	nopicmip
 	{
-		map textures/pad_trash/kb_verzierung2.tga
+		map textures/pad_trash/kb_verzierung2
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -492,13 +492,13 @@ textures/pad_trash/kb_verzierung3
 	cull disable
 	nopicmip
 	{
-		map textures/pad_trash/kb_verzierung3.tga
+		map textures/pad_trash/kb_verzierung3
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -512,13 +512,13 @@ textures/pad_trash/kb_spraywallblue
 	cull disable
 	nopicmip
 	{
-		map textures/pad_trash/kb_spraywallblue.tga
+		map textures/pad_trash/kb_spraywallblue
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -532,13 +532,13 @@ textures/pad_trash/kb_spraywallred
 	cull disable
 	nopicmip
 	{
-		map textures/pad_trash/kb_spraywallred.tga
+		map textures/pad_trash/kb_spraywallred
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -547,20 +547,20 @@ textures/pad_trash/kb_spraywallred
 
 textures/pad_trash/kb_green_02
 {
-	qer_editorimage textures/pad_gfx02/busch.tga
+	qer_editorimage textures/pad_gfx02/busch
 	surfaceparm alphashadow
 	surfaceparm trans
 	surfaceparm nomarks
 	cull disable
 	nopicmip
 	{
-		map textures/pad_gfx02/busch.tga
+		map textures/pad_gfx02/busch
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -570,20 +570,20 @@ textures/pad_trash/kb_green_02
 
 textures/pad_trash/kb_green_03
 {
-	qer_editorimage models\mapobjects\pad_ddmix\trashcan\bush.tga
+	qer_editorimage models\mapobjects\pad_ddmix\trashcan\bush
 	surfaceparm alphashadow
 	surfaceparm trans
 	surfaceparm nomarks
 	cull disable
 	nopicmip
 	{
-		map models\mapobjects\pad_ddmix\trashcan\bush.tga
+		map models\mapobjects\pad_ddmix\trashcan\bush
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 		blendfunc filter
 		depthFunc equal
@@ -592,59 +592,59 @@ textures/pad_trash/kb_green_03
 
 textures/pad_trash/kb_sand
 {
-	qer_editorimage textures/pad_trash/kb_sand.tga
-	surfaceparm sandsteps	
+	qer_editorimage textures/pad_trash/kb_sand
+	surfaceparm sandsteps
 	q3map_nonplanar
 	q3map_shadeangle 60
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 	{
-		map textures/pad_trash/kb_sand.tga
+		map textures/pad_trash/kb_sand
 		blendfunc filter
 	}
 }
 
 textures/pad_trash/kb_laubboden_01
 {
-	qer_editorimage textures/pad_trash/kb_laubboden_01.tga
-	surfaceparm sandsteps	
+	qer_editorimage textures/pad_trash/kb_laubboden_01
+	surfaceparm sandsteps
 	q3map_nonplanar
 	q3map_shadeangle 60
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 	{
-		map textures/pad_trash/kb_laubboden_01.tga
+		map textures/pad_trash/kb_laubboden_01
 		blendfunc filter
 	}
 }
 
 textures/pad_trash/kb_muell
 {
-	qer_editorimage textures/pad_trash/kb_muell.tga
-	surfaceparm softsteps	
+	qer_editorimage textures/pad_trash/kb_muell
+	surfaceparm softsteps
 	q3map_nonplanar
 	q3map_shadeangle 60
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 	}
 	{
-		map textures/pad_trash/kb_muell.tga
+		map textures/pad_trash/kb_muell
 		blendfunc filter
 	}
 }
 
 textures/pad_trash/kb_dirtywater
 {
-	qer_editorimage textures/pad_trash/dirtywater3.tga
-	q3map_lightimage textures/pad_trash/dirtywater2.tga
+	qer_editorimage textures/pad_trash/dirtywater3
+	q3map_lightimage textures/pad_trash/dirtywater2
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm nolightmap
@@ -655,13 +655,13 @@ textures/pad_trash/kb_dirtywater
 	q3map_globaltexture
 	q3map_surfacelight 40
 	{
-		map textures/pad_trash/dirtywater1.tga
+		map textures/pad_trash/dirtywater1
 		blendfunc filter
 		tcMod scale 0.5 0.5
 		tcMod scroll 0.07 0
 	}
 	{
-		map textures/pad_trash/dirtywater3.tga
+		map textures/pad_trash/dirtywater3
 		blendfunc add
 		rgbGen identity
 		tcMod scale 0.5 0.5
@@ -669,7 +669,7 @@ textures/pad_trash/kb_dirtywater
 		tcMod turb 0.2 0.1 0.1 0.05
 	}
 	{
-		map textures/pad_trash/dirtywater2.tga
+		map textures/pad_trash/dirtywater2
 		blendfunc filter
 		rgbGen identity
 		tcMod scale 0.5 0.5
@@ -680,8 +680,8 @@ textures/pad_trash/kb_dirtywater
 
 textures/pad_trash/kb_dirtywater_fog
 {
-	qer_editorimage textures/pad_trash/dirtywater3.tga
-	q3map_lightimage textures/pad_trash/dirtywater2.tga
+	qer_editorimage textures/pad_trash/dirtywater3
+	q3map_lightimage textures/pad_trash/dirtywater2
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm nolightmap
@@ -693,13 +693,13 @@ textures/pad_trash/kb_dirtywater_fog
 	q3map_surfacelight 40
 	fogparms ( .211 .231 .094 ) 650
 	{
-		map textures/pad_trash/dirtywater1.tga
+		map textures/pad_trash/dirtywater1
 		blendfunc filter
 		tcMod scale 0.5 0.5
 		tcMod scroll 0.07 0
 	}
 	{
-		map textures/pad_trash/dirtywater3.tga
+		map textures/pad_trash/dirtywater3
 		blendfunc add
 		rgbGen identity
 		tcMod scale 0.5 0.5
@@ -707,7 +707,7 @@ textures/pad_trash/kb_dirtywater_fog
 		tcMod turb 0.2 0.1 0.1 0.05
 	}
 	{
-		map textures/pad_trash/dirtywater2.tga
+		map textures/pad_trash/dirtywater2
 		blendfunc filter
 		rgbGen identity
 		tcMod scale 0.5 0.5
@@ -718,7 +718,7 @@ textures/pad_trash/kb_dirtywater_fog
 
 textures/pad_trash/kb_dirtywaterfall
 {
-	qer_editorimage textures/pad_trash/dirtywaterfall.tga
+	qer_editorimage textures/pad_trash/dirtywaterfall
 	surfaceparm noimpact
 	surfaceparm nonsolid
 	surfaceparm trans
@@ -727,14 +727,14 @@ textures/pad_trash/kb_dirtywaterfall
 	qer_trans 0.8
 	q3map_globaltexture
 	{
-		map textures/pad_trash/dirtywater3.tga
+		map textures/pad_trash/dirtywater3
 		blendfunc add
 		tcMod scale 0.5 0.5
 		tcMod turb 0.25 0.03 0 0.5
 		tcMod scroll 0 -0.2
 	}
 	{
-		map textures/pad_trash/dirtywaterfall.tga
+		map textures/pad_trash/dirtywaterfall
 		blendfunc filter
 		tcMod scale 0.5 0.5
 		tcMod turb 0.25 0.03 0 0.5
@@ -743,78 +743,78 @@ textures/pad_trash/kb_dirtywaterfall
 }
 
 textures/pad_trash/kb_gas
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_trash/kb_gas.tga
+		map textures/pad_trash/kb_gas
                	blendFunc blend
 		rgbGen vertex
 	}
 }
 
 textures/pad_trash/kb_hydrant
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_trash/kb_hydrant.tga
+		map textures/pad_trash/kb_hydrant
                	blendFunc blend
 		rgbGen vertex
 	}
 }
 
 textures/pad_trash/kb_sign_01
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_trash/kb_sign_01.tga
+		map textures/pad_trash/kb_sign_01
                	blendFunc blend
 		rgbGen vertex
 	}
 }
 
 textures/pad_trash/kb_sign_03
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_trash/kb_sign_03.tga
+		map textures/pad_trash/kb_sign_03
                	blendFunc blend
 		rgbGen vertex
 	}
 }
 
 textures/pad_trash/kb_sign_04
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_trash/kb_sign_04.tga
+		map textures/pad_trash/kb_sign_04
                	blendFunc blend
 		rgbGen vertex
 	}
 }
 
 textures/pad_trash/kb_sign_05
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_trash/kb_sign_05.tga
+		map textures/pad_trash/kb_sign_05
                	blendFunc blend
 		rgbGen vertex
 	}
@@ -827,55 +827,55 @@ textures/pad_trash/kb_sign_07
 	cull disable
 	nopicmip
 	{
-		map textures/pad_trash/kb_sign_07.tga
+		map textures/pad_trash/kb_sign_07
 		rgbGen identity
 		depthWrite
 		alphaFunc GE128
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
-		tcGen lightmap 
+		tcGen lightmap
 		depthFunc equal
 	}
 }
 
 textures/pad_trash/kb_donotfeed
-{    
-     qer_editorimage textures/pad_trash/donotfeed.tga
-     surfaceparm nomarks   
+{
+     qer_editorimage textures/pad_trash/donotfeed
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_trash/donotfeed.tga
+		map textures/pad_trash/donotfeed
                	blendFunc blend
 		rgbGen vertex
 	}
 }
 
 textures/pad_trash/kb_kanaldeckel
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_trash/kb_kanaldeckel.tga
+		map textures/pad_trash/kb_kanaldeckel
                	blendFunc blend
 		rgbGen vertex
 	}
 }
 
 textures/pad_poster/greensun
-{    
-     surfaceparm nomarks   
+{
+     surfaceparm nomarks
      surfaceparm trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_poster/poster.tga
+		map textures/pad_poster/poster
                	blendFunc blend
 		rgbGen vertex
 	}
@@ -883,117 +883,117 @@ textures/pad_poster/greensun
 
 textures/pad_trash/kb_light_15000
 {
-	qer_editorimage textures/pad_trash/kb_light_on.tga
-	q3map_lightimage textures/colors/white.tga
+	qer_editorimage textures/pad_trash/kb_light_on
+	q3map_lightimage textures/colors/white
 	surfaceparm nolightmap
 	q3map_surfacelight 15000
 	q3map_flareShader flareShader
 	{
-		map textures/pad_trash/kb_light_on.tga
+		map textures/pad_trash/kb_light_on
 	}
 }
 
 textures/pad_trash/kb_light_25000
 {
-	qer_editorimage textures/pad_trash/kb_light_on.tga
-	q3map_lightimage textures/colors/white.tga
+	qer_editorimage textures/pad_trash/kb_light_on
+	q3map_lightimage textures/colors/white
 	surfaceparm nolightmap
 	q3map_surfacelight 25000
 	q3map_flareShader flareShader
 	{
-		map textures/pad_trash/kb_light_on.tga
+		map textures/pad_trash/kb_light_on
 	}
 }
 
 textures/pad_trash/kb_light2_15000
 {
-	qer_editorimage textures/pad_trash/kb_light2_on.tga
-	q3map_lightimage textures/colors/white.tga
+	qer_editorimage textures/pad_trash/kb_light2_on
+	q3map_lightimage textures/colors/white
 	surfaceparm nolightmap
 	q3map_surfacelight 15000
 	{
-		map textures/pad_trash/kb_light2_on.tga
+		map textures/pad_trash/kb_light2_on
 	}
 }
 
 textures/pad_trash/kb_dirtywatercalm_lit
-{ 
-        qer_editorimage textures/pad_trash/dirtywater3.tga 
-        qer_trans 0.5 
-        q3map_globaltexture 
+{
+        qer_editorimage textures/pad_trash/dirtywater3
+        qer_trans 0.5
+        q3map_globaltexture
 	surfaceparm noimpact
-        surfaceparm trans 
-        surfaceparm nolightmap 
-        surfaceparm nonsolid 
-        surfaceparm water 
+        surfaceparm trans
+        surfaceparm nolightmap
+        surfaceparm nonsolid
+        surfaceparm water
 	q3map_surfacelight 30
-        cull disable 
+        cull disable
 
-        { 
-               map textures/pad_trash/dirtywater3.tga 
+        {
+               map textures/pad_trash/dirtywater3
 	       tcMod scale 0.5 0.5
-               tcMod turb 0.2 0.1 1 0.015 
-               tcMod scroll 0.001 0.001 
-               blendfunc add 
-               rgbGen identity 
+               tcMod turb 0.2 0.1 1 0.015
+               tcMod scroll 0.001 0.001
+               blendfunc add
+               rgbGen identity
 
-        } 
+        }
 	{
-		map textures/pad_trash/dirtywater2.tga
+		map textures/pad_trash/dirtywater2
 		blendfunc filter
 		rgbGen identity
 		tcMod turb 0.2 0.1 1 0.05
 		tcMod scroll 0.01 0.01
 	}
-} 
+}
 
 textures/pad_trash/kb_dirtywatercalm_unlit
-{ 
-        qer_editorimage textures/pad_trash/dirtywater3.tga 
-        qer_trans 0.5 
-        q3map_globaltexture 
+{
+        qer_editorimage textures/pad_trash/dirtywater3
+        qer_trans 0.5
+        q3map_globaltexture
 	surfaceparm noimpact
-        surfaceparm trans 
-        surfaceparm nolightmap 
-        surfaceparm nonsolid 
-        surfaceparm water 
-        cull disable 
+        surfaceparm trans
+        surfaceparm nolightmap
+        surfaceparm nonsolid
+        surfaceparm water
+        cull disable
 
-        { 
-               map textures/pad_trash/dirtywater3.tga 
+        {
+               map textures/pad_trash/dirtywater3
 	       tcMod scale 0.5 0.5
-               tcMod turb 0.2 0.1 1 0.015 
-               tcMod scroll 0.001 0.001 
-               blendfunc add 
-               rgbGen identity 
+               tcMod turb 0.2 0.1 1 0.015
+               tcMod scroll 0.001 0.001
+               blendfunc add
+               rgbGen identity
 
-        } 
+        }
 	{
-		map textures/pad_trash/dirtywater2.tga
+		map textures/pad_trash/dirtywater2
 		blendfunc filter
 		rgbGen identity
 		tcMod turb 0.2 0.1 1 0.05
 		tcMod scroll 0.01 0.01
 	}
-} 
+}
 
 textures/pad_trash/kb_holzscheit
 {
-	qer_editorimage textures/pad_trash/kb_holzscheit_base.tga
+	qer_editorimage textures/pad_trash/kb_holzscheit_base
 	surfaceparm nomarks
 	surfaceparm woodsteps
 	{
-		map $lightmap 
+		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_holzscheit_base.tga
+		map textures/pad_trash/kb_holzscheit_base
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_holzscheit_blend.tga
-		rgbGen wave sin 0.1 0.2 0 0.15 
+		map textures/pad_trash/kb_holzscheit_blend
+		rgbGen wave sin 0.1 0.2 0 0.15
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -1003,28 +1003,28 @@ textures/pad_trash/kb_feuer
 	surfaceparm trans
 	surfaceparm nomarks
 	surfaceparm nonsolid
-	qer_editorimage textures/pad_garden/sflame1.tga
+	qer_editorimage textures/pad_garden/sflame1
 	q3map_surfacelight 1500
 	surfaceparm nolightmap
 	cull none
 
 	{
-		animMap 10 textures/pad_garden/sflame1.tga textures/pad_garden/sflame2.tga textures/pad_garden/sflame3.tga textures/pad_garden/sflame4.tga textures/pad_garden/sflame5.tga textures/pad_garden/sflame6.tga textures/pad_garden/sflame7.tga textures/pad_garden/sflame8.tga
+		animMap 10 textures/pad_garden/sflame1 textures/pad_garden/sflame2 textures/pad_garden/sflame3 textures/pad_garden/sflame4 textures/pad_garden/sflame5 textures/pad_garden/sflame6 textures/pad_garden/sflame7 textures/pad_garden/sflame8
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 10
-		
-	}	
+
+	}
 	{
-		animMap 10 textures/pad_garden/sflame2.tga textures/pad_garden/sflame3.tga textures/pad_garden/sflame4.tga textures/pad_garden/sflame5.tga textures/pad_garden/sflame6.tga textures/pad_garden/sflame7.tga textures/pad_garden/sflame8.tga textures/pad_garden/sflame1.tga
+		animMap 10 textures/pad_garden/sflame2 textures/pad_garden/sflame3 textures/pad_garden/sflame4 textures/pad_garden/sflame5 textures/pad_garden/sflame6 textures/pad_garden/sflame7 textures/pad_garden/sflame8 textures/pad_garden/sflame1
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave sawtooth 0 1 0 10
-	}	
+	}
 
 
 	{
-		map textures/pad_garden/sflameball.tga
+		map textures/pad_garden/sflameball
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+		rgbGen wave sin .6 .2 0 .6
 	}
 }
 
@@ -1032,13 +1032,13 @@ textures/pad_trash/wallstone_001we
 {
 	tessSize 64
 	deformVertexes normal 1 5
-	qer_editorimage textures/pad_wallout/wallstone_001.tga
+	qer_editorimage textures/pad_wallout/wallstone_001
         {
-		map textures/pad_wallout/wallstone_001.tga
-                rgbGen identity    
+		map textures/pad_wallout/wallstone_001
+                rgbGen identity
         }
         {
-		map textures/pad_trash/kb_reflection.tga
+		map textures/pad_trash/kb_reflection
                 Blendfunc add
 		tcgen environment
 		rgbgen wave sin .3 0 0 0
@@ -1056,13 +1056,13 @@ textures/pad_trash/wallstone_002we
 {
 	tessSize 128
 	deformVertexes normal 1 5
-	qer_editorimage textures/pad_garden/rostii.tga
+	qer_editorimage textures/pad_garden/rostii
         {
-		map textures/pad_garden/rostii.tga
-                rgbGen identity    
+		map textures/pad_garden/rostii
+                rgbGen identity
         }
         {
-		map textures/pad_trash/kb_reflection.tga
+		map textures/pad_trash/kb_reflection
                 Blendfunc add
 		tcgen environment
 		rgbgen wave sin .3 0 0 0
@@ -1080,13 +1080,13 @@ textures/pad_trash/rost_we
 {
 	tessSize 128
 	deformVertexes normal 1 5
-	qer_editorimage textures/pad_jail/pad_jail_metal1.tga
+	qer_editorimage textures/pad_jail/pad_jail_metal1
         {
-		map textures/pad_jail/pad_jail_metal1.tga
-                rgbGen identity    
+		map textures/pad_jail/pad_jail_metal1
+                rgbGen identity
         }
         {
-		map textures/pad_trash/kb_reflection.tga
+		map textures/pad_trash/kb_reflection
                 Blendfunc add
 		tcgen environment
 		rgbgen wave sin .3 0 0 0
@@ -1101,14 +1101,14 @@ textures/pad_trash/rost_we
 }
 
 textures/pad_trash/kb_greensun
-{    
-     	qer_editorimage textures/pad_poster/greensun.tga
-	surfaceparm nomarks   
+{
+     	qer_editorimage textures/pad_poster/greensun
+	surfaceparm nomarks
      	surfaceparm trans
      	surfaceparm pointlight
      	polygonOffset
         {
-		map textures/pad_poster/greensun.tga
+		map textures/pad_poster/greensun
                	blendFunc blend
 		rgbGen vertex
 	}
@@ -1124,11 +1124,11 @@ textures/pad_trash/kb_container_01
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_container_01.tga
+		map textures/pad_trash/kb_container_01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 textures/pad_trash/kb_container_02
 {
@@ -1138,11 +1138,11 @@ textures/pad_trash/kb_container_02
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_container_02.tga
+		map textures/pad_trash/kb_container_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 textures/pad_trash/kb_container_03
 {
@@ -1152,7 +1152,7 @@ textures/pad_trash/kb_container_03
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_container_03.tga
+		map textures/pad_trash/kb_container_03
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1166,7 +1166,7 @@ textures/pad_trash/kb_deckel
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_deckel.tga
+		map textures/pad_trash/kb_deckel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1180,11 +1180,11 @@ textures/pad_trash/kb_stirnholz
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_stirnholz.tga
+		map textures/pad_trash/kb_stirnholz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-} 
+}
 
 textures/pad_trash/kb_metallboden
 {
@@ -1194,7 +1194,7 @@ textures/pad_trash/kb_metallboden
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_metallboden.tga
+		map textures/pad_trash/kb_metallboden
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1208,7 +1208,7 @@ textures/pad_trash/kb_pylone1
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_pylone1.tga
+		map textures/pad_trash/kb_pylone1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1222,7 +1222,7 @@ textures/pad_trash/kb_pylone2
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_pylone2.tga
+		map textures/pad_trash/kb_pylone2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1236,7 +1236,7 @@ textures/pad_trash/kb_tor_links
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_tor_links.tga
+		map textures/pad_trash/kb_tor_links
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1250,7 +1250,7 @@ textures/pad_trash/kb_tor_rechts
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_tor_rechts.tga
+		map textures/pad_trash/kb_tor_rechts
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1264,7 +1264,7 @@ textures/pad_trash/kb_tor_trim
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_tor_trim.tga
+		map textures/pad_trash/kb_tor_trim
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1278,7 +1278,7 @@ textures/pad_trash/kb_vent_01
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_vent_01.tga
+		map textures/pad_trash/kb_vent_01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1292,7 +1292,7 @@ textures/pad_trash/kb_vent_02
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_vent_02.tga
+		map textures/pad_trash/kb_vent_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1306,7 +1306,7 @@ textures/pad_trash/kb_vent_03
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_vent_03.tga
+		map textures/pad_trash/kb_vent_03
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1320,7 +1320,7 @@ textures/pad_trash/kb_verteilerkasten_back
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_verteilerkasten_back.tga
+		map textures/pad_trash/kb_verteilerkasten_back
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1334,7 +1334,7 @@ textures/pad_trash/kb_verteilerkasten_front
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_verteilerkasten_front.tga
+		map textures/pad_trash/kb_verteilerkasten_front
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1348,7 +1348,7 @@ textures/pad_trash/kb_verteilerkasten_sideleft
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_verteilerkasten_sideleft.tga
+		map textures/pad_trash/kb_verteilerkasten_sideleft
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1362,7 +1362,7 @@ textures/pad_trash/kb_verteilerkasten_sideright
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_verteilerkasten_sideright.tga
+		map textures/pad_trash/kb_verteilerkasten_sideright
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1376,7 +1376,7 @@ textures/pad_trash/kb_wellblech
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_wellblech.tga
+		map textures/pad_trash/kb_wellblech
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1390,7 +1390,7 @@ textures/pad_trash/kb_schuttcontainer1
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_schuttcontainer1.tga
+		map textures/pad_trash/kb_schuttcontainer1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1404,7 +1404,7 @@ textures/pad_trash/kb_schuttcontainer2
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_schuttcontainer2.tga
+		map textures/pad_trash/kb_schuttcontainer2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1418,7 +1418,7 @@ textures/pad_trash/kb_feuerleiter
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_feuerleiter.tga
+		map textures/pad_trash/kb_feuerleiter
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1426,14 +1426,14 @@ textures/pad_trash/kb_feuerleiter
 
 textures/pad_trash/kb_rinne
 {
-		qer_editorimage textures/pad_jail/jail2_leuchte1.tga
+		qer_editorimage textures/pad_jail/jail2_leuchte1
 		surfaceparm metalsteps
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_jail/jail2_leuchte1.tga
+		map textures/pad_jail/jail2_leuchte1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1447,7 +1447,7 @@ textures/pad_trash/kb_fabrik
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_fabrik.tga
+		map textures/pad_trash/kb_fabrik
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1455,14 +1455,14 @@ textures/pad_trash/kb_fabrik
 
 textures/pad_trash/kb_achtung
 {
-		qer_editorimage textures/pad_trash/kb_sign_05.tga
+		qer_editorimage textures/pad_trash/kb_sign_05
 		surfaceparm metalsteps
 	{
 		map $lightmap
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_sign_05.tga
+		map textures/pad_trash/kb_sign_05
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1476,7 +1476,7 @@ textures/pad_trash/kb_fass01
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_fass01.tga
+		map textures/pad_trash/kb_fass01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1490,7 +1490,7 @@ textures/pad_trash/kb_fass02
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_fass02.tga
+		map textures/pad_trash/kb_fass02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1504,7 +1504,7 @@ textures/pad_trash/kb_traeger01
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_traeger01.tga
+		map textures/pad_trash/kb_traeger01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1518,7 +1518,7 @@ textures/pad_trash/kb_traeger02
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_traeger02.tga
+		map textures/pad_trash/kb_traeger02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1532,7 +1532,7 @@ textures/pad_trash/kb_ablaufgitter
 		rgbGen identity
 	}
 	{
-		map textures/pad_trash/kb_ablaufgitter.tga
+		map textures/pad_trash/kb_ablaufgitter
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1542,7 +1542,7 @@ textures/pad_trash/kb_ablaufgitter
 
 textures/pad_trash/trash_skybox_night
 {
-	qer_editorimage env/pc-friday-13th-512_ft.tga
+	qer_editorimage env/pc-friday-13th-512_ft
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm sky
@@ -1552,8 +1552,8 @@ textures/pad_trash/trash_skybox_night
 
 textures/pad_trash/trash_skybox_day
 {
-	qer_editorimage env/padcity512_ft.tga
-	q3map_lightimage textures/pad_garden/brightyell.tga
+	qer_editorimage env/padcity512_ft
+	q3map_lightimage textures/pad_garden/brightyell
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm sky
@@ -1564,8 +1564,8 @@ textures/pad_trash/trash_skybox_day
 
 textures/pad_trash/trash_skybox_evening
 {
-        qer_editorimage env/pc-morning-madness512_ft.tga
-        q3map_lightimage textures/pad_petesky/orange2.tga
+        qer_editorimage env/pc-morning-madness512_ft
+        q3map_lightimage textures/pad_petesky/orange2
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm sky

--- a/wop/scripts.pk3dir/scripts/q3map2_wop_diner.shader
+++ b/wop/scripts.pk3dir/scripts/q3map2_wop_diner.shader
@@ -8,7 +8,7 @@ wop_diner/C0B1521B369240DCA02849A4A7478C0E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -19,7 +19,7 @@ wop_diner/C0B1521B369240DCA02849A4A7478C0E
 	}
 
 	{
-		map textures/pad_harm/sitzbank01b_white2.tga
+		map textures/pad_harm/sitzbank01b_white2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -31,17 +31,17 @@ wop_diner/C63A5073ADFFF5ACCD914A78E9C1833B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0010.tga
+		map maps/wop_diner/lm_0010
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -53,17 +53,17 @@ wop_diner/CCE17D6C46074B172BB70C34F3F4B59F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0011.tga
+		map maps/wop_diner/lm_0011
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -75,17 +75,17 @@ wop_diner/D3EB59F87D259AE6D2A7A2A3ED0FFBD9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0004.tga
+		map maps/wop_diner/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/musicbox_front.tga
+		map textures/pad_harm/musicbox_front
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -97,17 +97,17 @@ wop_diner/ADCF426F021EDA8B788DF79907D8BFBD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0001.tga
+		map maps/wop_diner/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/dinerground2.tga
+		map textures/pad_harm/dinerground2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -119,17 +119,17 @@ wop_diner/4A28260D1B5D99AF0BC1ED49A3C67846
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0001.tga
+		map maps/wop_diner/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/dinerground.tga
+		map textures/pad_harm/dinerground
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -141,7 +141,7 @@ wop_diner/85E46B8870AEA94AC25B873D6F0AADAD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -152,7 +152,7 @@ wop_diner/85E46B8870AEA94AC25B873D6F0AADAD
 	}
 
 	{
-		map textures/pad_wood/wood019a.tga
+		map textures/pad_wood/wood019a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -164,17 +164,17 @@ wop_diner/9B24CAF9C1949F08ADFE5CAC223FDD41
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0011.tga
+		map maps/wop_diner/lm_0011
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood019a.tga
+		map textures/pad_wood/wood019a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -186,17 +186,17 @@ wop_diner/5A3E83AD0FDEF9124F5714892C3EF126
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0003.tga
+		map maps/wop_diner/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/metalline01b.tga
+		map textures/pad_harm/metalline01b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -208,17 +208,17 @@ wop_diner/FA5E67CC6CFA62CF974C21B4077E879E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0004.tga
+		map maps/wop_diner/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -230,7 +230,7 @@ wop_diner/616019306E6410440B6B31A061569E59
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -241,7 +241,7 @@ wop_diner/616019306E6410440B6B31A061569E59
 	}
 
 	{
-		map textures/pad_harm/sitzbank01b_white2.tga
+		map textures/pad_harm/sitzbank01b_white2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -253,17 +253,17 @@ wop_diner/8B52C55D4692FEF9E96E5B6C6141E76B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0009.tga
+		map maps/wop_diner/lm_0009
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -275,17 +275,17 @@ wop_diner/770FB59977580A71B5EF7D257FBAD77F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0003.tga
+		map maps/wop_diner/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/musicbox_front.tga
+		map textures/pad_harm/musicbox_front
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -297,17 +297,17 @@ wop_diner/F3D7384E73CFA011655A609CACF1F128
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0010.tga
+		map maps/wop_diner/lm_0010
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood019a.tga
+		map textures/pad_wood/wood019a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -319,17 +319,17 @@ wop_diner/1075F04F1CA28B8D860DEEE40D371D98
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0003.tga
+		map maps/wop_diner/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -341,17 +341,17 @@ wop_diner/786770417E14BD8E7CCBA851910AD303
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0000.tga
+		map maps/wop_diner/lm_0000
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -363,17 +363,17 @@ wop_diner/6930C0A374DF8AAC1126CA118F84CE73
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_diner/lm_0008.tga
+		map maps/wop_diner/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallin/color32.tga
+		map textures/pad_wallin/color32
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}

--- a/wop/scripts.pk3dir/scripts/q3map2_wop_dinerBB.shader
+++ b/wop/scripts.pk3dir/scripts/q3map2_wop_dinerBB.shader
@@ -8,7 +8,7 @@ wop_dinerBB/B611A673C803C59F4667C56491997A4B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -19,7 +19,7 @@ wop_dinerBB/B611A673C803C59F4667C56491997A4B
 	}
 
 	{
-		map textures/pad_harm/sitzbank01b_white2.tga
+		map textures/pad_harm/sitzbank01b_white2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -31,17 +31,17 @@ wop_dinerBB/32A7EA3E3BE65C22737B5826B98C1E6D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0008.tga
+		map maps/wop_dinerBB/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -53,17 +53,17 @@ wop_dinerBB/DC04DA76CD2321B81A5538F754E56C84
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0003.tga
+		map maps/wop_dinerBB/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/dinerground2.tga
+		map textures/pad_harm/dinerground2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -75,17 +75,17 @@ wop_dinerBB/25D25655530F2E12DA2440933C41F3B5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0003.tga
+		map maps/wop_dinerBB/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/dinerground.tga
+		map textures/pad_harm/dinerground
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -97,17 +97,17 @@ wop_dinerBB/FE0A9852BD4F9CA60374DFA304B17B2F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0008.tga
+		map maps/wop_dinerBB/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood019a.tga
+		map textures/pad_wood/wood019a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -119,17 +119,17 @@ wop_dinerBB/5651E6EF702DF1BBCE508DF7EC93B60D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0002.tga
+		map maps/wop_dinerBB/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/metalline01b.tga
+		map textures/pad_harm/metalline01b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -141,17 +141,17 @@ wop_dinerBB/73666EB0C2CF8B408755B1B321908BBE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0004.tga
+		map maps/wop_dinerBB/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/sitzbank01b_white2.tga
+		map textures/pad_harm/sitzbank01b_white2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -163,17 +163,17 @@ wop_dinerBB/F3D2A53FC41ED309C0060609282F06DC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0007.tga
+		map maps/wop_dinerBB/lm_0007
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -185,17 +185,17 @@ wop_dinerBB/8AE756171F8382B448B29289FE8276AF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0006.tga
+		map maps/wop_dinerBB/lm_0006
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -207,17 +207,17 @@ wop_dinerBB/CEBF3BC23BF6DE2A5357F95C558ED68E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0002.tga
+		map maps/wop_dinerBB/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/dinerground2.tga
+		map textures/pad_harm/dinerground2
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -229,17 +229,17 @@ wop_dinerBB/E36377B5DB63EB32A015811D5F19AE77
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0002.tga
+		map maps/wop_dinerBB/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/dinerground.tga
+		map textures/pad_harm/dinerground
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -251,17 +251,17 @@ wop_dinerBB/B23B4B85E20CDD394FD2DA508C158415
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0007.tga
+		map maps/wop_dinerBB/lm_0007
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood019a.tga
+		map textures/pad_wood/wood019a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -273,17 +273,17 @@ wop_dinerBB/5697DAA32CC15DE50BAB541221CBC442
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0003.tga
+		map maps/wop_dinerBB/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_harm/metalline01b.tga
+		map textures/pad_harm/metalline01b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -295,17 +295,17 @@ wop_dinerBB/FE361E195E08AEA7D95AB512D23EA346
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_dinerBB/lm_0000.tga
+		map maps/wop_dinerBB/lm_0000
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wood/wood026a.tga
+		map textures/pad_wood/wood026a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}

--- a/wop/scripts.pk3dir/scripts/q3map2_wop_trashmap.shader
+++ b/wop/scripts.pk3dir/scripts/q3map2_wop_trashmap.shader
@@ -8,17 +8,17 @@ wop_trashmap/AA0C0A6AD2AEEAFBCA6FC2A618745986
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0022.tga
+		map maps/wop_trashmap/lm_0022
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -30,17 +30,17 @@ wop_trashmap/C9F02C6E291F2CF74FA569E51223E0EE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0016.tga
+		map maps/wop_trashmap/lm_0016
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -52,17 +52,17 @@ wop_trashmap/736D32B740F28546D86081A868AF9891
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0020.tga
+		map maps/wop_trashmap/lm_0020
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -74,17 +74,17 @@ wop_trashmap/31A9FC418A6B5FEE321B02B18249D21D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0017.tga
+		map maps/wop_trashmap/lm_0017
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -96,17 +96,17 @@ wop_trashmap/EFBA601DDD4BECDB031ADD9B8A0210D6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0018.tga
+		map maps/wop_trashmap/lm_0018
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -118,17 +118,17 @@ wop_trashmap/3D7339D9DB115F353E8CEBD6A14F6FE4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0016.tga
+		map maps/wop_trashmap/lm_0016
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -140,17 +140,17 @@ wop_trashmap/FCA589916D63F0047658A1EC9B38E8CD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0021.tga
+		map maps/wop_trashmap/lm_0021
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -162,17 +162,17 @@ wop_trashmap/1BC81295E9435A9F5548442D052A70C7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0017.tga
+		map maps/wop_trashmap/lm_0017
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -184,17 +184,17 @@ wop_trashmap/5F91327CBF9D877B91882BA5BC37BF8B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0037.tga
+		map maps/wop_trashmap/lm_0037
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -206,17 +206,17 @@ wop_trashmap/9049D74DFACA1B0A2D22128EE6A1EC82
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0036.tga
+		map maps/wop_trashmap/lm_0036
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -228,17 +228,17 @@ wop_trashmap/167EE43282004290B67CDF88492A7EE0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0044.tga
+		map maps/wop_trashmap/lm_0044
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -250,17 +250,17 @@ wop_trashmap/D7CE0993AB4D30F8BFD1F5746C5D392A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0026.tga
+		map maps/wop_trashmap/lm_0026
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -272,17 +272,17 @@ wop_trashmap/1BF7E78F81EBF88747639AC7ECF6896E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0002.tga
+		map maps/wop_trashmap/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/gumkabel.tga
+		map textures/pad_garden/gumkabel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -294,17 +294,17 @@ wop_trashmap/3796CE82491FA0E3B5C7CBAF40F13E88
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/gumkabel.tga
+		map textures/pad_garden/gumkabel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -316,17 +316,17 @@ wop_trashmap/C67BBD78C184B42E8D3A097276486675
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0045.tga
+		map maps/wop_trashmap/lm_0045
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -338,17 +338,17 @@ wop_trashmap/60F3CE577519DF8106ADE14176B9751F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0043.tga
+		map maps/wop_trashmap/lm_0043
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -360,7 +360,7 @@ wop_trashmap/77C0DDF1C8E7FA6534C087946C80CDAD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -371,7 +371,7 @@ wop_trashmap/77C0DDF1C8E7FA6534C087946C80CDAD
 	}
 
 	{
-		map textures/pad_jail/pad_jail_pipes1.tga
+		map textures/pad_jail/pad_jail_pipes1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -383,17 +383,17 @@ wop_trashmap/998A8994365CF2EA16359A2F1082DC7C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0010.tga
+		map maps/wop_trashmap/lm_0010
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_pipes1.tga
+		map textures/pad_jail/pad_jail_pipes1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -405,17 +405,17 @@ wop_trashmap/2B8F894F5AB6BA2C079DDF21B7ADD606
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0011.tga
+		map maps/wop_trashmap/lm_0011
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_pipes1.tga
+		map textures/pad_jail/pad_jail_pipes1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -427,17 +427,17 @@ wop_trashmap/62D5D692F5454BC03D39888C6F76DABD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0014.tga
+		map maps/wop_trashmap/lm_0014
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -449,17 +449,17 @@ wop_trashmap/3A74709375FE366A7D8D1FCC554CDC97
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_basket_metal.tga
+		map textures/pad_jail/pad_jail_basket_metal
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -471,17 +471,17 @@ wop_trashmap/879BD93C33A2BE9970989C8789852F67
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0044.tga
+		map maps/wop_trashmap/lm_0044
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_plakat.tga
+		map textures/pad_trash/kb_plakat
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -493,10 +493,10 @@ wop_trashmap/1E7E727DF15EA25C733D3E942683FF47
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -504,7 +504,7 @@ wop_trashmap/1E7E727DF15EA25C733D3E942683FF47
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -516,7 +516,7 @@ wop_trashmap/78FA596B71B0CDB34C4C426B1B3E34A9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -527,7 +527,7 @@ wop_trashmap/78FA596B71B0CDB34C4C426B1B3E34A9
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -539,17 +539,17 @@ wop_trashmap/13C96029998FB8FF6FD0877119F31CAB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -561,17 +561,17 @@ wop_trashmap/94BF9B634D5420084844E1F38F92D948
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0002.tga
+		map maps/wop_trashmap/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -583,17 +583,17 @@ wop_trashmap/B89C115CFE226C3124F1282AF1FC1D8C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_gfx02/git04.tga
+		map textures/pad_gfx02/git04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -605,17 +605,17 @@ wop_trashmap/D2148D3FFE9B578048D2213E01341FBF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_metal10_keyhole.tga
+		map textures/pad_jail/pad_jail_metal10_keyhole
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -627,17 +627,17 @@ wop_trashmap/98A6FF76D71773B37546DAACC4155723
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0009.tga
+		map maps/wop_trashmap/lm_0009
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_metal10_keyhole.tga
+		map textures/pad_jail/pad_jail_metal10_keyhole
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -649,17 +649,17 @@ wop_trashmap/77007A23D876152050FD41758C5AD50E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0034.tga
+		map maps/wop_trashmap/lm_0034
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -671,17 +671,17 @@ wop_trashmap/B01A7CD0F842FFA5ADDBE7BC593BEC8A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -693,17 +693,17 @@ wop_trashmap/CB6884D700CFB8BD314509F5CD540F55
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0032.tga
+		map maps/wop_trashmap/lm_0032
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -715,17 +715,17 @@ wop_trashmap/1A36D38CC7AD04704642C0A99D765030
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0037.tga
+		map maps/wop_trashmap/lm_0037
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -737,17 +737,17 @@ wop_trashmap/9E46EFBE5B568F0499BB2833E8509059
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -759,17 +759,17 @@ wop_trashmap/4FD7DEEA32595EB55CA5805398C0401A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -781,17 +781,17 @@ wop_trashmap/7F83172D557DAF92030933508E8C7CB4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0061.tga
+		map maps/wop_trashmap/lm_0061
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_western/metalrollup0026.tga
+		map textures/pad_western/metalrollup0026
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -803,17 +803,17 @@ wop_trashmap/308E909E431F66BAA58A608BAC77F3EA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0059.tga
+		map maps/wop_trashmap/lm_0059
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_western/metalrollup0026.tga
+		map textures/pad_western/metalrollup0026
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -825,17 +825,17 @@ wop_trashmap/028E56D118FB2801A372AF4E5D191441
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0041.tga
+		map maps/wop_trashmap/lm_0041
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_rand.tga
+		map textures/pad_trash/kb_pflaster_rand
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -847,17 +847,17 @@ wop_trashmap/1EF2C9762DF26AB658BBD2F52E7F9ED5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0009.tga
+		map maps/wop_trashmap/lm_0009
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -869,17 +869,17 @@ wop_trashmap/ED752B49A29A8FA67ECB7E19CC092C80
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -891,7 +891,7 @@ wop_trashmap/E4838EEC17D36C36D82F43B2C443C656
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -902,7 +902,7 @@ wop_trashmap/E4838EEC17D36C36D82F43B2C443C656
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -914,7 +914,7 @@ wop_trashmap/C2C4F9A665AF0A976FE4DAAF90277C6B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -925,7 +925,7 @@ wop_trashmap/C2C4F9A665AF0A976FE4DAAF90277C6B
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -937,10 +937,10 @@ wop_trashmap/687D744DD421434CBF61446346D65391
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0029.tga
+		map maps/wop_trashmap/lm_0029
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -948,7 +948,7 @@ wop_trashmap/687D744DD421434CBF61446346D65391
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -960,17 +960,17 @@ wop_trashmap/2D76E41D4491F3861AB7F6570AC8E2D7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0029.tga
+		map maps/wop_trashmap/lm_0029
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -982,17 +982,17 @@ wop_trashmap/4C140FFABA313143DD5CA9F9BA651A3D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0028.tga
+		map maps/wop_trashmap/lm_0028
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1004,7 +1004,7 @@ wop_trashmap/5F1535811F5D5B55B679B5F4726FA463
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -1015,7 +1015,7 @@ wop_trashmap/5F1535811F5D5B55B679B5F4726FA463
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1027,7 +1027,7 @@ wop_trashmap/A99E67C7280CCBA74E0EDDB0FD43B1BA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -1038,7 +1038,7 @@ wop_trashmap/A99E67C7280CCBA74E0EDDB0FD43B1BA
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1050,17 +1050,17 @@ wop_trashmap/BEEBC0502CCEE37131568CA7B03C07A4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_sockel.tga
+		map textures/pad_trash/kb_mauerwerk_sockel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1072,17 +1072,17 @@ wop_trashmap/3316F86910B9AEECF8F68AFF958E6C33
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1094,10 +1094,10 @@ wop_trashmap/21921152DD842779F9F091F7D5AD287F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0016.tga
+		map maps/wop_trashmap/lm_0016
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -1105,7 +1105,7 @@ wop_trashmap/21921152DD842779F9F091F7D5AD287F
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1117,17 +1117,17 @@ wop_trashmap/E669897485816964C01CAABBE8620E9D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0030.tga
+		map maps/wop_trashmap/lm_0030
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1139,17 +1139,17 @@ wop_trashmap/EA179465B6777EF43EE5569FE4B2D06D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0032.tga
+		map maps/wop_trashmap/lm_0032
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1161,17 +1161,17 @@ wop_trashmap/E9F1BE7B1CF3C887E5BEEFBF463C19FA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0033.tga
+		map maps/wop_trashmap/lm_0033
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1183,17 +1183,17 @@ wop_trashmap/365E154ACAF0827415D253A3FAB5E630
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0039.tga
+		map maps/wop_trashmap/lm_0039
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1205,17 +1205,17 @@ wop_trashmap/48CB66688773EB2BE188E1263855BCDF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0020.tga
+		map maps/wop_trashmap/lm_0020
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1227,17 +1227,17 @@ wop_trashmap/94A7DDC3C5B2C5A305028C7364897A81
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1249,10 +1249,10 @@ wop_trashmap/81D21B12CFD62A8876A100BA70194FA4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -1260,7 +1260,7 @@ wop_trashmap/81D21B12CFD62A8876A100BA70194FA4
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1272,10 +1272,10 @@ wop_trashmap/CBB789A6EFE7A5D767DFB86BBBDCF228
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -1283,7 +1283,7 @@ wop_trashmap/CBB789A6EFE7A5D767DFB86BBBDCF228
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1295,17 +1295,17 @@ wop_trashmap/494FC9FB49CAE85AC29DB3394D8F6A70
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1317,17 +1317,17 @@ wop_trashmap/12E9782617BA3AA4AD411640312F3050
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0041.tga
+		map maps/wop_trashmap/lm_0041
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_gross.tga
+		map textures/pad_trash/kb_pflaster_gross
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1339,17 +1339,17 @@ wop_trashmap/7223E27A88FB5B6B60E4D018273479AD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1361,17 +1361,17 @@ wop_trashmap/B459F502B47AECB2B4D86B1F48B8F07E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0044.tga
+		map maps/wop_trashmap/lm_0044
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1383,17 +1383,17 @@ wop_trashmap/AB2C513157F161B09428D4BA80AF7EBA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0047.tga
+		map maps/wop_trashmap/lm_0047
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1405,17 +1405,17 @@ wop_trashmap/2548FAEEC3CC5A9F5AF79789773D64C6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0053.tga
+		map maps/wop_trashmap/lm_0053
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1427,17 +1427,17 @@ wop_trashmap/EC04C2BB6110C0311C63EE31274BD4AD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1449,17 +1449,17 @@ wop_trashmap/66818CAFC3AB02E74F7BB48C5E588F01
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0041.tga
+		map maps/wop_trashmap/lm_0041
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1471,17 +1471,17 @@ wop_trashmap/3AFF556373E1A8B30C18B70468FF810C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0030.tga
+		map maps/wop_trashmap/lm_0030
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1493,17 +1493,17 @@ wop_trashmap/5701DDB9A98EE1776628F53B8BF8A342
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0045.tga
+		map maps/wop_trashmap/lm_0045
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1515,17 +1515,17 @@ wop_trashmap/F38CAA3AE6BD3DBCE0664C394BFC47F1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0056.tga
+		map maps/wop_trashmap/lm_0056
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1537,17 +1537,17 @@ wop_trashmap/900FA1A4ABAABAF0B0EC5AB486B42A41
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0010.tga
+		map maps/wop_trashmap/lm_0010
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1559,17 +1559,17 @@ wop_trashmap/338308BCAB92FE3D43FEADD2F6778420
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1581,17 +1581,17 @@ wop_trashmap/4F9AD84C7EC6A32614B1B8A1AD0A72B4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0018.tga
+		map maps/wop_trashmap/lm_0018
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1603,17 +1603,17 @@ wop_trashmap/6B1FEE16637CC4F3F8344472DC0BC45A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0038.tga
+		map maps/wop_trashmap/lm_0038
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1625,17 +1625,17 @@ wop_trashmap/51C49EF55953E4745736E6365DF6BD44
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0036.tga
+		map maps/wop_trashmap/lm_0036
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1647,17 +1647,17 @@ wop_trashmap/6A4E9ACC4C12127374A6267771991549
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0035.tga
+		map maps/wop_trashmap/lm_0035
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1669,17 +1669,17 @@ wop_trashmap/0FA52168DB2EB1EC3712AE240F55EF4E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0043.tga
+		map maps/wop_trashmap/lm_0043
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1691,17 +1691,17 @@ wop_trashmap/486C75F2F8752A1B55CB1FAEF41FD147
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0037.tga
+		map maps/wop_trashmap/lm_0037
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1713,17 +1713,17 @@ wop_trashmap/1D29863BA07B23548B71F4B3FD56C460
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0034.tga
+		map maps/wop_trashmap/lm_0034
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1735,17 +1735,17 @@ wop_trashmap/F91408F94A809F1B25FF7CF6676EBDDA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0040.tga
+		map maps/wop_trashmap/lm_0040
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1757,17 +1757,17 @@ wop_trashmap/6B375B7C4EF057EA9AE422B0CC66DC31
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0041.tga
+		map maps/wop_trashmap/lm_0041
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1779,17 +1779,17 @@ wop_trashmap/12F14AAA0312B5DB1C1D5B37E23ED048
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1801,17 +1801,17 @@ wop_trashmap/16FEE2586FA63094C31285FF748D15BC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0018.tga
+		map maps/wop_trashmap/lm_0018
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1823,17 +1823,17 @@ wop_trashmap/9526F1E8ED5BC080F70F4B6E1BEB97D5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0053.tga
+		map maps/wop_trashmap/lm_0053
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1845,10 +1845,10 @@ wop_trashmap/E432D50BBCE0B6B85000EF4ECBFFAB94
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -1856,7 +1856,7 @@ wop_trashmap/E432D50BBCE0B6B85000EF4ECBFFAB94
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1868,17 +1868,17 @@ wop_trashmap/EC412D2D530748F15820D64A5A27D566
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1890,17 +1890,17 @@ wop_trashmap/C6D298E02DBE7FBB7C2F1127BE08D5BF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0049.tga
+		map maps/wop_trashmap/lm_0049
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1912,10 +1912,10 @@ wop_trashmap/FD7E79F8F334564BFAB6B9D3FAA16760
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0046.tga
+		map maps/wop_trashmap/lm_0046
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -1923,7 +1923,7 @@ wop_trashmap/FD7E79F8F334564BFAB6B9D3FAA16760
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1935,17 +1935,17 @@ wop_trashmap/1E5428AF25C8683B4339206C29B6A344
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1957,17 +1957,17 @@ wop_trashmap/365E62162BCE025245178A3F09D19B38
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -1979,17 +1979,17 @@ wop_trashmap/0CA90F65664F4F7B40A2AD8EDAE1E60E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2001,17 +2001,17 @@ wop_trashmap/A9B7B7A764D091322044750DA2D4131E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0015.tga
+		map maps/wop_trashmap/lm_0015
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2023,17 +2023,17 @@ wop_trashmap/39CB3D8D2B203DBB831ED148ACB4008C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0021.tga
+		map maps/wop_trashmap/lm_0021
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2045,17 +2045,17 @@ wop_trashmap/0981EAAD08DB34187F3079FDB364C4F0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0013.tga
+		map maps/wop_trashmap/lm_0013
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2067,17 +2067,17 @@ wop_trashmap/9666B15A55B3DB35ACE2B6D22C0F1D17
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0018.tga
+		map maps/wop_trashmap/lm_0018
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2089,17 +2089,17 @@ wop_trashmap/F5856178581FC4C9F5F7A8A2E32457B0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0016.tga
+		map maps/wop_trashmap/lm_0016
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2111,17 +2111,17 @@ wop_trashmap/BC3FA47417576A39903BEEE3004FA3FE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2133,17 +2133,17 @@ wop_trashmap/8E1838191DF0DA43A82407ACA9AFD4B4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0020.tga
+		map maps/wop_trashmap/lm_0020
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2155,17 +2155,17 @@ wop_trashmap/68C40B21DC1958BFD66EC6B147778C0B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0028.tga
+		map maps/wop_trashmap/lm_0028
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2177,17 +2177,17 @@ wop_trashmap/F4EECA8E8961AE6AE311B4325BA975C1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0053.tga
+		map maps/wop_trashmap/lm_0053
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2199,17 +2199,17 @@ wop_trashmap/82FD5BC844C383C998976E3116CCAFAF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0024.tga
+		map maps/wop_trashmap/lm_0024
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2221,17 +2221,17 @@ wop_trashmap/6A4B38E851707E56224646BF6301CAFB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0025.tga
+		map maps/wop_trashmap/lm_0025
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2243,10 +2243,10 @@ wop_trashmap/BE1DD9F4378EECC3C08971C1E49688D6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0025.tga
+		map maps/wop_trashmap/lm_0025
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -2254,7 +2254,7 @@ wop_trashmap/BE1DD9F4378EECC3C08971C1E49688D6
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2266,17 +2266,17 @@ wop_trashmap/C85C973ACEFC72BB37980EC271B5F1E1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2288,10 +2288,10 @@ wop_trashmap/F145203D945FFBE464ACFFE1CC92C1F1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0025.tga
+		map maps/wop_trashmap/lm_0025
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -2299,7 +2299,7 @@ wop_trashmap/F145203D945FFBE464ACFFE1CC92C1F1
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2311,7 +2311,7 @@ wop_trashmap/5D9F53F3A2945798AE6D6677DD527704
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -2322,7 +2322,7 @@ wop_trashmap/5D9F53F3A2945798AE6D6677DD527704
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2334,10 +2334,10 @@ wop_trashmap/BA810E9BC29B3881044F1BC857E4B4A2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0024.tga
+		map maps/wop_trashmap/lm_0024
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -2345,7 +2345,7 @@ wop_trashmap/BA810E9BC29B3881044F1BC857E4B4A2
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2357,10 +2357,10 @@ wop_trashmap/3E619850A280B4815695CA0139CCE3AE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0025.tga
+		map maps/wop_trashmap/lm_0025
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -2368,7 +2368,7 @@ wop_trashmap/3E619850A280B4815695CA0139CCE3AE
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2380,10 +2380,10 @@ wop_trashmap/BE5F1AE42C2B6068618BEFD9ED18CC42
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0024.tga
+		map maps/wop_trashmap/lm_0024
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -2391,7 +2391,7 @@ wop_trashmap/BE5F1AE42C2B6068618BEFD9ED18CC42
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2403,10 +2403,10 @@ wop_trashmap/BEF3E204C0113CCEDE8F4E7CCE066760
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -2414,7 +2414,7 @@ wop_trashmap/BEF3E204C0113CCEDE8F4E7CCE066760
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2426,10 +2426,10 @@ wop_trashmap/5117DDBF1459AD845EC3868D6567B8CF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0024.tga
+		map maps/wop_trashmap/lm_0024
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -2437,7 +2437,7 @@ wop_trashmap/5117DDBF1459AD845EC3868D6567B8CF
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2449,17 +2449,17 @@ wop_trashmap/45BC7A08B1C5B5AD1966F4954F7A9035
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0041.tga
+		map maps/wop_trashmap/lm_0041
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2471,17 +2471,17 @@ wop_trashmap/65C30478FBC675322D6B632785FA77A2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0032.tga
+		map maps/wop_trashmap/lm_0032
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2493,17 +2493,17 @@ wop_trashmap/727414BF9C06FCCC2A67156E65610B5B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0046.tga
+		map maps/wop_trashmap/lm_0046
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2515,17 +2515,17 @@ wop_trashmap/C61C88A0586DA266BE667DC863ED0D5F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2537,17 +2537,17 @@ wop_trashmap/33063884E6503169F791FD781A6E09F4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0025.tga
+		map maps/wop_trashmap/lm_0025
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2559,17 +2559,17 @@ wop_trashmap/7EFC14D78B5CDC11748762FDC2E830A7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2581,17 +2581,17 @@ wop_trashmap/928E6AC87E9FA58DF01A5CEA5C7334BD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/gumkabel.tga
+		map textures/pad_garden/gumkabel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2603,17 +2603,17 @@ wop_trashmap/7D01695A4495E8AAB05266DD961C718E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/gumkabel.tga
+		map textures/pad_garden/gumkabel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2625,17 +2625,17 @@ wop_trashmap/C77548BC361631D8C60DDD676A2B04CF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2647,17 +2647,17 @@ wop_trashmap/343C9D2515CA088AB36C3645485B3E91
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_teelicht_side.tga
+		map textures/pad_trash/kb_teelicht_side
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2669,17 +2669,17 @@ wop_trashmap/55542BD9A42B84904368C5A5FA16F8AF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_teelicht_side.tga
+		map textures/pad_trash/kb_teelicht_side
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2691,17 +2691,17 @@ wop_trashmap/96A5C3E06179E308DF02513BC1A0DF46
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0013.tga
+		map maps/wop_trashmap/lm_0013
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_pipes1.tga
+		map textures/pad_jail/pad_jail_pipes1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2713,17 +2713,17 @@ wop_trashmap/8C283D1011D27227EB52AAD34F6F4345
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0006.tga
+		map maps/wop_trashmap/lm_0006
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_gfx02/git04.tga
+		map textures/pad_gfx02/git04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2735,17 +2735,17 @@ wop_trashmap/EC24598BFC4D88D347DC2E0B30E2CEFB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0014.tga
+		map maps/wop_trashmap/lm_0014
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_pipes1.tga
+		map textures/pad_jail/pad_jail_pipes1
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2757,17 +2757,17 @@ wop_trashmap/E05F086960185B13705E2E726E1F64C4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2779,17 +2779,17 @@ wop_trashmap/7AA9F7DCC9FD69016BC9EBF60A9DFD6E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0014.tga
+		map maps/wop_trashmap/lm_0014
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_tex/col06b.tga
+		map textures/pad_tex/col06b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2801,17 +2801,17 @@ wop_trashmap/D36519F1089C064821572430CAB44830
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0013.tga
+		map maps/wop_trashmap/lm_0013
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_tex/col06b.tga
+		map textures/pad_tex/col06b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2823,17 +2823,17 @@ wop_trashmap/3F4D62DD6A6D08EECBC8CFEE81A933D7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2845,7 +2845,7 @@ wop_trashmap/56C5304881452D6387EA638BF365DC13
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -2856,7 +2856,7 @@ wop_trashmap/56C5304881452D6387EA638BF365DC13
 	}
 
 	{
-		map textures/pad_garden/gumkabel.tga
+		map textures/pad_garden/gumkabel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2868,17 +2868,17 @@ wop_trashmap/28FBA4CF1E3C3E9CE18D5743D75CB39A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/gumkabel.tga
+		map textures/pad_garden/gumkabel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2890,17 +2890,17 @@ wop_trashmap/158863E930E231F5843E80C4EDA289F8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0047.tga
+		map maps/wop_trashmap/lm_0047
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2912,17 +2912,17 @@ wop_trashmap/8E3B365BA984F770C107798F127DD686
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0044.tga
+		map maps/wop_trashmap/lm_0044
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2934,17 +2934,17 @@ wop_trashmap/0D70F4DD3B84E90CBC65D39D4EE66D90
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2956,17 +2956,17 @@ wop_trashmap/57BFD349CFCAEB4FDCF1B9DC8C7743F2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -2978,17 +2978,17 @@ wop_trashmap/ACA76B70A12BE78CA134F63C6CA0B21C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0053.tga
+		map maps/wop_trashmap/lm_0053
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3000,17 +3000,17 @@ wop_trashmap/B85ED63F7F1463CE126C0138052592F1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3022,17 +3022,17 @@ wop_trashmap/7F74AA81B43F28F617BA0CECD58C9400
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0046.tga
+		map maps/wop_trashmap/lm_0046
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3044,17 +3044,17 @@ wop_trashmap/C44211B13A5E6BEE18BAF7D865430FE4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0063.tga
+		map maps/wop_trashmap/lm_0063
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3066,17 +3066,17 @@ wop_trashmap/7EBF4CF9C7FF11180AB893C6BD0F8F97
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0049.tga
+		map maps/wop_trashmap/lm_0049
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3088,17 +3088,17 @@ wop_trashmap/3168DD5A88B85776D2762AD6A7BF69B9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3110,17 +3110,17 @@ wop_trashmap/C5671DA50C2A92EA4A2561D4FC9D52E6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3132,17 +3132,17 @@ wop_trashmap/3223010581D5572F6E01DAE7E7243509
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_basket_metal.tga
+		map textures/pad_jail/pad_jail_basket_metal
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3154,17 +3154,17 @@ wop_trashmap/25027646735B3362DE54004840EEBDD3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3176,17 +3176,17 @@ wop_trashmap/DF64C4811980479E569FE9D920CF8A2F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0006.tga
+		map maps/wop_trashmap/lm_0006
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3198,17 +3198,17 @@ wop_trashmap/B15ED899C6710AB1380C2A09CAB4C576
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0011.tga
+		map maps/wop_trashmap/lm_0011
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3220,17 +3220,17 @@ wop_trashmap/DFC1BAE2C67D8280DCDDE41D0D0B455E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3242,17 +3242,17 @@ wop_trashmap/DF67A0244BB8D41461D81A21D1A64B5D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0007.tga
+		map maps/wop_trashmap/lm_0007
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3264,17 +3264,17 @@ wop_trashmap/7A271004DBAD063C8B8DECDA7981037A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3286,17 +3286,17 @@ wop_trashmap/E5E36E6F435864AD5F4A3A47CA03D52C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0010.tga
+		map maps/wop_trashmap/lm_0010
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3308,17 +3308,17 @@ wop_trashmap/09900660F2015133663A0B172F0C417C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0036.tga
+		map maps/wop_trashmap/lm_0036
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3330,17 +3330,17 @@ wop_trashmap/29628BE0C4B94E7E7D3F1F432010AC49
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0037.tga
+		map maps/wop_trashmap/lm_0037
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3352,17 +3352,17 @@ wop_trashmap/9E196705AA977AAA9A80C6E86234C822
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0034.tga
+		map maps/wop_trashmap/lm_0034
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3374,17 +3374,17 @@ wop_trashmap/DBA803B52B3D486475B1629DC58C08FF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_attic/besen02.tga
+		map textures/pad_attic/besen02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3396,7 +3396,7 @@ wop_trashmap/87B895662C037CA141A8170BF47005CB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -3407,7 +3407,7 @@ wop_trashmap/87B895662C037CA141A8170BF47005CB
 	}
 
 	{
-		map textures/pad_attic/besen01.tga
+		map textures/pad_attic/besen01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3419,10 +3419,10 @@ wop_trashmap/08E8394BBD6C1DA51EB1E7963C3C6201
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -3430,7 +3430,7 @@ wop_trashmap/08E8394BBD6C1DA51EB1E7963C3C6201
 	}
 
 	{
-		map textures/pad_attic/besen01.tga
+		map textures/pad_attic/besen01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3442,10 +3442,10 @@ wop_trashmap/DC2DB3BED9733CAF5DE9A85BAE6ED0C7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -3453,7 +3453,7 @@ wop_trashmap/DC2DB3BED9733CAF5DE9A85BAE6ED0C7
 	}
 
 	{
-		map textures/pad_attic/besen01.tga
+		map textures/pad_attic/besen01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3465,7 +3465,7 @@ wop_trashmap/39C3A710ED2BE20D86DF33D1252DA7B9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -3476,7 +3476,7 @@ wop_trashmap/39C3A710ED2BE20D86DF33D1252DA7B9
 	}
 
 	{
-		map textures/pad_attic/besen01.tga
+		map textures/pad_attic/besen01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3488,7 +3488,7 @@ wop_trashmap/5035AE016C7AB81243D896157432C8D5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -3499,7 +3499,7 @@ wop_trashmap/5035AE016C7AB81243D896157432C8D5
 	}
 
 	{
-		map textures/pad_attic/besen01.tga
+		map textures/pad_attic/besen01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3511,17 +3511,17 @@ wop_trashmap/4353A72EE8224B2C2EF8F197675D1A73
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0058.tga
+		map maps/wop_trashmap/lm_0058
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_plakat.tga
+		map textures/pad_trash/kb_plakat
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3533,17 +3533,17 @@ wop_trashmap/0ECA290CFB83D68465E0AE8870CF691A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3555,10 +3555,10 @@ wop_trashmap/E627714553539954AD92FA8EE77302C9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -3566,7 +3566,7 @@ wop_trashmap/E627714553539954AD92FA8EE77302C9
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3578,17 +3578,17 @@ wop_trashmap/9BA304F888B563746EE5F83B0227FF0C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3600,17 +3600,17 @@ wop_trashmap/439AC075E1DC26D1B63112DC71DF8C9B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3622,7 +3622,7 @@ wop_trashmap/ACFB3A38FE143B5F8D89F708BE93C3A9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -3633,7 +3633,7 @@ wop_trashmap/ACFB3A38FE143B5F8D89F708BE93C3A9
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3645,10 +3645,10 @@ wop_trashmap/5D86C61EEFA9CA1BC38B81DB9443854E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -3656,7 +3656,7 @@ wop_trashmap/5D86C61EEFA9CA1BC38B81DB9443854E
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3668,17 +3668,17 @@ wop_trashmap/3ED6125040C1C92DFC99D8E8FECE5925
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_door/door13.tga
+		map textures/pad_door/door13
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3690,17 +3690,17 @@ wop_trashmap/3EF993515737DDA95C729CFE2ADC6E72
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0009.tga
+		map maps/wop_trashmap/lm_0009
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_gfx02/git04.tga
+		map textures/pad_gfx02/git04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3712,17 +3712,17 @@ wop_trashmap/0740E36F2830F319BEA308B988485CB0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0010.tga
+		map maps/wop_trashmap/lm_0010
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_gfx02/git04.tga
+		map textures/pad_gfx02/git04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3734,17 +3734,17 @@ wop_trashmap/3807C3407B51B251EBCC8E4E69E2217D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_fountain/wall_04b.tga
+		map textures/pad_fountain/wall_04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3756,17 +3756,17 @@ wop_trashmap/DA2D041EB7D0F623DFA6EEFB06EB598E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_fountain/wall_04b.tga
+		map textures/pad_fountain/wall_04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3778,10 +3778,10 @@ wop_trashmap/B431EF7264CD8867C0D67EA3FD41F030
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0002.tga
+		map maps/wop_trashmap/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -3789,7 +3789,7 @@ wop_trashmap/B431EF7264CD8867C0D67EA3FD41F030
 	}
 
 	{
-		map textures/pad_fountain/wall_04b.tga
+		map textures/pad_fountain/wall_04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3801,17 +3801,17 @@ wop_trashmap/7B8AA4A45EB4D19B4CBA09ECC93BB3D4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz_red.tga
+		map textures/pad_trash/kb_rauhputz_red
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3823,17 +3823,17 @@ wop_trashmap/C058CB1490DC0A7D9BDDB1A8A1F862F8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0013.tga
+		map maps/wop_trashmap/lm_0013
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_metal10_keyhole.tga
+		map textures/pad_jail/pad_jail_metal10_keyhole
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3845,17 +3845,17 @@ wop_trashmap/CD075A0CCFF7D204DB601F0D22EDBA6A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_sign_06.tga
+		map textures/pad_trash/kb_sign_06
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3867,17 +3867,17 @@ wop_trashmap/A98A08FBA43F70987586FA6C3E7DE8E6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_mittel.tga
+		map textures/pad_trash/kb_pflaster_mittel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3889,17 +3889,17 @@ wop_trashmap/AB972CC019760111957C7CB96F1B065F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0045.tga
+		map maps/wop_trashmap/lm_0045
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3911,17 +3911,17 @@ wop_trashmap/B2CD72348BD2E56F850529C3096F36C1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0044.tga
+		map maps/wop_trashmap/lm_0044
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3933,17 +3933,17 @@ wop_trashmap/B95BB7F7A98419D6625C760773E01251
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0069.tga
+		map maps/wop_trashmap/lm_0069
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3955,17 +3955,17 @@ wop_trashmap/90C45A211731DD748DD97E9380D62F5E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0068.tga
+		map maps/wop_trashmap/lm_0068
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3977,17 +3977,17 @@ wop_trashmap/E343091849AACEFFFA477D2E210CAED4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0059.tga
+		map maps/wop_trashmap/lm_0059
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -3999,17 +3999,17 @@ wop_trashmap/4A7D2E802C100644F662D3443ABE5435
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0063.tga
+		map maps/wop_trashmap/lm_0063
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4021,10 +4021,10 @@ wop_trashmap/4939C05E94141E6FAC7CBEEC56C4D0C2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -4032,7 +4032,7 @@ wop_trashmap/4939C05E94141E6FAC7CBEEC56C4D0C2
 	}
 
 	{
-		map textures/pad_trash/kb_schachtdeckel.tga
+		map textures/pad_trash/kb_schachtdeckel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4044,17 +4044,17 @@ wop_trashmap/F402C01D96915DFF10B7532888EF34F5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0076.tga
+		map maps/wop_trashmap/lm_0076
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_western/metalrollup0026.tga
+		map textures/pad_western/metalrollup0026
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4066,17 +4066,17 @@ wop_trashmap/789B894244551E3F65178909BB4263E6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0080.tga
+		map maps/wop_trashmap/lm_0080
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_western/metalrollup0026.tga
+		map textures/pad_western/metalrollup0026
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4088,17 +4088,17 @@ wop_trashmap/D850CAFF03A4C163F99D29A4C42808CC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0078.tga
+		map maps/wop_trashmap/lm_0078
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_western/metalrollup0026.tga
+		map textures/pad_western/metalrollup0026
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4110,17 +4110,17 @@ wop_trashmap/0387C7CE9A8D62B5786E65F50ED7D876
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_rand.tga
+		map textures/pad_trash/kb_pflaster_rand
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4132,17 +4132,17 @@ wop_trashmap/162ABED5788D10C08039E79C9380D96E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0011.tga
+		map maps/wop_trashmap/lm_0011
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4154,7 +4154,7 @@ wop_trashmap/AF99AC8928C853E555ACF947588BC195
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -4165,7 +4165,7 @@ wop_trashmap/AF99AC8928C853E555ACF947588BC195
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4177,17 +4177,17 @@ wop_trashmap/A5544270BDA7FE0352C3106C181083A5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0040.tga
+		map maps/wop_trashmap/lm_0040
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4199,17 +4199,17 @@ wop_trashmap/CCCDFB582581A504BF890B595F700DE8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0041.tga
+		map maps/wop_trashmap/lm_0041
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4221,17 +4221,17 @@ wop_trashmap/1B04C8E9BAA7886A8E6AE7F33A57E02B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0038.tga
+		map maps/wop_trashmap/lm_0038
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4243,17 +4243,17 @@ wop_trashmap/5B371D142119C6D7C5B4CA1EA95C4284
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0036.tga
+		map maps/wop_trashmap/lm_0036
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4265,17 +4265,17 @@ wop_trashmap/9F03DDAEBE9688B14B3293587E589084
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0037.tga
+		map maps/wop_trashmap/lm_0037
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4287,17 +4287,17 @@ wop_trashmap/CFE0B3CDB3F73B5CCAA4E4CB880C435E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0040.tga
+		map maps/wop_trashmap/lm_0040
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_sockel.tga
+		map textures/pad_trash/kb_mauerwerk_sockel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4309,17 +4309,17 @@ wop_trashmap/60AA2CE401BE887A1026B589316DECCE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0040.tga
+		map maps/wop_trashmap/lm_0040
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4331,17 +4331,17 @@ wop_trashmap/31CE11B31045872F4519260C4FE66E3A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0044.tga
+		map maps/wop_trashmap/lm_0044
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4353,17 +4353,17 @@ wop_trashmap/4DFBCB9831A5095C397CBF0687E9CFD4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0041.tga
+		map maps/wop_trashmap/lm_0041
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4375,17 +4375,17 @@ wop_trashmap/EBB4E30E0EC0C8942CF0455608598106
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0037.tga
+		map maps/wop_trashmap/lm_0037
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4397,17 +4397,17 @@ wop_trashmap/F2FDF6634FD0DB3AAB90368D5924002A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0045.tga
+		map maps/wop_trashmap/lm_0045
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4419,17 +4419,17 @@ wop_trashmap/B267FB958ADE6279CA7956B2018981D1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4441,17 +4441,17 @@ wop_trashmap/B8E60A3C98EBD840CFA4B1C6E5C2F498
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0038.tga
+		map maps/wop_trashmap/lm_0038
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4463,17 +4463,17 @@ wop_trashmap/644777D0C52D217B1568BE77CB6D822C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0029.tga
+		map maps/wop_trashmap/lm_0029
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4485,17 +4485,17 @@ wop_trashmap/9A97140CA0C59F1661623EF3DE6C2AF8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0049.tga
+		map maps/wop_trashmap/lm_0049
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4507,7 +4507,7 @@ wop_trashmap/67E25AEB4C9BCA4BA028694F973489EE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -4518,7 +4518,7 @@ wop_trashmap/67E25AEB4C9BCA4BA028694F973489EE
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4530,7 +4530,7 @@ wop_trashmap/2FAA383EBC301B25F12E55EA16923E24
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -4541,7 +4541,7 @@ wop_trashmap/2FAA383EBC301B25F12E55EA16923E24
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4553,17 +4553,17 @@ wop_trashmap/A1EDCB4BFA6D29F8CB23464064E7DB0E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0007.tga
+		map maps/wop_trashmap/lm_0007
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4575,17 +4575,17 @@ wop_trashmap/37C82B60B2C06A85B4BE0C70C0101E65
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4597,17 +4597,17 @@ wop_trashmap/EDFB4A5C05B1329F6C74ABA5CAAE47A2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0006.tga
+		map maps/wop_trashmap/lm_0006
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4619,17 +4619,17 @@ wop_trashmap/1076209EB07B68761995D679BD81B259
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4641,17 +4641,17 @@ wop_trashmap/596C00DDDD1F522C6AAB530FA275193E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0002.tga
+		map maps/wop_trashmap/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4663,10 +4663,10 @@ wop_trashmap/F232E6A4CB7378269D742E87E18E620D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0002.tga
+		map maps/wop_trashmap/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -4674,7 +4674,7 @@ wop_trashmap/F232E6A4CB7378269D742E87E18E620D
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4686,10 +4686,10 @@ wop_trashmap/3369F7FF65C1D0836C36BA306F32B980
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -4697,7 +4697,7 @@ wop_trashmap/3369F7FF65C1D0836C36BA306F32B980
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4709,17 +4709,17 @@ wop_trashmap/7BB27BCD089A2AA7401FBDA9A9F494C2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_01.tga
+		map textures/pad_trash/kb_mauerwerk_01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4731,17 +4731,17 @@ wop_trashmap/88C7AEF04F5BFF3F192C65F204CD77C1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0047.tga
+		map maps/wop_trashmap/lm_0047
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_01.tga
+		map textures/pad_trash/kb_mauerwerk_01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4753,17 +4753,17 @@ wop_trashmap/1C9BAFDBE4CDD7B7176A674CC11CBA54
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0049.tga
+		map maps/wop_trashmap/lm_0049
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_01.tga
+		map textures/pad_trash/kb_mauerwerk_01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4775,17 +4775,17 @@ wop_trashmap/F5D92FC94216275617CEF99D5A9955DA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0029.tga
+		map maps/wop_trashmap/lm_0029
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4797,17 +4797,17 @@ wop_trashmap/6690ACC166857E30F8E99064F553F3F7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0028.tga
+		map maps/wop_trashmap/lm_0028
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4819,17 +4819,17 @@ wop_trashmap/4E364DEE9A49B85C63A6FA327ACB8341
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0027.tga
+		map maps/wop_trashmap/lm_0027
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4841,17 +4841,17 @@ wop_trashmap/5618DAD39C72B58D63216D1CBB8BF59D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_gross.tga
+		map textures/pad_trash/kb_pflaster_gross
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4863,17 +4863,17 @@ wop_trashmap/115627A3C615333B93557D87BC827D4C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0015.tga
+		map maps/wop_trashmap/lm_0015
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart04b.tga
+		map textures/pad_objects/cart04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4885,10 +4885,10 @@ wop_trashmap/B54EE508B9667E92A7CF0E0F293B9CE7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0015.tga
+		map maps/wop_trashmap/lm_0015
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -4896,7 +4896,7 @@ wop_trashmap/B54EE508B9667E92A7CF0E0F293B9CE7
 	}
 
 	{
-		map textures/pad_objects/cart05.tga
+		map textures/pad_objects/cart05
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4908,17 +4908,17 @@ wop_trashmap/CF073D75E70B2D691007C79DF0C3DCB3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0015.tga
+		map maps/wop_trashmap/lm_0015
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart04c.tga
+		map textures/pad_objects/cart04c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4930,17 +4930,17 @@ wop_trashmap/3308CD9204CE913A91575C741C442633
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0015.tga
+		map maps/wop_trashmap/lm_0015
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart10c.tga
+		map textures/pad_objects/cart10c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4952,17 +4952,17 @@ wop_trashmap/CD1B1AA1D388FB8113F45FD3156A1B96
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0015.tga
+		map maps/wop_trashmap/lm_0015
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart12c.tga
+		map textures/pad_objects/cart12c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4974,7 +4974,7 @@ wop_trashmap/F77170B67129BBFA83E5C7A53CF5E506
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -4985,7 +4985,7 @@ wop_trashmap/F77170B67129BBFA83E5C7A53CF5E506
 	}
 
 	{
-		map textures/pad_objects/cart12c.tga
+		map textures/pad_objects/cart12c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -4997,10 +4997,10 @@ wop_trashmap/160A13A1CD167AD4E65ED078B9E3E011
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0071.tga
+		map maps/wop_trashmap/lm_0071
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -5008,7 +5008,7 @@ wop_trashmap/160A13A1CD167AD4E65ED078B9E3E011
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5020,7 +5020,7 @@ wop_trashmap/EBC075D8FEA52F7A36FA6D26A18E00A9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -5031,7 +5031,7 @@ wop_trashmap/EBC075D8FEA52F7A36FA6D26A18E00A9
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5043,17 +5043,17 @@ wop_trashmap/6A2759D286CE7B202CC93AF7E5F2EE8F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0041.tga
+		map maps/wop_trashmap/lm_0041
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5065,17 +5065,17 @@ wop_trashmap/C9135FA1DAA720F414EFDD4585B37CA7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0059.tga
+		map maps/wop_trashmap/lm_0059
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5087,10 +5087,10 @@ wop_trashmap/C3D5BA9ED69B2C1342F0A2C26CDE7080
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -5098,7 +5098,7 @@ wop_trashmap/C3D5BA9ED69B2C1342F0A2C26CDE7080
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5110,17 +5110,17 @@ wop_trashmap/F4407D4603DFE7F2ECE2ADFB36856271
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0066.tga
+		map maps/wop_trashmap/lm_0066
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5132,17 +5132,17 @@ wop_trashmap/9B108D3F82522BBE89FD282ECEAAFDE7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0007.tga
+		map maps/wop_trashmap/lm_0007
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5154,17 +5154,17 @@ wop_trashmap/47303ABDF9B26C255B3CC0E2DC6F8B87
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0062.tga
+		map maps/wop_trashmap/lm_0062
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5176,17 +5176,17 @@ wop_trashmap/FBCF10C538D5727F021F4B3525C984B8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0045.tga
+		map maps/wop_trashmap/lm_0045
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5198,17 +5198,17 @@ wop_trashmap/5EAAD5FE69E9022FB9C5A4CCA9641186
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0060.tga
+		map maps/wop_trashmap/lm_0060
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5220,17 +5220,17 @@ wop_trashmap/3C1C482F0F46F04F9E6E374AF947B51F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5242,17 +5242,17 @@ wop_trashmap/A23F83B7E4C817C5E4B3D7AA5988C573
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5264,17 +5264,17 @@ wop_trashmap/8D538954FE2028586A15360EECD2B08A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0053.tga
+		map maps/wop_trashmap/lm_0053
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5286,17 +5286,17 @@ wop_trashmap/EB586BEAE93A6F501C8D6FD2AF9A52EA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5308,17 +5308,17 @@ wop_trashmap/40EA164CAF9D65F11D3C1EBD296EA3D9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0040.tga
+		map maps/wop_trashmap/lm_0040
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5330,17 +5330,17 @@ wop_trashmap/1DCB98CFDE96A157B718BF8F846B818B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0034.tga
+		map maps/wop_trashmap/lm_0034
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5352,17 +5352,17 @@ wop_trashmap/52291F3A735F5E9314ABF7BD72F1C00A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0035.tga
+		map maps/wop_trashmap/lm_0035
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5374,17 +5374,17 @@ wop_trashmap/B832D9938DF679166C766594721503C7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0063.tga
+		map maps/wop_trashmap/lm_0063
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5396,17 +5396,17 @@ wop_trashmap/9B216E3FC08EF36A4E8F1BCCEBAF5FF9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0064.tga
+		map maps/wop_trashmap/lm_0064
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5418,17 +5418,17 @@ wop_trashmap/FE7D1548809F02A05BCDD0582E7212C7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0053.tga
+		map maps/wop_trashmap/lm_0053
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5440,17 +5440,17 @@ wop_trashmap/486B9C6D2B56E795F9E53693F4F5A46E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0069.tga
+		map maps/wop_trashmap/lm_0069
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5462,17 +5462,17 @@ wop_trashmap/42D78335E70C380917989370FC58AF13
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0068.tga
+		map maps/wop_trashmap/lm_0068
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5484,17 +5484,17 @@ wop_trashmap/5BD6ADC9951C084F518F841DA6055B5C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0064.tga
+		map maps/wop_trashmap/lm_0064
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5506,17 +5506,17 @@ wop_trashmap/415DE0904A19B7482B272FD2744CB66B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0046.tga
+		map maps/wop_trashmap/lm_0046
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5528,17 +5528,17 @@ wop_trashmap/29C0F630BA5CD6E0C95FCA08F39A0968
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0058.tga
+		map maps/wop_trashmap/lm_0058
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5550,17 +5550,17 @@ wop_trashmap/4B863A924ABB42758C8FC356C63FC034
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0059.tga
+		map maps/wop_trashmap/lm_0059
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5572,17 +5572,17 @@ wop_trashmap/A44D39524D7FD8919C27ACA6569B6A8B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0074.tga
+		map maps/wop_trashmap/lm_0074
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5594,17 +5594,17 @@ wop_trashmap/DA2079CA22544C9267FDD1A56570B662
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0066.tga
+		map maps/wop_trashmap/lm_0066
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5616,17 +5616,17 @@ wop_trashmap/781CFBB6B5087E16CDB16777DCC76A4B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0015.tga
+		map maps/wop_trashmap/lm_0015
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5638,17 +5638,17 @@ wop_trashmap/E9A5597FE7D10740DB1679B836233010
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0060.tga
+		map maps/wop_trashmap/lm_0060
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5660,17 +5660,17 @@ wop_trashmap/E151229209BB23007615C3E4B804891F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5682,17 +5682,17 @@ wop_trashmap/8CE2DEE49C3D94AD941F17A14185C8B3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0053.tga
+		map maps/wop_trashmap/lm_0053
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5704,17 +5704,17 @@ wop_trashmap/DA46E3A14A6DC7EF50C19C09D9FFDFEB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0059.tga
+		map maps/wop_trashmap/lm_0059
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5726,17 +5726,17 @@ wop_trashmap/28E5EC75635530C2DDEEF313425E8CD2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0063.tga
+		map maps/wop_trashmap/lm_0063
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5748,17 +5748,17 @@ wop_trashmap/3DADBF9CB3C1A0AEA8E2DDC225383031
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0049.tga
+		map maps/wop_trashmap/lm_0049
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5770,17 +5770,17 @@ wop_trashmap/147E173FE9EA825CB47BA5426FC9FD14
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0064.tga
+		map maps/wop_trashmap/lm_0064
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5792,17 +5792,17 @@ wop_trashmap/3CDCB1252DD121A0492B2E4E906C10D8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0043.tga
+		map maps/wop_trashmap/lm_0043
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5814,17 +5814,17 @@ wop_trashmap/23C86D6D2EB5A4A713DD4E0FC8C8262E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5836,10 +5836,10 @@ wop_trashmap/E0D301A8691353C57615F6C11FA1B476
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -5847,7 +5847,7 @@ wop_trashmap/E0D301A8691353C57615F6C11FA1B476
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5859,17 +5859,17 @@ wop_trashmap/59CB13F7FBC826C6CA6572B048725C0C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0069.tga
+		map maps/wop_trashmap/lm_0069
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5881,17 +5881,17 @@ wop_trashmap/97717CFABB7FEF441D9C3610E3F8443C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0068.tga
+		map maps/wop_trashmap/lm_0068
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5903,17 +5903,17 @@ wop_trashmap/052807621D8F15EBD6565537BD41A837
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0071.tga
+		map maps/wop_trashmap/lm_0071
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5925,17 +5925,17 @@ wop_trashmap/F0D001D12DCEBDCE7885859509FFB1B2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0070.tga
+		map maps/wop_trashmap/lm_0070
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5947,17 +5947,17 @@ wop_trashmap/C20CFE2F0E46557FAF989B8D774EB890
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5969,17 +5969,17 @@ wop_trashmap/5E5C1455889B7BEB6C0A2AF84A0C4BC1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0022.tga
+		map maps/wop_trashmap/lm_0022
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -5991,17 +5991,17 @@ wop_trashmap/6AC907128E81D8A193F84F6EBC505434
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0053.tga
+		map maps/wop_trashmap/lm_0053
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6013,17 +6013,17 @@ wop_trashmap/87B62B9433A729C3ADF07AE4F87D720C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0045.tga
+		map maps/wop_trashmap/lm_0045
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6035,17 +6035,17 @@ wop_trashmap/8F5F9457BA4B084EC22910BFA041ADB0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6057,17 +6057,17 @@ wop_trashmap/CB7971C8BA8E57438DD0C1149656FB8E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0047.tga
+		map maps/wop_trashmap/lm_0047
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6079,17 +6079,17 @@ wop_trashmap/39C534BB1D39965247CA5BC43E8D6632
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0049.tga
+		map maps/wop_trashmap/lm_0049
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6101,17 +6101,17 @@ wop_trashmap/7B32EBB42DA159A7EB4196893DE5D9D0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0042.tga
+		map maps/wop_trashmap/lm_0042
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6123,17 +6123,17 @@ wop_trashmap/BC5221ED0B5EE61D9AB0246AF10AD22D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6145,17 +6145,17 @@ wop_trashmap/F115C02D445B1C7805B55F13A4BA4747
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0044.tga
+		map maps/wop_trashmap/lm_0044
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6167,17 +6167,17 @@ wop_trashmap/EE4719646DB047D3B8D48D23642070A4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6189,17 +6189,17 @@ wop_trashmap/5D693C2A2A9930ECF21B04EDBE7627BB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6211,17 +6211,17 @@ wop_trashmap/40DFCC47124FBCBBA6518783E3E12907
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0046.tga
+		map maps/wop_trashmap/lm_0046
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6233,17 +6233,17 @@ wop_trashmap/9DB8A11E738E702E7508C15D12C01250
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6255,17 +6255,17 @@ wop_trashmap/50F2A5ECE068C5D2A7AAB13897F7260F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6277,17 +6277,17 @@ wop_trashmap/19E4001A244CBEDB04D3644BE8B66538
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6299,17 +6299,17 @@ wop_trashmap/190C6AEBDF2843F4839C270C97D09573
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6321,10 +6321,10 @@ wop_trashmap/ADC3D28D7869CDEF70DE015AAB7CD6CD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -6332,7 +6332,7 @@ wop_trashmap/ADC3D28D7869CDEF70DE015AAB7CD6CD
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6344,17 +6344,17 @@ wop_trashmap/A87DF018D33555889AADD615A045B297
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0007.tga
+		map maps/wop_trashmap/lm_0007
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6366,17 +6366,17 @@ wop_trashmap/87C5486FAECBEB8D41160A568DCE0B6D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0022.tga
+		map maps/wop_trashmap/lm_0022
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6388,17 +6388,17 @@ wop_trashmap/FB40EAD5E610AD3A607572A8064C2221
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0068.tga
+		map maps/wop_trashmap/lm_0068
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6410,17 +6410,17 @@ wop_trashmap/657C00C25F03226D01E2F8B690A0B2D9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0067.tga
+		map maps/wop_trashmap/lm_0067
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6432,17 +6432,17 @@ wop_trashmap/4A1E63D0D3A7D33AD09973D3770CD73D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0069.tga
+		map maps/wop_trashmap/lm_0069
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6454,17 +6454,17 @@ wop_trashmap/EA1F813867D7D4968D6C20AE01ACF7A3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0064.tga
+		map maps/wop_trashmap/lm_0064
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6476,17 +6476,17 @@ wop_trashmap/75A97575D53B0C296E4F4E5B1A1D6A97
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0058.tga
+		map maps/wop_trashmap/lm_0058
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6498,17 +6498,17 @@ wop_trashmap/9E23D6489F3D793F6F1DB86D8E041DC8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0062.tga
+		map maps/wop_trashmap/lm_0062
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6520,17 +6520,17 @@ wop_trashmap/1BA600499A3C058F0A06B8C3536143CD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0070.tga
+		map maps/wop_trashmap/lm_0070
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6542,17 +6542,17 @@ wop_trashmap/6B61CDB023090FD177DEA950C86C977F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6564,17 +6564,17 @@ wop_trashmap/ED906303FB7ECE8DF898677F443ACA81
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6586,17 +6586,17 @@ wop_trashmap/808250DABECC7F751C4FEF4CE4846FB1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6608,17 +6608,17 @@ wop_trashmap/A5BB532B4840A3719FBE174928C47FF1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0059.tga
+		map maps/wop_trashmap/lm_0059
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6630,17 +6630,17 @@ wop_trashmap/19A662F73B4D8C35365C60748C2DB7A3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6652,17 +6652,17 @@ wop_trashmap/C590DD6A908EDC67612F6555680E8FC8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0019.tga
+		map maps/wop_trashmap/lm_0019
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6674,17 +6674,17 @@ wop_trashmap/B3521E538099A3F198E811F67E28BEC3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0022.tga
+		map maps/wop_trashmap/lm_0022
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6696,10 +6696,10 @@ wop_trashmap/C26FACF8145B461DF0026116EE8493E1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0021.tga
+		map maps/wop_trashmap/lm_0021
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -6707,7 +6707,7 @@ wop_trashmap/C26FACF8145B461DF0026116EE8493E1
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6719,17 +6719,17 @@ wop_trashmap/D04F7C7E7252F06634421B5AA8C7C453
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0017.tga
+		map maps/wop_trashmap/lm_0017
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6741,10 +6741,10 @@ wop_trashmap/B84F16EA52EBD01605F6C3FCAAE87F28
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0019.tga
+		map maps/wop_trashmap/lm_0019
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -6752,7 +6752,7 @@ wop_trashmap/B84F16EA52EBD01605F6C3FCAAE87F28
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6764,7 +6764,7 @@ wop_trashmap/C0E60AE72C4CEB55137FF9E16F0D460F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -6775,7 +6775,7 @@ wop_trashmap/C0E60AE72C4CEB55137FF9E16F0D460F
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6787,17 +6787,17 @@ wop_trashmap/074DA06B48FA51A2C8312A85997800FD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6809,17 +6809,17 @@ wop_trashmap/8C76ADF7291EF7390D62250E0CF64607
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0006.tga
+		map maps/wop_trashmap/lm_0006
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6831,10 +6831,10 @@ wop_trashmap/0AA825E663E460688EDF5514679A4882
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0018.tga
+		map maps/wop_trashmap/lm_0018
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -6842,7 +6842,7 @@ wop_trashmap/0AA825E663E460688EDF5514679A4882
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6854,10 +6854,10 @@ wop_trashmap/1901BAE46B570BF6A84A2D18DC67D840
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0020.tga
+		map maps/wop_trashmap/lm_0020
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -6865,7 +6865,7 @@ wop_trashmap/1901BAE46B570BF6A84A2D18DC67D840
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6877,10 +6877,10 @@ wop_trashmap/07565CAB80082EADBCB0AE83714D0815
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -6888,7 +6888,7 @@ wop_trashmap/07565CAB80082EADBCB0AE83714D0815
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6900,17 +6900,17 @@ wop_trashmap/D232B0D325A29A83C40006CF935CDC98
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0026.tga
+		map maps/wop_trashmap/lm_0026
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6922,17 +6922,17 @@ wop_trashmap/B5169A51E4D8E1F1465504DC009AFDC8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0022.tga
+		map maps/wop_trashmap/lm_0022
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6944,17 +6944,17 @@ wop_trashmap/25F994DD82BDC370F37E50DB81A3EFA3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0027.tga
+		map maps/wop_trashmap/lm_0027
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6966,7 +6966,7 @@ wop_trashmap/E768A1389C6E381D66CB3C9BBF3557D3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -6977,7 +6977,7 @@ wop_trashmap/E768A1389C6E381D66CB3C9BBF3557D3
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -6989,7 +6989,7 @@ wop_trashmap/F69EE371ADAA6B53CAE0D686DB7AB6B1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7000,7 +7000,7 @@ wop_trashmap/F69EE371ADAA6B53CAE0D686DB7AB6B1
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7012,10 +7012,10 @@ wop_trashmap/130CFFEB438810360F98B88970E8A745
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7023,7 +7023,7 @@ wop_trashmap/130CFFEB438810360F98B88970E8A745
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7035,17 +7035,17 @@ wop_trashmap/5B30636FFC8FE97C34359DD56C05B378
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0019.tga
+		map maps/wop_trashmap/lm_0019
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7057,17 +7057,17 @@ wop_trashmap/D1E26A33C4205B12D169A308B8F500D7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0033.tga
+		map maps/wop_trashmap/lm_0033
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7079,17 +7079,17 @@ wop_trashmap/0BADFCFDBA1A12E07FD2C0CEC8434C57
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0047.tga
+		map maps/wop_trashmap/lm_0047
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7101,17 +7101,17 @@ wop_trashmap/4F5BD43DF56D906AECA3DF93BBDDECFC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7123,17 +7123,17 @@ wop_trashmap/2C3333DEBC4DE5AE63B52B65BF62303A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0039.tga
+		map maps/wop_trashmap/lm_0039
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7145,17 +7145,17 @@ wop_trashmap/914A196467D9A9BB1FC9F13C6C4743A8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7167,17 +7167,17 @@ wop_trashmap/F8E16F362E5F44C7E893F4DC1D4E341C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7189,17 +7189,17 @@ wop_trashmap/9B69B33D75120C9089E940CF3497B28E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_teelicht_side.tga
+		map textures/pad_trash/kb_teelicht_side
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7211,17 +7211,17 @@ wop_trashmap/A248C8FB01162316E0764F89E254101B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_teelicht_side.tga
+		map textures/pad_trash/kb_teelicht_side
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7233,17 +7233,17 @@ wop_trashmap/E89FE9F00674DB7FF339E5A4886716EC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0058.tga
+		map maps/wop_trashmap/lm_0058
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7255,17 +7255,17 @@ wop_trashmap/E897E1837CA75323DFE606C4ABF1415A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7277,17 +7277,17 @@ wop_trashmap/C422DEF6A11C2515DCE82A3880B08B57
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7299,17 +7299,17 @@ wop_trashmap/5FEE01DF4FB93AAC1F19A1C71674600B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0026.tga
+		map maps/wop_trashmap/lm_0026
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7321,17 +7321,17 @@ wop_trashmap/200D3FD670E93FD451071AE110F9EB6B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0025.tga
+		map maps/wop_trashmap/lm_0025
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7343,10 +7343,10 @@ wop_trashmap/E5835EEC98F5FA1F9742A8E5BE981E9B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7354,7 +7354,7 @@ wop_trashmap/E5835EEC98F5FA1F9742A8E5BE981E9B
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7366,10 +7366,10 @@ wop_trashmap/2B88E6BCA171CBC3CB4E7FD9C87648D2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0047.tga
+		map maps/wop_trashmap/lm_0047
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7377,7 +7377,7 @@ wop_trashmap/2B88E6BCA171CBC3CB4E7FD9C87648D2
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7389,17 +7389,17 @@ wop_trashmap/F3DBF9B7E1DF07AF04EFD9F3B19E1024
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0010.tga
+		map maps/wop_trashmap/lm_0010
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_basket_metal.tga
+		map textures/pad_jail/pad_jail_basket_metal
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7411,17 +7411,17 @@ wop_trashmap/4793A646C4347ED3C00F8ACBE1AB89C1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0002.tga
+		map maps/wop_trashmap/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7433,17 +7433,17 @@ wop_trashmap/E130067B2AF98831F6164D94968EBDDE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0009.tga
+		map maps/wop_trashmap/lm_0009
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7455,17 +7455,17 @@ wop_trashmap/52B92F50D096890905368824FC6C48F5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/windowboard02.tga
+		map textures/pad_garden/windowboard02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7477,17 +7477,17 @@ wop_trashmap/5E54F0FB1EF08A28AE0C5BAAF16993A4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0032.tga
+		map maps/wop_trashmap/lm_0032
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7499,10 +7499,10 @@ wop_trashmap/7FFE48132148789CA7A369E234D7F793
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0037.tga
+		map maps/wop_trashmap/lm_0037
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7510,7 +7510,7 @@ wop_trashmap/7FFE48132148789CA7A369E234D7F793
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7522,10 +7522,10 @@ wop_trashmap/A6C81C0C32D4CEB1B70D7DF1642EFFB6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0037.tga
+		map maps/wop_trashmap/lm_0037
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7533,7 +7533,7 @@ wop_trashmap/A6C81C0C32D4CEB1B70D7DF1642EFFB6
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7545,7 +7545,7 @@ wop_trashmap/8928F22C20DACB37AC8D85F8DF349F0B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7556,7 +7556,7 @@ wop_trashmap/8928F22C20DACB37AC8D85F8DF349F0B
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7568,7 +7568,7 @@ wop_trashmap/AE56DB07F86A70E5BE7D454F2EBF3C09
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7579,7 +7579,7 @@ wop_trashmap/AE56DB07F86A70E5BE7D454F2EBF3C09
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7591,7 +7591,7 @@ wop_trashmap/3C56BFA5EB2040AB32C0AA14EFCA0356
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7602,7 +7602,7 @@ wop_trashmap/3C56BFA5EB2040AB32C0AA14EFCA0356
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7614,7 +7614,7 @@ wop_trashmap/C11D1C2F1CE7BD615338191C38C6EE15
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7625,7 +7625,7 @@ wop_trashmap/C11D1C2F1CE7BD615338191C38C6EE15
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7637,10 +7637,10 @@ wop_trashmap/6358974D2DC8C5D418EE2790F3BCCF23
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0037.tga
+		map maps/wop_trashmap/lm_0037
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7648,7 +7648,7 @@ wop_trashmap/6358974D2DC8C5D418EE2790F3BCCF23
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7660,7 +7660,7 @@ wop_trashmap/E4917707598A1E1D7D2AEB36F6D4FCDB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7671,7 +7671,7 @@ wop_trashmap/E4917707598A1E1D7D2AEB36F6D4FCDB
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7683,7 +7683,7 @@ wop_trashmap/D55B204BC127AADFDD07AA70FB39BF47
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7694,7 +7694,7 @@ wop_trashmap/D55B204BC127AADFDD07AA70FB39BF47
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7706,7 +7706,7 @@ wop_trashmap/0D952094CE6931C2365CD1FF935BFD06
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7717,7 +7717,7 @@ wop_trashmap/0D952094CE6931C2365CD1FF935BFD06
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7729,17 +7729,17 @@ wop_trashmap/DC96C30EE59D5E203005D827BF1CABE8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0035.tga
+		map maps/wop_trashmap/lm_0035
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7751,10 +7751,10 @@ wop_trashmap/5766DAA9E35D26BC569C956B158EBDE4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0033.tga
+		map maps/wop_trashmap/lm_0033
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7762,7 +7762,7 @@ wop_trashmap/5766DAA9E35D26BC569C956B158EBDE4
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7774,10 +7774,10 @@ wop_trashmap/02F8AD38567434E543574DA8131A3CA7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0032.tga
+		map maps/wop_trashmap/lm_0032
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7785,7 +7785,7 @@ wop_trashmap/02F8AD38567434E543574DA8131A3CA7
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7797,10 +7797,10 @@ wop_trashmap/32917F552F28E304A9855DF6A5B9149D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7808,7 +7808,7 @@ wop_trashmap/32917F552F28E304A9855DF6A5B9149D
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7820,10 +7820,10 @@ wop_trashmap/16BB8426E5D52532A4B78FC19ED0A7F0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7831,7 +7831,7 @@ wop_trashmap/16BB8426E5D52532A4B78FC19ED0A7F0
 	}
 
 	{
-		map textures/pad_attic/besen02.tga
+		map textures/pad_attic/besen02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7843,7 +7843,7 @@ wop_trashmap/B53A621C970F6C45EDAE4BA2ACE1F33D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7854,7 +7854,7 @@ wop_trashmap/B53A621C970F6C45EDAE4BA2ACE1F33D
 	}
 
 	{
-		map textures/pad_attic/besen02.tga
+		map textures/pad_attic/besen02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7866,10 +7866,10 @@ wop_trashmap/B5F3178B8B64B748B5F2477AAD8A7B3A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7877,7 +7877,7 @@ wop_trashmap/B5F3178B8B64B748B5F2477AAD8A7B3A
 	}
 
 	{
-		map textures/pad_attic/besen01.tga
+		map textures/pad_attic/besen01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7889,17 +7889,17 @@ wop_trashmap/4D374F7C09C127479EB93EBB6777B94B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0059.tga
+		map maps/wop_trashmap/lm_0059
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_plakat.tga
+		map textures/pad_trash/kb_plakat
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7911,10 +7911,10 @@ wop_trashmap/2D665EC497B97FA51E49D7A0E07424D8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -7922,7 +7922,7 @@ wop_trashmap/2D665EC497B97FA51E49D7A0E07424D8
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7934,7 +7934,7 @@ wop_trashmap/66CBDA0D483289C1B70102C4C82666AF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -7945,7 +7945,7 @@ wop_trashmap/66CBDA0D483289C1B70102C4C82666AF
 	}
 
 	{
-		map textures/pad_garden/metallegb.tga
+		map textures/pad_garden/metallegb
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7957,17 +7957,17 @@ wop_trashmap/A7E0CBF3F4F4C195372E8855216140D6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0002.tga
+		map maps/wop_trashmap/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_fountain/wall_04b.tga
+		map textures/pad_fountain/wall_04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -7979,17 +7979,17 @@ wop_trashmap/0E8EB749DF06B27A5B2FB12F4C79C393
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz_red.tga
+		map textures/pad_trash/kb_rauhputz_red
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8001,7 +8001,7 @@ wop_trashmap/E623C017E256177D85AD355C20613726
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -8012,7 +8012,7 @@ wop_trashmap/E623C017E256177D85AD355C20613726
 	}
 
 	{
-		map textures/pad_jail/pad_jail_metal10_keyhole.tga
+		map textures/pad_jail/pad_jail_metal10_keyhole
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8024,7 +8024,7 @@ wop_trashmap/E631153396D824A859A9D21CCE10DC53
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -8035,7 +8035,7 @@ wop_trashmap/E631153396D824A859A9D21CCE10DC53
 	}
 
 	{
-		map textures/pad_jail/pad_jail_metal10_keyhole.tga
+		map textures/pad_jail/pad_jail_metal10_keyhole
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8047,10 +8047,10 @@ wop_trashmap/F4672544A68C5A5FA3C79BD56EA5914C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -8058,7 +8058,7 @@ wop_trashmap/F4672544A68C5A5FA3C79BD56EA5914C
 	}
 
 	{
-		map textures/pad_trash/kb_sign_06.tga
+		map textures/pad_trash/kb_sign_06
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8070,17 +8070,17 @@ wop_trashmap/DB9D94D7CEF6AEE7D0A1DD405B15FEC0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_mittel.tga
+		map textures/pad_trash/kb_pflaster_mittel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8092,10 +8092,10 @@ wop_trashmap/485C4D8B25CA0E6A28FC7D34A2DE21D8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0045.tga
+		map maps/wop_trashmap/lm_0045
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -8103,7 +8103,7 @@ wop_trashmap/485C4D8B25CA0E6A28FC7D34A2DE21D8
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8115,10 +8115,10 @@ wop_trashmap/FB2652592B5F3D338EE55220FD589A17
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0039.tga
+		map maps/wop_trashmap/lm_0039
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -8126,7 +8126,7 @@ wop_trashmap/FB2652592B5F3D338EE55220FD589A17
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8138,17 +8138,17 @@ wop_trashmap/4D1B83F1245CE32B22DB5EAE8D4DA06E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0058.tga
+		map maps/wop_trashmap/lm_0058
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8160,17 +8160,17 @@ wop_trashmap/1E99B940E54DBDB61BDAE4039705F6C1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8182,17 +8182,17 @@ wop_trashmap/210184A4C862037A53086D4FFED1AF0B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0065.tga
+		map maps/wop_trashmap/lm_0065
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8204,17 +8204,17 @@ wop_trashmap/80491396EBC4431B2FF25718116DED2B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0041.tga
+		map maps/wop_trashmap/lm_0041
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8226,17 +8226,17 @@ wop_trashmap/3555C7FCA3D53D3B412608883BD68FE6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8248,17 +8248,17 @@ wop_trashmap/33A6F4712760A22C2BE6190134D58259
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0064.tga
+		map maps/wop_trashmap/lm_0064
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_schachtdeckel.tga
+		map textures/pad_trash/kb_schachtdeckel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8270,17 +8270,17 @@ wop_trashmap/7A444C9E6DB8BF1BF67F572FDC8182D0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0079.tga
+		map maps/wop_trashmap/lm_0079
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_western/metalrollup0026.tga
+		map textures/pad_western/metalrollup0026
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8292,17 +8292,17 @@ wop_trashmap/3AE18A92AF4B7F288427B5985D46C93B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0077.tga
+		map maps/wop_trashmap/lm_0077
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_western/metalrollup0026.tga
+		map textures/pad_western/metalrollup0026
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8314,7 +8314,7 @@ wop_trashmap/D2B216B091A59C2DCFABDE499F0CE2BB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -8325,7 +8325,7 @@ wop_trashmap/D2B216B091A59C2DCFABDE499F0CE2BB
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8337,7 +8337,7 @@ wop_trashmap/B803DED738D00FD66F98E6DD35790E30
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -8348,7 +8348,7 @@ wop_trashmap/B803DED738D00FD66F98E6DD35790E30
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8360,17 +8360,17 @@ wop_trashmap/A9F8BD797B7B866EEBB75B41168DC88A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0039.tga
+		map maps/wop_trashmap/lm_0039
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8382,17 +8382,17 @@ wop_trashmap/F03B4BE99EA2C32B227BC2C528818A26
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0033.tga
+		map maps/wop_trashmap/lm_0033
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8404,7 +8404,7 @@ wop_trashmap/E37DADF85E5E2258E066087BF991D77F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -8415,7 +8415,7 @@ wop_trashmap/E37DADF85E5E2258E066087BF991D77F
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8427,17 +8427,17 @@ wop_trashmap/01CFBFAE62DEAECF324DC03F6A5A7DA9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0042.tga
+		map maps/wop_trashmap/lm_0042
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8449,17 +8449,17 @@ wop_trashmap/F18440625DC6F97B9D9A2E0F447A348F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8471,17 +8471,17 @@ wop_trashmap/32C25DA3080BCD2712C2504E8DB82348
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0047.tga
+		map maps/wop_trashmap/lm_0047
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8493,17 +8493,17 @@ wop_trashmap/8FCED067E02B7832DEDB6A7870E6A0BF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0053.tga
+		map maps/wop_trashmap/lm_0053
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8515,17 +8515,17 @@ wop_trashmap/4C7F9CF66B85B36DD51E14D0FF2800C1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0046.tga
+		map maps/wop_trashmap/lm_0046
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8537,17 +8537,17 @@ wop_trashmap/D458113B70C700055AFA99BCED02080C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0024.tga
+		map maps/wop_trashmap/lm_0024
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8559,7 +8559,7 @@ wop_trashmap/FE9FEC7A805F51304923207DCCA5B0AD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -8570,7 +8570,7 @@ wop_trashmap/FE9FEC7A805F51304923207DCCA5B0AD
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8582,7 +8582,7 @@ wop_trashmap/ACEE9BA35E6C4E9F59ACA2DE36684F75
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -8593,7 +8593,7 @@ wop_trashmap/ACEE9BA35E6C4E9F59ACA2DE36684F75
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8605,7 +8605,7 @@ wop_trashmap/24A3896F51FECD190A263D2AFB690C8A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -8616,7 +8616,7 @@ wop_trashmap/24A3896F51FECD190A263D2AFB690C8A
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8628,17 +8628,17 @@ wop_trashmap/14638556C6D4F04D9D57DFC3E2AFD07E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_01.tga
+		map textures/pad_trash/kb_mauerwerk_01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8650,17 +8650,17 @@ wop_trashmap/3FF0A7989B57299018DD538E60A2A90E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_01.tga
+		map textures/pad_trash/kb_mauerwerk_01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8672,17 +8672,17 @@ wop_trashmap/7EB77CF035B350E8B83EF622ECDD4FB3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8694,17 +8694,17 @@ wop_trashmap/F11FEA5B95B524B134280CC09512003B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0025.tga
+		map maps/wop_trashmap/lm_0025
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8716,17 +8716,17 @@ wop_trashmap/F3A28CB37E356E8A4BF916ABFA9F0DC2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0030.tga
+		map maps/wop_trashmap/lm_0030
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8738,7 +8738,7 @@ wop_trashmap/410AE1AC2112EAA296D025AE6BC5DEC8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -8749,7 +8749,7 @@ wop_trashmap/410AE1AC2112EAA296D025AE6BC5DEC8
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8761,17 +8761,17 @@ wop_trashmap/B5C16D7114E9E2EE47462E374EB2C11C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0014.tga
+		map maps/wop_trashmap/lm_0014
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart04b.tga
+		map textures/pad_objects/cart04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8783,17 +8783,17 @@ wop_trashmap/7FC9AD0AED2EA7217CAC4625646BC837
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0017.tga
+		map maps/wop_trashmap/lm_0017
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart04b.tga
+		map textures/pad_objects/cart04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8805,17 +8805,17 @@ wop_trashmap/E8D80CCB936595CF838EB0B2660685B0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0016.tga
+		map maps/wop_trashmap/lm_0016
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart04b.tga
+		map textures/pad_objects/cart04b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8827,17 +8827,17 @@ wop_trashmap/C324C16B353BEF6B36911659425F52CF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0015.tga
+		map maps/wop_trashmap/lm_0015
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart05.tga
+		map textures/pad_objects/cart05
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8849,17 +8849,17 @@ wop_trashmap/FEE81142484B8EB741F6C9325D366115
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0017.tga
+		map maps/wop_trashmap/lm_0017
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart04c.tga
+		map textures/pad_objects/cart04c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8871,17 +8871,17 @@ wop_trashmap/9965CC2D5B360FE65E75F13D925FCE0B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0014.tga
+		map maps/wop_trashmap/lm_0014
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart10c.tga
+		map textures/pad_objects/cart10c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8893,17 +8893,17 @@ wop_trashmap/A6D1DAADB63C44A9088E2AFC0F55D0F0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0016.tga
+		map maps/wop_trashmap/lm_0016
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart12c.tga
+		map textures/pad_objects/cart12c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8915,17 +8915,17 @@ wop_trashmap/9512C5802B2E70B6C29D1E621E3142F7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0017.tga
+		map maps/wop_trashmap/lm_0017
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart12c.tga
+		map textures/pad_objects/cart12c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8937,17 +8937,17 @@ wop_trashmap/60B3CAADDDB0A0A22EB24C284CD57907
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0060.tga
+		map maps/wop_trashmap/lm_0060
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8959,17 +8959,17 @@ wop_trashmap/64B06FCEF710F2DA3C9C5F58F05516F5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0073.tga
+		map maps/wop_trashmap/lm_0073
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -8981,10 +8981,10 @@ wop_trashmap/F7F899AED46249D3CF4DA72855120A30
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -8992,7 +8992,7 @@ wop_trashmap/F7F899AED46249D3CF4DA72855120A30
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9004,17 +9004,17 @@ wop_trashmap/898E5CE82C9A66619F5A014A203CC6C0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0072.tga
+		map maps/wop_trashmap/lm_0072
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9026,17 +9026,17 @@ wop_trashmap/A595A85871AF5299A077E8B13439D527
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0065.tga
+		map maps/wop_trashmap/lm_0065
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9048,17 +9048,17 @@ wop_trashmap/84720AE3BADDB71B94ACDD22D3A39353
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0006.tga
+		map maps/wop_trashmap/lm_0006
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9070,17 +9070,17 @@ wop_trashmap/AE9065B06DBD977F8C24CE2006B7E4FC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0063.tga
+		map maps/wop_trashmap/lm_0063
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9092,17 +9092,17 @@ wop_trashmap/43B4C788DE7BA8A949A210A1F2134D08
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9114,17 +9114,17 @@ wop_trashmap/2AD43EF5CF1C9D23A1546EF23D016ECB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0061.tga
+		map maps/wop_trashmap/lm_0061
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9136,17 +9136,17 @@ wop_trashmap/AE474073F119611ACF0351D25AC96AA6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0058.tga
+		map maps/wop_trashmap/lm_0058
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9158,17 +9158,17 @@ wop_trashmap/ABBB00F97215463A9E57C56D67396E71
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0032.tga
+		map maps/wop_trashmap/lm_0032
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9180,17 +9180,17 @@ wop_trashmap/8BAFC794ECBB6A24E3815A29EE8BBA51
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9202,17 +9202,17 @@ wop_trashmap/749285F083EF3405763052B7EF75059A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9224,17 +9224,17 @@ wop_trashmap/F88D8DB24A4B493CB4BA2386DAB6E090
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0066.tga
+		map maps/wop_trashmap/lm_0066
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9246,17 +9246,17 @@ wop_trashmap/AEEC475A07A023A534C8FC49414B7B8F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9268,17 +9268,17 @@ wop_trashmap/03D5CCBDA9905C1575BFD60A247A29AA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0033.tga
+		map maps/wop_trashmap/lm_0033
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9290,17 +9290,17 @@ wop_trashmap/2631B080BC239B0BF2333DE56FC13099
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0071.tga
+		map maps/wop_trashmap/lm_0071
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9312,17 +9312,17 @@ wop_trashmap/C5BD70EE42018DF4251200B0D746DD61
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0027.tga
+		map maps/wop_trashmap/lm_0027
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9334,17 +9334,17 @@ wop_trashmap/B79666F29725C3F935A9F2B6B2070FCC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9356,17 +9356,17 @@ wop_trashmap/1FA80052E1C978EDDC31EB74C8842EF7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0054.tga
+		map maps/wop_trashmap/lm_0054
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9378,17 +9378,17 @@ wop_trashmap/9FAC2BDF45CCA9FAD3A3C6CDA959C55A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9400,17 +9400,17 @@ wop_trashmap/6BB5E0B7683B82DF1F768593BD525B89
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0062.tga
+		map maps/wop_trashmap/lm_0062
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9422,17 +9422,17 @@ wop_trashmap/73AD21539A93D536860EAE7CB316457D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9444,17 +9444,17 @@ wop_trashmap/177181057E7363505C2C80BC303CB116
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9466,17 +9466,17 @@ wop_trashmap/75D5666E92FCA0E22C956064C17FF608
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0067.tga
+		map maps/wop_trashmap/lm_0067
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9488,17 +9488,17 @@ wop_trashmap/F023CB4400EB67340829EBC9D0244BB1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0060.tga
+		map maps/wop_trashmap/lm_0060
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9510,10 +9510,10 @@ wop_trashmap/A410B0ABE7369D35B8F10116D01B1639
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0058.tga
+		map maps/wop_trashmap/lm_0058
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -9521,7 +9521,7 @@ wop_trashmap/A410B0ABE7369D35B8F10116D01B1639
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9533,17 +9533,17 @@ wop_trashmap/03BC1FDEE6B9A27CBC200C8FDF461F5D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0070.tga
+		map maps/wop_trashmap/lm_0070
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9555,17 +9555,17 @@ wop_trashmap/DAE792E7F117E80DE020B739C2312F16
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0065.tga
+		map maps/wop_trashmap/lm_0065
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9577,17 +9577,17 @@ wop_trashmap/72CFD42B38EC163F182CBA88D5C0CC2C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9599,17 +9599,17 @@ wop_trashmap/01074045883069D8E14B44FAB7135441
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0016.tga
+		map maps/wop_trashmap/lm_0016
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9621,17 +9621,17 @@ wop_trashmap/2858D3E94E9CF9E82554C9E9BA1AE90D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0061.tga
+		map maps/wop_trashmap/lm_0061
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9643,17 +9643,17 @@ wop_trashmap/43E202DEB7870E7197E38208CBE148DE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0065.tga
+		map maps/wop_trashmap/lm_0065
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9665,10 +9665,10 @@ wop_trashmap/692924C5830BFBBEAA869838EC49E25A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -9676,7 +9676,7 @@ wop_trashmap/692924C5830BFBBEAA869838EC49E25A
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9688,17 +9688,17 @@ wop_trashmap/7433081A5A3D91599457746CDC7C356F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0019.tga
+		map maps/wop_trashmap/lm_0019
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9710,17 +9710,17 @@ wop_trashmap/91212738D152B09C2034AE54387A6D0E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0017.tga
+		map maps/wop_trashmap/lm_0017
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9732,17 +9732,17 @@ wop_trashmap/E395938EB021C13CC4ED2BC6BA3E33A9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9754,17 +9754,17 @@ wop_trashmap/B31D8E0F97E5BECB050E9C6BAC9ACFDA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9776,10 +9776,10 @@ wop_trashmap/52AAFBDC1AF217D4B8320082B1FDE2BB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -9787,7 +9787,7 @@ wop_trashmap/52AAFBDC1AF217D4B8320082B1FDE2BB
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9799,17 +9799,17 @@ wop_trashmap/09FDB8BC965C968655448FF324CC71DC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0006.tga
+		map maps/wop_trashmap/lm_0006
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9821,17 +9821,17 @@ wop_trashmap/9314C90198A704289DC7FBDBAD00910A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9843,17 +9843,17 @@ wop_trashmap/CED732306839B93C410A902A651EF511
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0072.tga
+		map maps/wop_trashmap/lm_0072
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9865,17 +9865,17 @@ wop_trashmap/7D4DC7E2AAEFD88AAFA92D5686AE6D4C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0073.tga
+		map maps/wop_trashmap/lm_0073
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9887,17 +9887,17 @@ wop_trashmap/AD8E85678ED4FE0B32A32BB899041699
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0075.tga
+		map maps/wop_trashmap/lm_0075
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9909,17 +9909,17 @@ wop_trashmap/4E80064939997BFB712F76F17C0197A4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0036.tga
+		map maps/wop_trashmap/lm_0036
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9931,17 +9931,17 @@ wop_trashmap/EB9C76013199840CE9FEBE937B28AEE7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9953,17 +9953,17 @@ wop_trashmap/229B7633FAC71EDD05F4D19DFBAB461B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9975,17 +9975,17 @@ wop_trashmap/A00B7D4E9F45942729B6AEC7270C5674
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0056.tga
+		map maps/wop_trashmap/lm_0056
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -9997,10 +9997,10 @@ wop_trashmap/05BE8A31BDE51ED28A0BA885544E5F56
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10008,7 +10008,7 @@ wop_trashmap/05BE8A31BDE51ED28A0BA885544E5F56
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10020,10 +10020,10 @@ wop_trashmap/16393405672634C2F964C9CF95C8C1AF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0047.tga
+		map maps/wop_trashmap/lm_0047
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10031,7 +10031,7 @@ wop_trashmap/16393405672634C2F964C9CF95C8C1AF
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10043,7 +10043,7 @@ wop_trashmap/DE66A33A8D3411F55250389B124971DF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -10054,7 +10054,7 @@ wop_trashmap/DE66A33A8D3411F55250389B124971DF
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10066,10 +10066,10 @@ wop_trashmap/BDF76304E156B06D7B44EAE0B175164F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10077,7 +10077,7 @@ wop_trashmap/BDF76304E156B06D7B44EAE0B175164F
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10089,17 +10089,17 @@ wop_trashmap/DE3CE5CC9432461C4B68D50C23373861
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10111,10 +10111,10 @@ wop_trashmap/D2DB0EDEAB396A76C09E0A7AC24A2FCA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10122,7 +10122,7 @@ wop_trashmap/D2DB0EDEAB396A76C09E0A7AC24A2FCA
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10134,17 +10134,17 @@ wop_trashmap/F839C703E4916A5F68ACC8D2EDB9152D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0006.tga
+		map maps/wop_trashmap/lm_0006
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10156,17 +10156,17 @@ wop_trashmap/E76D15B6F68D1CC3FBB14D23394C3BE6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0009.tga
+		map maps/wop_trashmap/lm_0009
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10178,17 +10178,17 @@ wop_trashmap/D00B60CB960C4AE86F22B479775A2928
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10200,10 +10200,10 @@ wop_trashmap/FF1BA7AD9A25000ADB305C2260FFC6B4
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0071.tga
+		map maps/wop_trashmap/lm_0071
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10211,7 +10211,7 @@ wop_trashmap/FF1BA7AD9A25000ADB305C2260FFC6B4
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10223,17 +10223,17 @@ wop_trashmap/11BE994886B4C7C45E1F519CAFBEDE73
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0065.tga
+		map maps/wop_trashmap/lm_0065
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10245,17 +10245,17 @@ wop_trashmap/F53A80F31A78C9DA72CBB8B0C7CDCD4D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0071.tga
+		map maps/wop_trashmap/lm_0071
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10267,10 +10267,10 @@ wop_trashmap/54A565A885EF3025964C6DF43E07774A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0068.tga
+		map maps/wop_trashmap/lm_0068
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10278,7 +10278,7 @@ wop_trashmap/54A565A885EF3025964C6DF43E07774A
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10290,17 +10290,17 @@ wop_trashmap/0331514A87675DE4A151C9584C659FB7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0007.tga
+		map maps/wop_trashmap/lm_0007
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10312,17 +10312,17 @@ wop_trashmap/C63537700AF80B4514E0D0AEABF85DF2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0019.tga
+		map maps/wop_trashmap/lm_0019
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10334,10 +10334,10 @@ wop_trashmap/A83C6363A96AE686F167B6AE010B232B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0020.tga
+		map maps/wop_trashmap/lm_0020
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10345,7 +10345,7 @@ wop_trashmap/A83C6363A96AE686F167B6AE010B232B
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10357,17 +10357,17 @@ wop_trashmap/B6991D8E4EEF92C9B6352FB050DB4731
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0024.tga
+		map maps/wop_trashmap/lm_0024
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10379,17 +10379,17 @@ wop_trashmap/E0712AD7EDEE3FC8FBCEC0FAD86F2DC1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0025.tga
+		map maps/wop_trashmap/lm_0025
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10401,17 +10401,17 @@ wop_trashmap/50DCF9C17BA7DECF29CF89160D42E379
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0007.tga
+		map maps/wop_trashmap/lm_0007
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10423,10 +10423,10 @@ wop_trashmap/ED4881EB7BEF8F4D8868FFDFE1BEB8E3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0019.tga
+		map maps/wop_trashmap/lm_0019
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10434,7 +10434,7 @@ wop_trashmap/ED4881EB7BEF8F4D8868FFDFE1BEB8E3
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10446,10 +10446,10 @@ wop_trashmap/879902EC2A7F612405850AF31CD4DDFA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0020.tga
+		map maps/wop_trashmap/lm_0020
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10457,7 +10457,7 @@ wop_trashmap/879902EC2A7F612405850AF31CD4DDFA
 	}
 
 	{
-		map textures/pad_trash/kb_beton_nass.tga
+		map textures/pad_trash/kb_beton_nass
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10469,17 +10469,17 @@ wop_trashmap/FDE06E22CDD4EEAF911A3447663ADAB9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10491,17 +10491,17 @@ wop_trashmap/DF15BC27ED01398C222319AF0AA4CDE5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0021.tga
+		map maps/wop_trashmap/lm_0021
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10513,10 +10513,10 @@ wop_trashmap/9BAC22FA18DB27C9E07A71E2F7B4DDC6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0023.tga
+		map maps/wop_trashmap/lm_0023
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10524,7 +10524,7 @@ wop_trashmap/9BAC22FA18DB27C9E07A71E2F7B4DDC6
 	}
 
 	{
-		map textures/pad_trash/kb_container_04.tga
+		map textures/pad_trash/kb_container_04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10536,17 +10536,17 @@ wop_trashmap/40230F3214CD3381B5F94DDAFE0260E5
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0019.tga
+		map maps/wop_trashmap/lm_0019
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10558,17 +10558,17 @@ wop_trashmap/89A1B82D95D844DF484EF50582C4959A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0035.tga
+		map maps/wop_trashmap/lm_0035
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10580,10 +10580,10 @@ wop_trashmap/33C33AEBD062078D3D92C92CA360F403
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0003.tga
+		map maps/wop_trashmap/lm_0003
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10591,7 +10591,7 @@ wop_trashmap/33C33AEBD062078D3D92C92CA360F403
 	}
 
 	{
-		map textures/pad_garden/gumkabel.tga
+		map textures/pad_garden/gumkabel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10603,17 +10603,17 @@ wop_trashmap/B4C6A207FF53D3FEF21AF5B197C71DBA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0049.tga
+		map maps/wop_trashmap/lm_0049
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_teelicht_side.tga
+		map textures/pad_trash/kb_teelicht_side
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10625,17 +10625,17 @@ wop_trashmap/9A031C8DC4AF5787260938D514A6FA22
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0007.tga
+		map maps/wop_trashmap/lm_0007
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_gfx02/git04.tga
+		map textures/pad_gfx02/git04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10647,17 +10647,17 @@ wop_trashmap/4ABD1E4CB6BF51F25935BB51BD31129C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0049.tga
+		map maps/wop_trashmap/lm_0049
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pvc.tga
+		map textures/pad_trash/kb_pvc
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10669,17 +10669,17 @@ wop_trashmap/3465B80B11B58BAE614D0EC79403F610
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0015.tga
+		map maps/wop_trashmap/lm_0015
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_tex/col06b.tga
+		map textures/pad_tex/col06b
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10691,17 +10691,17 @@ wop_trashmap/78B1E6ED5969C126DDD4914B13F0D18A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0032.tga
+		map maps/wop_trashmap/lm_0032
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10713,17 +10713,17 @@ wop_trashmap/8ECB1EDE9FCFD01A9C7EBE6456952CC6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0030.tga
+		map maps/wop_trashmap/lm_0030
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10735,17 +10735,17 @@ wop_trashmap/2D0E75E69EF7CD94B425E4646F8F110B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0058.tga
+		map maps/wop_trashmap/lm_0058
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_redrope.tga
+		map textures/pad_trash/kb_redrope
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10757,17 +10757,17 @@ wop_trashmap/B7FA7C562FC0C3FAC8FCD1555F51DFAD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0009.tga
+		map maps/wop_trashmap/lm_0009
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_basket_metal.tga
+		map textures/pad_jail/pad_jail_basket_metal
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10779,7 +10779,7 @@ wop_trashmap/E5BBB679DCBC2480619E3C7499D53FD0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -10790,7 +10790,7 @@ wop_trashmap/E5BBB679DCBC2480619E3C7499D53FD0
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10802,17 +10802,17 @@ wop_trashmap/6449A41741218F48AF50DFEB5AFBBAEB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0029.tga
+		map maps/wop_trashmap/lm_0029
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10824,17 +10824,17 @@ wop_trashmap/F0D8764A08E5FA5E3B2FC1DEDDC54154
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10846,7 +10846,7 @@ wop_trashmap/D66DB694B55711406812448C8777A2AB
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -10857,7 +10857,7 @@ wop_trashmap/D66DB694B55711406812448C8777A2AB
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10869,17 +10869,17 @@ wop_trashmap/9DFB6D4C3721CD336DC0C96FA534A43E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0033.tga
+		map maps/wop_trashmap/lm_0033
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10891,10 +10891,10 @@ wop_trashmap/C85373FE77C1D335F288CFB221E11643
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10902,7 +10902,7 @@ wop_trashmap/C85373FE77C1D335F288CFB221E11643
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10914,10 +10914,10 @@ wop_trashmap/C37E99C6E233F57CF25B532FA344BA0A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10925,7 +10925,7 @@ wop_trashmap/C37E99C6E233F57CF25B532FA344BA0A
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10937,10 +10937,10 @@ wop_trashmap/416A021772499F46F501DC5FAD651ACF
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0031.tga
+		map maps/wop_trashmap/lm_0031
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10948,7 +10948,7 @@ wop_trashmap/416A021772499F46F501DC5FAD651ACF
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10960,10 +10960,10 @@ wop_trashmap/11C4F18A54C8F53C0E54AE5D27DE5ED9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0030.tga
+		map maps/wop_trashmap/lm_0030
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10971,7 +10971,7 @@ wop_trashmap/11C4F18A54C8F53C0E54AE5D27DE5ED9
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -10983,10 +10983,10 @@ wop_trashmap/AD655A953F2829DEBBD6EC4E841ACDF7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0034.tga
+		map maps/wop_trashmap/lm_0034
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -10994,7 +10994,7 @@ wop_trashmap/AD655A953F2829DEBBD6EC4E841ACDF7
 	}
 
 	{
-		map textures/pad_trash/kb_geroell.tga
+		map textures/pad_trash/kb_geroell
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11006,10 +11006,10 @@ wop_trashmap/E08AD781A22F4FBE9155C0E2DC369F73
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0001.tga
+		map maps/wop_trashmap/lm_0001
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -11017,7 +11017,7 @@ wop_trashmap/E08AD781A22F4FBE9155C0E2DC369F73
 	}
 
 	{
-		map textures/pad_attic/besen02.tga
+		map textures/pad_attic/besen02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11029,17 +11029,17 @@ wop_trashmap/6C5CACAB28117A3629C7AE886952E354
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_gfx02/git04.tga
+		map textures/pad_gfx02/git04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11051,17 +11051,17 @@ wop_trashmap/99745C2875E264E0D580AFB72EB70673
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0012.tga
+		map maps/wop_trashmap/lm_0012
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_metal10_keyhole.tga
+		map textures/pad_jail/pad_jail_metal10_keyhole
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11073,7 +11073,7 @@ wop_trashmap/083842DFB3AFA450808DF3D3035CC677
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -11084,7 +11084,7 @@ wop_trashmap/083842DFB3AFA450808DF3D3035CC677
 	}
 
 	{
-		map textures/pad_jail/pad_jail_metal10_keyhole.tga
+		map textures/pad_jail/pad_jail_metal10_keyhole
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11096,10 +11096,10 @@ wop_trashmap/B61BE158424BB344B3B9ED5C95749820
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0013.tga
+		map maps/wop_trashmap/lm_0013
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -11107,7 +11107,7 @@ wop_trashmap/B61BE158424BB344B3B9ED5C95749820
 	}
 
 	{
-		map textures/pad_jail/pad_jail_metal10_keyhole.tga
+		map textures/pad_jail/pad_jail_metal10_keyhole
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11119,17 +11119,17 @@ wop_trashmap/A261C1DFFC20D6550D751C662E1741DA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0011.tga
+		map maps/wop_trashmap/lm_0011
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_jail/pad_jail_metal10_keyhole.tga
+		map textures/pad_jail/pad_jail_metal10_keyhole
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11141,10 +11141,10 @@ wop_trashmap/4B315BD68A16CBFBE51E5F96CCBCFA97
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -11152,7 +11152,7 @@ wop_trashmap/4B315BD68A16CBFBE51E5F96CCBCFA97
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_mittel.tga
+		map textures/pad_trash/kb_pflaster_mittel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11164,17 +11164,17 @@ wop_trashmap/52B6BE133CA1A3156915DBD0DF170BE7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0039.tga
+		map maps/wop_trashmap/lm_0039
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11186,17 +11186,17 @@ wop_trashmap/666B42655B2B635D6F80A637F1C9BBE8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0040.tga
+		map maps/wop_trashmap/lm_0040
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11208,7 +11208,7 @@ wop_trashmap/1286F8949FB84B60D1DB9D3AA1567836
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -11219,7 +11219,7 @@ wop_trashmap/1286F8949FB84B60D1DB9D3AA1567836
 	}
 
 	{
-		map textures/pad_trash/kb_mauer.tga
+		map textures/pad_trash/kb_mauer
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11231,17 +11231,17 @@ wop_trashmap/332E041EB6FF94B5FD8D261DECE87ECD
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0064.tga
+		map maps/wop_trashmap/lm_0064
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11253,17 +11253,17 @@ wop_trashmap/9393BF49F6E4A8133134CEED7022D34E
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0071.tga
+		map maps/wop_trashmap/lm_0071
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11275,17 +11275,17 @@ wop_trashmap/35D2C512FDE79C7D2D7AF840B30B2783
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0062.tga
+		map maps/wop_trashmap/lm_0062
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone044big.tga
+		map textures/pad_wallout/wall_stone044big
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11297,17 +11297,17 @@ wop_trashmap/1999D928C606D846B599B5EEC775323A
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0060.tga
+		map maps/wop_trashmap/lm_0060
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_schachtdeckel.tga
+		map textures/pad_trash/kb_schachtdeckel
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11319,17 +11319,17 @@ wop_trashmap/1EDB0BD6C830B96587319C1386771071
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0081.tga
+		map maps/wop_trashmap/lm_0081
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_western/metalrollup0026.tga
+		map textures/pad_western/metalrollup0026
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11341,17 +11341,17 @@ wop_trashmap/A596BE78A7DBD58A7F32D6C958B9D3A2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0013.tga
+		map maps/wop_trashmap/lm_0013
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11363,17 +11363,17 @@ wop_trashmap/33FD02F4213D048CD89E5B7CDAA6F1DE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0012.tga
+		map maps/wop_trashmap/lm_0012
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11385,7 +11385,7 @@ wop_trashmap/E0EA9B54962BA0F011879B7B59C2801C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -11396,7 +11396,7 @@ wop_trashmap/E0EA9B54962BA0F011879B7B59C2801C
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11408,7 +11408,7 @@ wop_trashmap/A4C55AE2321658532E13ED5EB6BC24FE
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -11419,7 +11419,7 @@ wop_trashmap/A4C55AE2321658532E13ED5EB6BC24FE
 	}
 
 	{
-		map textures/pad_trash/kb_kaputtputz.tga
+		map textures/pad_trash/kb_kaputtputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11431,17 +11431,17 @@ wop_trashmap/70844D4CDB0BFE62D65E7343F72B9C02
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11453,17 +11453,17 @@ wop_trashmap/84C1B11203262D51F0674A309ABF5A21
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_02.tga
+		map textures/pad_trash/kb_mauerwerk_02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11475,7 +11475,7 @@ wop_trashmap/573553B548C27077A298740343FBB0F2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -11486,7 +11486,7 @@ wop_trashmap/573553B548C27077A298740343FBB0F2
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11498,10 +11498,10 @@ wop_trashmap/D5A38D30EAB0773F976770BCDA2F6142
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -11509,7 +11509,7 @@ wop_trashmap/D5A38D30EAB0773F976770BCDA2F6142
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11521,10 +11521,10 @@ wop_trashmap/B90BD40BCAD94871F6F97A510CB927A6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0002.tga
+		map maps/wop_trashmap/lm_0002
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -11532,7 +11532,7 @@ wop_trashmap/B90BD40BCAD94871F6F97A510CB927A6
 	}
 
 	{
-		map textures/pad_garden/oldwall_512.tga
+		map textures/pad_garden/oldwall_512
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11544,7 +11544,7 @@ wop_trashmap/78D7C0FFB84783CE1793D59CDB715A28
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -11555,7 +11555,7 @@ wop_trashmap/78D7C0FFB84783CE1793D59CDB715A28
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_01.tga
+		map textures/pad_trash/kb_mauerwerk_01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11567,17 +11567,17 @@ wop_trashmap/080625AF0F3DC7FBD0E4A2797C5708B6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0046.tga
+		map maps/wop_trashmap/lm_0046
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_mauerwerk_01.tga
+		map textures/pad_trash/kb_mauerwerk_01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11589,17 +11589,17 @@ wop_trashmap/BC7ADB1B496C37B280D3542ECAD34066
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0026.tga
+		map maps/wop_trashmap/lm_0026
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11611,17 +11611,17 @@ wop_trashmap/2DBCAB4CE94C1F5ED6D18C26F0A32202
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0024.tga
+		map maps/wop_trashmap/lm_0024
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_dach.tga
+		map textures/pad_trash/kb_dach
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11633,17 +11633,17 @@ wop_trashmap/0921A180B9D2D428FACA36650371D463
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0014.tga
+		map maps/wop_trashmap/lm_0014
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart04c.tga
+		map textures/pad_objects/cart04c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11655,17 +11655,17 @@ wop_trashmap/004C56403838FB21E43A9FC19F51E379
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0014.tga
+		map maps/wop_trashmap/lm_0014
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_objects/cart12c.tga
+		map textures/pad_objects/cart12c
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11677,10 +11677,10 @@ wop_trashmap/DF48F7A576F9D0900ABAB095287E34FA
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0050.tga
+		map maps/wop_trashmap/lm_0050
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -11688,7 +11688,7 @@ wop_trashmap/DF48F7A576F9D0900ABAB095287E34FA
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11700,17 +11700,17 @@ wop_trashmap/CA336F3D43B5E89F3EB02C513075B9F7
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0058.tga
+		map maps/wop_trashmap/lm_0058
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11722,17 +11722,17 @@ wop_trashmap/EB67C9C306F8269E5BEE233B33200427
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0005.tga
+		map maps/wop_trashmap/lm_0005
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone054.tga
+		map textures/pad_wallout/wall_stone054
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11744,17 +11744,17 @@ wop_trashmap/4ADDEB14C71658D3EDBACC0A09C49532
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0051.tga
+		map maps/wop_trashmap/lm_0051
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11766,17 +11766,17 @@ wop_trashmap/5D2349574723A40D5C0390E76E29A00D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0052.tga
+		map maps/wop_trashmap/lm_0052
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_rauhputz.tga
+		map textures/pad_trash/kb_rauhputz
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11788,17 +11788,17 @@ wop_trashmap/83376CBADBC1F418AC11084EE83F87A9
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0019.tga
+		map maps/wop_trashmap/lm_0019
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11810,17 +11810,17 @@ wop_trashmap/C3968C871134939F203BDCC3CCCD9CA8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0057.tga
+		map maps/wop_trashmap/lm_0057
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11832,17 +11832,17 @@ wop_trashmap/0068DD422A2B7058254546922CF89B1D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0069.tga
+		map maps/wop_trashmap/lm_0069
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11854,17 +11854,17 @@ wop_trashmap/0CB86F9AE01623C7F81CD0DFCE0AA6BC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11876,17 +11876,17 @@ wop_trashmap/D9A77494EA15C0DBC2D881DD036B9B32
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0062.tga
+		map maps/wop_trashmap/lm_0062
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone040.tga
+		map textures/pad_wallout/wall_stone040
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11898,17 +11898,17 @@ wop_trashmap/BB00103A86F6ECFE3B6EA20FC6950060
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0019.tga
+		map maps/wop_trashmap/lm_0019
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11920,17 +11920,17 @@ wop_trashmap/D5412519A542EE0D19A5D7429952B0D2
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0033.tga
+		map maps/wop_trashmap/lm_0033
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11942,17 +11942,17 @@ wop_trashmap/AA8551A21402DB7FF4ED940A06B12ECC
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0024.tga
+		map maps/wop_trashmap/lm_0024
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11964,17 +11964,17 @@ wop_trashmap/FFFC92CF07ED1441C1481868DDD3D0F0
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0040.tga
+		map maps/wop_trashmap/lm_0040
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -11986,17 +11986,17 @@ wop_trashmap/1C122E4C0DB4E8EC2B3647ED02B31A2B
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0066.tga
+		map maps/wop_trashmap/lm_0066
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone001a.tga
+		map textures/pad_wallout/wall_stone001a
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12008,10 +12008,10 @@ wop_trashmap/9980131267325AEBAEB099C98DBBCC49
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -12019,7 +12019,7 @@ wop_trashmap/9980131267325AEBAEB099C98DBBCC49
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12031,17 +12031,17 @@ wop_trashmap/C34933D774009A3528C59E736F173DB8
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0009.tga
+		map maps/wop_trashmap/lm_0009
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12053,17 +12053,17 @@ wop_trashmap/F5C63A0E94D70A7F2D4BF4EC516D39E1
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0044.tga
+		map maps/wop_trashmap/lm_0044
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12075,17 +12075,17 @@ wop_trashmap/B53A281C82FA8696222843C70F09810D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0014.tga
+		map maps/wop_trashmap/lm_0014
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12097,17 +12097,17 @@ wop_trashmap/8972368E89601155A847045C2738210D
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0055.tga
+		map maps/wop_trashmap/lm_0055
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12119,17 +12119,17 @@ wop_trashmap/0DA69B345398339E2AA3084CB71BA78C
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0035.tga
+		map maps/wop_trashmap/lm_0035
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12141,17 +12141,17 @@ wop_trashmap/B3AA2B1C4372FFFFC789611DFC627621
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0034.tga
+		map maps/wop_trashmap/lm_0034
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12163,17 +12163,17 @@ wop_trashmap/5DACCDD45F4AC411D7DB8C95B1F9BD88
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0048.tga
+		map maps/wop_trashmap/lm_0048
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wallstone_001.tga
+		map textures/pad_wallout/wallstone_001
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12185,17 +12185,17 @@ wop_trashmap/E3ADB92B3968BA86FAB3515924DDFE05
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0039.tga
+		map maps/wop_trashmap/lm_0039
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_trash/kb_pflaster_klein.tga
+		map textures/pad_trash/kb_pflaster_klein
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12207,10 +12207,10 @@ wop_trashmap/DED8B60D7A74DDA50E7DFB446A8D4089
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0008.tga
+		map maps/wop_trashmap/lm_0008
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -12218,7 +12218,7 @@ wop_trashmap/DED8B60D7A74DDA50E7DFB446A8D4089
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12230,10 +12230,10 @@ wop_trashmap/8022EB9235942582E9A5B25AAE623894
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0004.tga
+		map maps/wop_trashmap/lm_0004
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -12241,7 +12241,7 @@ wop_trashmap/8022EB9235942582E9A5B25AAE623894
 	}
 
 	{
-		map textures/pad_garden/rostii.tga
+		map textures/pad_garden/rostii
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12253,10 +12253,10 @@ wop_trashmap/B4ABA020E13ECA0E4C4639FF75D902A3
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0070.tga
+		map maps/wop_trashmap/lm_0070
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
@@ -12264,7 +12264,7 @@ wop_trashmap/B4ABA020E13ECA0E4C4639FF75D902A3
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12276,7 +12276,7 @@ wop_trashmap/386560D7F845F0FF222CD9E934ECA2D6
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
 		map $lightmap
@@ -12287,7 +12287,7 @@ wop_trashmap/386560D7F845F0FF222CD9E934ECA2D6
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
@@ -12299,17 +12299,17 @@ wop_trashmap/A0DB9C4759597A05339965ED16F1AD3F
 		map $lightmap
 		rgbGen identity
 	}
-	
+
 	// Q3Map2 custom lightstyle stage(s)
 	{
-		map maps/wop_trashmap/lm_0066.tga
+		map maps/wop_trashmap/lm_0066
 		blendFunc GL_SRC_ALPHA GL_ONE
 		rgbGen wave noise 0.5 1 0 5.37 // style 1
 		tcGen lightmap
 	}
 
 	{
-		map textures/pad_wallout/wall_stone030.tga
+		map textures/pad_wallout/wall_stone030
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}

--- a/wop/scripts.pk3dir/scripts/wop_code.shader
+++ b/wop/scripts.pk3dir/scripts/wop_code.shader
@@ -6,8 +6,8 @@
 //spraypuff
 models/weaponsfx/spraypuff { {  map models/weaponsfx/spraypuff  blendFunc blend  rgbGen vertex  alphaGen vertex } }
 
-powerupeffect/puff { {  map powerupeffect/puff.tga  blendFunc blend  rgbGen vertex  alphaGen vertex } }
-powerupeffect/revival { {  map powerupeffect/heart_noalpha.tga  blendFunc add  rgbGen vertex  alphaGen vertex } }
+powerupeffect/puff { {  map powerupeffect/puff  blendFunc blend  rgbGen vertex  alphaGen vertex } }
+powerupeffect/revival { {  map powerupeffect/heart_noalpha  blendFunc add  rgbGen vertex  alphaGen vertex } }
 
 //spraymark ... I will use the spraypuff =)
 models/weaponsfx/spraymark { polygonoffset {  map models/weaponsfx/spraypuff  blendFunc blend  rgbGen vertex  alphaGen vertex } }
@@ -21,7 +21,7 @@ gfx/2d/WoPascii
 	nopicmip
 	nomipmaps
 	{
-		map gfx/2d/WoPascii.tga
+		map gfx/2d/WoPascii
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbgen vertex
 	}
@@ -94,14 +94,14 @@ teleEffectBlueFP
 {
 	cull none
 	{
-		map models/weaponsfx/teleflash.tga
+		map models/weaponsfx/teleflash
 		blendFunc add
 		rgbGen vertex
 		tcMod scale 3 3
 		tcMod scroll 1.2 1.9
 	}
 	{
-		map models/weaponsfx/teleflash.tga
+		map models/weaponsfx/teleflash
 		blendFunc add
 		rgbGen vertex
 		tcMod scale 4 4
@@ -113,14 +113,14 @@ teleEffectRedFP
 {
 	cull none
 	{
-		map models/weaponsfx/redteleflash.tga
+		map models/weaponsfx/redteleflash
 		blendFunc add
 		rgbGen vertex
 		tcMod scale 3 3
 		tcMod scroll 1.2 1.9
 	}
 	{
-		map models/weaponsfx/redteleflash.tga
+		map models/weaponsfx/redteleflash
 		blendFunc add
 		rgbGen vertex
 		tcMod scale 4 4
@@ -132,14 +132,14 @@ teleEffectGreenFP
 {
 	cull none
 	{
-		map models/weaponsfx/greenteleflash.tga
+		map models/weaponsfx/greenteleflash
 		blendFunc add
 		rgbGen vertex
 		tcMod scale 3 3
 		tcMod scroll 1.2 1.9
 	}
 	{
-		map models/weaponsfx/greenteleflash.tga
+		map models/weaponsfx/greenteleflash
 		blendFunc add
 		rgbGen vertex
 		tcMod scale 4 4
@@ -155,7 +155,7 @@ gfx/damage/bullet_mrk
 {
 	polygonOffset
 	{
-		map gfx/damage/bullet_mrk.tga
+		map gfx/damage/bullet_mrk
 		blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
 		rgbGen exactVertex
 	}
@@ -165,7 +165,7 @@ gfx/damage/burn_med_mrk
 {
 	polygonOffset
 	{
-		map gfx/damage/burn_med_mrk.tga
+		map gfx/damage/burn_med_mrk
 		blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
 		rgbGen exactVertex
 	}
@@ -175,7 +175,7 @@ gfx/damage/hole_lg_mrk
 {
 	polygonOffset
 	{
-		map gfx/damage/hole_lg_mrk.tga
+		map gfx/damage/hole_lg_mrk
 		blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
 		rgbGen exactVertex
 	}
@@ -185,7 +185,7 @@ gfx/damage/plasma_mrk
 {
 	polygonOffset
 	{
-		map gfx/damage/plasma_mrk.tga
+		map gfx/damage/plasma_mrk
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen vertex
 		alphaGen vertex
@@ -196,7 +196,7 @@ gfx/damage/snow_mrk
 {
 	polygonOffset
 	{
-		map gfx/damage/burn_med_mrk.tga
+		map gfx/damage/burn_med_mrk
 		blendFunc add
 		rgbGen vertex
 		alphaGen vertex
@@ -234,7 +234,7 @@ gfx/kmazoomAura
 {
 	sort nearest
 	{
-		map $whiteimage 
+		map $whiteimage
 		blendfunc GL_ONE_MINUS_DST_COLOR GL_ONE_MINUS_SRC_COLOR
 	}
 }
@@ -243,7 +243,7 @@ gfx/kmaBlueScreen
 {
 	sort 14
 	{
-		map $whiteimage 
+		map $whiteimage
 		blendfunc blend
 		alphaGen const 0.5
 		rgbGen const ( 0.0 0.0 0.50 )
@@ -262,7 +262,7 @@ disconnected
 {
 	nopicmip
 	{
-		map gfx/2d/net.tga
+		map gfx/2d/net
 	}
 }
 
@@ -271,10 +271,10 @@ markShadow
 {
 	polygonOffset
 	{
-		map marks/shadow.tga
+		map marks/shadow
 		blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
 		rgbGen exactVertex
-	}	
+	}
 }
 
 // projectionShadow is used for cheap squashed model shadows
@@ -286,28 +286,28 @@ projectionShadow
 		map			*white
 		blendFunc GL_ONE GL_ZERO
 		rgbGen wave square 0 0 0 0				// just solid black
-	}	
+	}
 }
 
 // wake is the mark on water surfaces for paddling players
 wake
 {
 	{
-		clampmap marks/splash.tga
+		clampmap marks/splash
 		blendFunc GL_ONE GL_ONE
 		rgbGen vertex
                 tcmod rotate 150
                 tcMod stretch sin .9 0.1 0 0.7
 		rgbGen wave sin .7 .3 .25 .5
-	}	
+	}
         {
-		clampmap marks/splash.tga
+		clampmap marks/splash
 		blendFunc GL_ONE GL_ONE
 		rgbGen vertex
                 tcmod rotate -130
                 tcMod stretch sin .9 0.05 0 0.9
 		rgbGen wave sin .7 .3 .25 .4
-	}	
+	}
 }
 
 waterBubble
@@ -316,7 +316,7 @@ waterBubble
 	cull none
 	entityMergable		// allow all the sprites to be merged together
 	{
-		map sprites/bubble.tga
+		map sprites/bubble
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen		vertex
 		alphaGen	vertex
@@ -329,7 +329,7 @@ gfx/2d/bigchars
 	nopicmip
 	nomipmaps
 	{
-		map gfx/2d/bigchars.tga
+		map gfx/2d/bigchars
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbgen vertex
 	}

--- a/wop/scripts.pk3dir/scripts/wop_glowmodels.shader
+++ b/wop/scripts.pk3dir/scripts/wop_glowmodels.shader
@@ -5,35 +5,35 @@
 models/wop_players/padman/padman_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padman/padman_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	{
+              map models/wop_players/padman/padman_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-	{		
-              map models/wop_players/padman/padman_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+	{
+              map models/wop_players/padman/padman_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padman/padman_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padman/padman_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-              {		
-              map models/wop_players/padman/padman_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	nopicmip
+              {
+              map models/wop_players/padman/padman_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+              {
+              map models/wop_players/padman/padman_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padman/padman_cape_light_s
@@ -41,13 +41,13 @@ models/wop_players/padman/padman_cape_light_s
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/padman_body_light.tga
+                map models/wop_players/padman/padman_body_light
                 blendFunc GL_ONE GL_ZERO
                 rgbGen identity
         }
         {
-                map models/wop_players/padman/padman_body_light.tga
-                blendFunc GL_ONE GL_ZERO 
+                map models/wop_players/padman/padman_body_light
+                blendFunc GL_ONE GL_ZERO
                 rgbGen entity
         }
 }
@@ -60,35 +60,35 @@ models/wop_players/padman/padman_cape_light_s
 models/wop_players/padman/rock_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padman/rock_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	{
+              map models/wop_players/padman/rock_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-	{		
-              map models/wop_players/padman/rock_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+	{
+              map models/wop_players/padman/rock_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padman/rock_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padman/rock_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-              {		
-              map models/wop_players/padman/rock_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	nopicmip
+              {
+              map models/wop_players/padman/rock_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+              {
+              map models/wop_players/padman/rock_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -99,35 +99,35 @@ models/wop_players/padman/rock_body_light_s
 models/wop_players/padman/super_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padman/super_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	{
+              map models/wop_players/padman/super_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-	{		
-              map models/wop_players/padman/super_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+	{
+              map models/wop_players/padman/super_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padman/super_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padman/super_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-              {		
-              map models/wop_players/padman/super_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	nopicmip
+              {
+              map models/wop_players/padman/super_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+              {
+              map models/wop_players/padman/super_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 // =================
@@ -137,35 +137,35 @@ models/wop_players/padman/super_body_light_s
 models/wop_players/padman/ra_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padman/ra_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padman/ra_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padman/ra_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padman/ra_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padman/ra_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padman/ra_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padman/ra_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padman/ra_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padman/ra_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padman/ra_cape_light_s
@@ -173,14 +173,14 @@ models/wop_players/padman/ra_cape_light_s
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/ra_body_light.tga
+                map models/wop_players/padman/ra_body_light
                 blendFunc GL_ONE GL_ZERO
                 alphaFunc ge128
                 rgbGen identity
         }
         {
-                map models/wop_players/padman/ra_body_light.tga
-                blendFunc GL_ONE GL_ZERO 
+                map models/wop_players/padman/ra_body_light
+                blendFunc GL_ONE GL_ZERO
                 rgbGen entity
         }
 }
@@ -193,35 +193,35 @@ models/wop_players/padman/ra_cape_light_s
 models/wop_players/padman/bio_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padman/bio_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padman/bio_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padman/bio_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padman/bio_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padman/bio_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padman/bio_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padman/bio_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padman/bio_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padman/bio_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -231,10 +231,10 @@ models/wop_players/padman/bio_body_light_s
 
 models/wop_players/padman/stone_head_light_s
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/stonepad_head.tga
+                map models/wop_players/padman/stonepad_head
                 alphaFunc GE128
 		rgbGen identity
         }
@@ -242,19 +242,19 @@ models/wop_players/padman/stone_head_light_s
 
 models/wop_players/padman/stone_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padman/stone_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padman/stone_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padman/stone_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padman/stone_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -265,35 +265,35 @@ models/wop_players/padman/stone_body_light_s
 models/wop_players/padman/soldier_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padman/soldier_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padman/soldier_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padman/soldier_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padman/soldier_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padman/soldier_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padman/soldier_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padman/soldier_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padman/soldier_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padman/soldier_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -304,35 +304,35 @@ models/wop_players/padman/soldier_body_light_s
 models/wop_players/padgirl/padgirl_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padgirl/padgirl_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padgirl/padgirl_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padgirl/padgirl_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padgirl/padgirl_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padgirl/padgirl_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padgirl/padgirl_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padgirl/padgirl_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padgirl/padgirl_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padgirl/padgirl_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 // =================
@@ -342,35 +342,35 @@ models/wop_players/padgirl/padgirl_body_light_s
 models/wop_players/padgirl/padbabe_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padgirl/padbabe_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padgirl/padbabe_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padgirl/padbabe_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padgirl/padbabe_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padgirl/padbabe_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padgirl/padbabe_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padgirl/padbabe_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padgirl/padbabe_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padgirl/padbabe_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -381,35 +381,35 @@ models/wop_players/padgirl/padbabe_body_light_s
 models/wop_players/padlilly/lilly_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padlilly/lilly_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padlilly/lilly_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padlilly/lilly_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padlilly/lilly_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padlilly/lilly_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padlilly/lilly_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padlilly/lilly_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padlilly/lilly_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padlilly/lilly_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 // =================
@@ -419,35 +419,35 @@ models/wop_players/padlilly/lilly_body_light_s
 models/wop_players/padlilly/dilla_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padlilly/dilla_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padlilly/dilla_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padlilly/dilla_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padlilly/dilla_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padlilly/dilla_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padlilly/dilla_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padlilly/dilla_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padlilly/dilla_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padlilly/dilla_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -458,35 +458,35 @@ models/wop_players/padlilly/dilla_body_light_s
 models/wop_players/monster/monster_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/monster/monster_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/monster/monster_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/monster/monster_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/monster/monster_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/monster/monster_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/monster/monster_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/monster/monster_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/monster/monster_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/monster/monster_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -497,35 +497,35 @@ models/wop_players/monster/monster_body_light_s
 models/wop_players/monster/hawk_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/monster/hawk_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/monster/hawk_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/monster/hawk_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/monster/hawk_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/monster/hawk_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/monster/hawk_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/monster/hawk_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/monster/hawk_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/monster/hawk_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -536,52 +536,52 @@ models/wop_players/monster/hawk_body_light_s
 models/wop_players/fatpad/fatpad_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/fatpad/fatpad_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/fatpad/fatpad_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/fatpad/fatpad_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/fatpad/fatpad_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/fatpad/fatpad_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/fatpad/fatpad_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/fatpad/fatpad_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/fatpad/fatpad_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/fatpad/fatpad_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/fatpad/fatpad_lower_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/fatpad/fatpad_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/fatpad/fatpad_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/fatpad/fatpad_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/fatpad/fatpad_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -592,52 +592,52 @@ models/wop_players/fatpad/fatpad_lower_light_s
 models/wop_players/fatpad/fatty_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/fatpad/fatty_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/fatpad/fatty_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/fatpad/fatty_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/fatpad/fatty_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/fatpad/fatty_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/fatpad/fatty_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/fatpad/fatty_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/fatpad/fatty_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/fatpad/fatty_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/fatpad/fatty_lower_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/fatpad/fatty_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/fatpad/fatty_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/fatpad/fatty_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/fatpad/fatty_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -647,10 +647,10 @@ models/wop_players/fatpad/fatty_lower_light_s
 
 models/wop_players/padpunk/punk_head_light_s
 {
-    
+
     cull disable
         {
-                map models/wop_players/padpunk/punk_head_light.tga
+                map models/wop_players/padpunk/punk_head_light
                 alphaFunc GE128
 		rgbGen identity
         }
@@ -658,36 +658,36 @@ models/wop_players/padpunk/punk_head_light_s
 
 models/wop_players/padpunk/punk_torso_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padpunk/punk_torso_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padpunk/punk_torso_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padpunk/punk_torso_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padpunk/punk_torso_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padpunk/punk_legs_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padpunk/punk_legs_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padpunk/punk_legs_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padpunk/punk_legs_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padpunk/punk_legs_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -699,54 +699,54 @@ models/wop_players/padking/king_head_light_s
               {
 	nopicmip
 	cull none
-	{		
-              map models/wop_players/padking/king_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padking/king_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padking/king_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padking/king_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padking/king_lower_light_s
               {
 	nopicmip
-	cull none	
-              {		
-              map models/wop_players/padking/king_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	cull none
+              {
+              map models/wop_players/padking/king_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padking/king_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padking/king_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padking/king_upper_light_s
               {
 	nopicmip
 	cull none
-              {		
-              map models/wop_players/padking/king_upper_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+              {
+              map models/wop_players/padking/king_upper_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padking/king_upper_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padking/king_upper_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -758,65 +758,65 @@ models/wop_players/padking/padknight_feather_light_s
 {
 	nopicmip
 	cull none
-	{		
-              map models/wop_players/padking/knight_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-        }	
+	{
+              map models/wop_players/padking/knight_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+        }
 }
 
 models/wop_players/padking/knight_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padking/knight_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padking/knight_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padking/knight_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padking/knight_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padking/knight_lower_light_s
               {
 	nopicmip
 	cull none
-              {		
-              map models/wop_players/padking/knight_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+              {
+              map models/wop_players/padking/knight_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padking/knight_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padking/knight_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padking/knight_upper_light_s
               {
 	nopicmip
-	cull disable	
-              {		
-              map models/wop_players/padking/knight_upper_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	cull disable
+              {
+              map models/wop_players/padking/knight_upper_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padking/knight_upper_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padking/knight_upper_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -827,52 +827,52 @@ models/wop_players/padking/knight_upper_light_s
 models/wop_players/beachpad/beach_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/beachpad/beach_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/beachpad/beach_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/beachpad/beach_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/beachpad/beach_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/beachpad/beach_body_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/beachpad/beach_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/beachpad/beach_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/beachpad/beach_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/beachpad/beach_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/beachpad/beach_barrel_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/beachpad/beach_barrel_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/beachpad/beach_barrel_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/beachpad/beach_barrel_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/beachpad/beach_barrel_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -883,52 +883,52 @@ models/wop_players/beachpad/beach_barrel_light_s
 models/wop_players/padcho/padcho_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/padcho/padcho_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/padcho/padcho_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/padcho/padcho_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/padcho/padcho_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padcho/padcho_upper_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padcho/padcho_upper_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padcho/padcho_upper_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padcho/padcho_upper_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padcho/padcho_upper_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/padcho/padcho_lower_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/padcho/padcho_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/padcho/padcho_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/padcho/padcho_lower_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/padcho/padcho_lower_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -939,52 +939,52 @@ models/wop_players/padcho/padcho_lower_light_s
 models/wop_players/piratepad/pirat_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/piratepad/pirat_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/piratepad/pirat_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/piratepad/pirat_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/piratepad/pirat_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/piratepad/pirat_legs_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/piratepad/pirat_legs_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/piratepad/pirat_legs_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/piratepad/pirat_legs_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/piratepad/pirat_legs_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/piratepad/pirat_torso_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/piratepad/pirat_torso_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/piratepad/pirat_torso_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/piratepad/pirat_torso_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/piratepad/pirat_torso_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 // =================
@@ -994,52 +994,52 @@ models/wop_players/piratepad/pirat_torso_light_s
 models/wop_players/piratepad/ghost_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/piratepad/ghost_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/piratepad/ghost_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/piratepad/ghost_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/piratepad/ghost_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/piratepad/ghost_legs_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/piratepad/ghost_legs_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/piratepad/ghost_legs_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/piratepad/ghost_legs_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/piratepad/ghost_legs_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/piratepad/ghost_torso_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/piratepad/ghost_torso_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/piratepad/ghost_torso_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/piratepad/ghost_torso_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }		
+              {
+              map models/wop_players/piratepad/ghost_torso_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 
@@ -1050,77 +1050,77 @@ models/wop_players/piratepad/ghost_torso_light_s
 models/wop_players/piratepad/spooky_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/piratepad/spooky_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/piratepad/spooky_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
+	{
+              map models/wop_players/piratepad/spooky_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {	
-                map models/wop_players/piratepad/beam.tga
+	{
+              map models/wop_players/piratepad/spooky_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
+              {
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
-	}    
+	}
 
 
 }
 
 models/wop_players/piratepad/spooky_legs_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/piratepad/spooky_legs_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/piratepad/spooky_legs_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/piratepad/spooky_legs_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
+              {
+              map models/wop_players/piratepad/spooky_legs_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
               }
-              {	
-                map models/wop_players/piratepad/beam.tga
+              {
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
-	}    
+	}
 
 
 }
 
 models/wop_players/piratepad/spooky_torso_light_s
               {
-	nopicmip	
-              {		
-              map models/wop_players/piratepad/spooky_torso_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
+	nopicmip
+              {
+              map models/wop_players/piratepad/spooky_torso_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
               }
-              {		
-              map models/wop_players/piratepad/spooky_torso_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
+              {
+              map models/wop_players/piratepad/spooky_torso_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
               }
-              {	
-                map models/wop_players/piratepad/beam.tga
+              {
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
-	}    
+	}
 
 
 }
@@ -1133,59 +1133,59 @@ models/wop_players/piratepad/spooky_torso_light_s
 models/wop_players/paddybell/default_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/paddybell/default_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/paddybell/default_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/paddybell/default_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/paddybell/default_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/paddybell/default_body_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/paddybell/default_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/paddybell/default_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/paddybell/default_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/paddybell/default_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/paddybell/default_leg_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/paddybell/default_leg_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/paddybell/default_leg_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/paddybell/default_leg_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/paddybell/default_leg_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/paddybell/default_wings_glow_s
 {
      cull none
         {
-                map models/wop_players/paddybell/default_body.tga
+                map models/wop_players/paddybell/default_body
 		blendfunc blend
 		rgbGen lightingdiffuse
         }
@@ -1199,59 +1199,59 @@ models/wop_players/paddybell/default_wings_glow_s
 models/wop_players/paddybell/badpaddy_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/paddybell/badpaddy_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/paddybell/badpaddy_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/paddybell/badpaddy_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/paddybell/badpaddy_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/paddybell/badpaddy_body_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/paddybell/badpaddy_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/paddybell/badpaddy_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/paddybell/badpaddy_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/paddybell/badpaddy_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/paddybell/badpaddy_leg_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/paddybell/badpaddy_leg_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/paddybell/badpaddy_leg_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/paddybell/badpaddy_leg_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/paddybell/badpaddy_leg_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/paddybell/badpaddy_wings_glow_s
 {
      cull none
         {
-                map models/wop_players/paddybell/badpaddy_body.tga
+                map models/wop_players/paddybell/badpaddy_body
 		blendfunc blend
 		rgbGen lightingdiffuse
         }
@@ -1265,59 +1265,59 @@ models/wop_players/paddybell/badpaddy_wings_glow_s
 models/wop_players/paddybell/paddybee_head_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/paddybell/paddybee_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/paddybell/paddybee_head_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/paddybell/paddybee_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/paddybell/paddybee_head_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/paddybell/paddybee_body_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/paddybell/paddybee_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/paddybell/paddybee_body_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/paddybell/paddybee_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/paddybell/paddybee_body_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/paddybell/paddybee_leg_light_s
               {
 	nopicmip
-	{		
-              map models/wop_players/paddybell/paddybee_leg_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc GE128		
-              rgbGen entity	
-              }	
-	{		
-              map models/wop_players/paddybell/paddybee_leg_light.tga		
-              blendFunc GL_ONE GL_ZERO		
-              alphaFunc LT128		
-              rgbGen identity	
-              }	
+	{
+              map models/wop_players/paddybell/paddybee_leg_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc GE128
+              rgbGen entity
+              }
+	{
+              map models/wop_players/paddybell/paddybee_leg_light
+              blendFunc GL_ONE GL_ZERO
+              alphaFunc LT128
+              rgbGen identity
+              }
 }
 
 models/wop_players/paddybell/paddybee_wings_glow_s
 {
      cull none
         {
-                map models/wop_players/paddybell/paddybee_body.tga
+                map models/wop_players/paddybell/paddybee_body
 		blendfunc blend
 		rgbGen lightingdiffuse
         }

--- a/wop/scripts.pk3dir/scripts/wop_levelshots.shader
+++ b/wop/scripts.pk3dir/scripts/wop_levelshots.shader
@@ -105,7 +105,7 @@ levelshots/wop_bathBB
 		map levelshots/wop_bath
 	}
 }
-	
+
 levelshots/wop_bathBBA
 {
 	nomipmaps
@@ -237,7 +237,7 @@ levelshots/wop_huetteBB
 		map levelshots/wop_huette
 		}
 	}
-	
+
 levelshots/wop_huetteBBA
 {
 	nomipmaps

--- a/wop/scripts.pk3dir/scripts/wop_menu.shader
+++ b/wop/scripts.pk3dir/scripts/wop_menu.shader
@@ -10,7 +10,7 @@ mainbgfx
 		tcMod rotate 7
 		tcMod turb .1 .1 .1 .1
 		alphaGen Vertex
-	}  
+	}
 }
 
 // =================

--- a/wop/scripts.pk3dir/scripts/wop_playermodels.shader
+++ b/wop/scripts.pk3dir/scripts/wop_playermodels.shader
@@ -6,13 +6,13 @@ models/wop_players/padman/default_goggles
 {
      cull disable
         {
-                map models/wop_players/padman/default_head.tga
+                map models/wop_players/padman/default_head
 		alphaFunc ge128
 	        rgbGen lightingDiffuse
         }
 	{
-                map models/wop_players/padman/pad_fx.tga
-		//map textures/effects/envmapdimb.tga
+                map models/wop_players/padman/pad_fx
+		//map textures/effects/envmapdimb
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
                 tcgen environment
 		rgbGen lightingDiffuse
@@ -26,10 +26,10 @@ models/wop_players/padman/default_cape
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/default_body.tga
+                map models/wop_players/padman/default_body
                 rgbGen identity
         }
-	
+
 }
 
 models/wop_players/padman/default_head
@@ -38,19 +38,19 @@ models/wop_players/padman/default_head
 	nomipmaps
 	cull none
         {
-                map models/wop_players/padman/default_head.tga
+                map models/wop_players/padman/default_head
 	  //alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
         }
         {
-                map models/wop_players/padman/default_head.tga
+                map models/wop_players/padman/default_head
 	  alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
@@ -63,24 +63,24 @@ models/wop_players/padman/default_body
 	nomipmaps
 	cull none
 	{
-		map models/wop_players/padman/default_body.tga
+		map models/wop_players/padman/default_body
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
 	}
 	{
- 		map models/wop_players/padman/default_body.tga
+ 		map models/wop_players/padman/default_body
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
-	
+
 }
 
 models/wop_players/padman/body_blue
@@ -89,24 +89,24 @@ models/wop_players/padman/body_blue
 	nomipmaps
 	cull none
 	{
-		map models/wop_players/padman/body_blue.tga
+		map models/wop_players/padman/body_blue
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
 	}
 	{
- 		map models/wop_players/padman/body_blue.tga
+ 		map models/wop_players/padman/body_blue
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
-	
+
 }
 
 models/wop_players/padman/cape_blue
@@ -114,10 +114,10 @@ models/wop_players/padman/cape_blue
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/body_blue.tga
+                map models/wop_players/padman/body_blue
                 rgbGen identity
         }
-	
+
 }
 
 models/wop_players/padman/body_red
@@ -126,24 +126,24 @@ models/wop_players/padman/body_red
 	nomipmaps
 	cull none
 	{
-		map models/wop_players/padman/body_red.tga
+		map models/wop_players/padman/body_red
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
 	}
 	{
- 		map models/wop_players/padman/body_red.tga
+ 		map models/wop_players/padman/body_red
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
-	
+
 }
 
 
@@ -152,10 +152,10 @@ models/wop_players/padman/cape_red
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/body_red.tga
+                map models/wop_players/padman/body_red
                 rgbGen identity
         }
-	
+
 }
 
 
@@ -179,19 +179,19 @@ models/wop_players/padman/padra_cape
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/padra_body.tga
+                map models/wop_players/padman/padra_body
 		alphaFunc ge128
                 rgbGen identity
         }
-	
+
 }
 
 models/wop_players/padman/padra_head
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/padra_head.tga
+                map models/wop_players/padman/padra_head
                 alphaFunc GE128
 		rgbGen lightingdiffuse
         }
@@ -202,19 +202,19 @@ models/wop_players/padman/padra_cape_blue
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/padra_body_blue.tga
+                map models/wop_players/padman/padra_body_blue
 		alphaFunc ge128
                 rgbGen identity
         }
-	
+
 }
 
 models/wop_players/padman/padra_head_blue
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/padra_head_blue.tga
+                map models/wop_players/padman/padra_head_blue
                 alphaFunc GE128
 		rgbGen lightingdiffuse
         }
@@ -225,19 +225,19 @@ models/wop_players/padman/padra_cape_red
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/padra_body_red.tga
+                map models/wop_players/padman/padra_body_red
 		alphaFunc ge128
                 rgbGen identity
         }
-	
+
 }
 
 models/wop_players/padman/padra_head_red
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/padra_head_red.tga
+                map models/wop_players/padman/padra_head_red
                 alphaFunc GE128
 		rgbGen lightingdiffuse
         }
@@ -252,12 +252,12 @@ models/wop_players/padman/padrock_goggles
 {
      cull disable
         {
-                map models/wop_players/padman/padrock_head.tga
+                map models/wop_players/padman/padrock_head
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		map models/wop_players/padman/pad_fx.tga
+		map models/wop_players/padman/pad_fx
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
 		tcgen environment
 		rgbGen lightingDiffuse
@@ -269,12 +269,12 @@ models/wop_players/padman/padrock_goggles_blue
 {
      cull disable
         {
-                map models/wop_players/padman/padrock_head_blue.tga
+                map models/wop_players/padman/padrock_head_blue
 		alphaFunc ge128
      	        rgbGen lightingDiffuse
         }
 	{
-                map models/wop_players/padman/pad_fx.tga
+                map models/wop_players/padman/pad_fx
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
                 tcgen environment
 		rgbGen lightingDiffuse
@@ -287,12 +287,12 @@ models/wop_players/padman/padrock_goggles_red
 {
      cull disable
         {
-                map models/wop_players/padman/padrock_head_red.tga
+                map models/wop_players/padman/padrock_head_red
 		alphaFunc ge128
                 rgbGen lightingDiffuse
         }
 	{
-                map models/wop_players/padman/pad_fx.tga
+                map models/wop_players/padman/pad_fx
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
                 tcgen environment
 		rgbGen lightingDiffuse
@@ -308,10 +308,10 @@ models/wop_players/padman/padrock_goggles_red
 
 models/wop_players/padman/padsoldier_head
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/padsoldier_head.tga
+                map models/wop_players/padman/padsoldier_head
                 alphaFunc GE128
 		rgbGen lightingdiffuse
         }
@@ -319,10 +319,10 @@ models/wop_players/padman/padsoldier_head
 
 models/wop_players/padman/padsoldier_head_blue
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/padsoldier_head_blue.tga
+                map models/wop_players/padman/padsoldier_head_blue
                 alphaFunc GE128
 		rgbGen lightingdiffuse
         }
@@ -331,10 +331,10 @@ models/wop_players/padman/padsoldier_head_blue
 
 models/wop_players/padman/padsoldier_head_red
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/padsoldier_head_red.tga
+                map models/wop_players/padman/padsoldier_head_red
                 alphaFunc GE128
 		rgbGen lightingdiffuse
         }
@@ -347,10 +347,10 @@ models/wop_players/padman/padsoldier_head_red
 
 models/wop_players/padman/stonepad_head
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/stonepad_head.tga
+                map models/wop_players/padman/stonepad_head
                 alphaFunc GE128
 		rgbGen lightingdiffuse
         }
@@ -358,10 +358,10 @@ models/wop_players/padman/stonepad_head
 
 models/wop_players/padman/stonepad_head_blue
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/stonepad_head_blue.tga
+                map models/wop_players/padman/stonepad_head_blue
                 alphaFunc GE128
 		rgbGen lightingdiffuse
         }
@@ -369,10 +369,10 @@ models/wop_players/padman/stonepad_head_blue
 
 models/wop_players/padman/stonepad_head_red
 {
-    
+
     cull disable
         {
-                map models/wop_players/padman/stonepad_head_red.tga
+                map models/wop_players/padman/stonepad_head_red
                 alphaFunc GE128
 		rgbGen lightingdiffuse
         }
@@ -387,12 +387,12 @@ models/wop_players/padman/superpad_goggles
 {
      cull disable
         {
-                map models/wop_players/padman/superpad_head.tga
+                map models/wop_players/padman/superpad_head
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		map models/wop_players/padman/pad_fx.tga
+		map models/wop_players/padman/pad_fx
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
 		tcgen environment
 		rgbGen lightingDiffuse
@@ -406,19 +406,19 @@ models/wop_players/padman/superpad_head
 	nomipmaps
 	cull none
         {
-                map models/wop_players/padman/superpad_head.tga
+                map models/wop_players/padman/superpad_head
 	  //alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
         }
         {
-                map models/wop_players/padman/superpad_head.tga
+                map models/wop_players/padman/superpad_head
 	  alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
@@ -430,19 +430,19 @@ models/wop_players/padman/superpad_body
 	nomipmaps
 	cull none
         {
-                map models/wop_players/padman/superpad_body.tga
+                map models/wop_players/padman/superpad_body
 	  //alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
         }
         {
-                map models/wop_players/padman/superpad_body.tga
+                map models/wop_players/padman/superpad_body
 	  alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
@@ -453,23 +453,23 @@ models/wop_players/padman/superpad_cape
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/superpad_body.tga
+                map models/wop_players/padman/superpad_body
 		alphaFunc ge128
                 rgbGen identity
         }
-	
+
 }
 
 models/wop_players/padman/superpad_goggles_blue
 {
      cull disable
         {
-                map models/wop_players/padman/superpad_head_blue.tga
+                map models/wop_players/padman/superpad_head_blue
 		alphaFunc ge128
      	        rgbGen lightingDiffuse
         }
         {
-		map models/wop_players/padman/pad_fx.tga
+		map models/wop_players/padman/pad_fx
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
 		tcgen environment
 		rgbGen lightingDiffuse
@@ -482,11 +482,11 @@ models/wop_players/padman/superpad_cape_blue
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/superpad_body_blue.tga
+                map models/wop_players/padman/superpad_body_blue
 		alphaFunc ge128
                 rgbGen identity
         }
-	
+
 }
 
 models/wop_players/padman/superpad_head_blue
@@ -495,19 +495,19 @@ models/wop_players/padman/superpad_head_blue
 	nomipmaps
 	cull none
         {
-                map models/wop_players/padman/superpad_head_blue.tga
+                map models/wop_players/padman/superpad_head_blue
 	  //alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
         }
         {
-                map models/wop_players/padman/superpad_head_blue.tga
+                map models/wop_players/padman/superpad_head_blue
 	  alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
@@ -519,19 +519,19 @@ models/wop_players/padman/superpad_body_blue
 	nomipmaps
 	cull none
         {
-                map models/wop_players/padman/superpad_body_blue.tga
+                map models/wop_players/padman/superpad_body_blue
 	  //alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
         }
         {
-                map models/wop_players/padman/superpad_body_blue.tga
+                map models/wop_players/padman/superpad_body_blue
 	  alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
@@ -541,12 +541,12 @@ models/wop_players/padman/superpad_goggles_red
 {
      cull disable
         {
-                map models/wop_players/padman/superpad_head_red.tga
+                map models/wop_players/padman/superpad_head_red
 		alphaFunc ge128
                 rgbGen lightingDiffuse
         }
         {
-		map models/wop_players/padman/pad_fx.tga
+		map models/wop_players/padman/pad_fx
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
 		tcgen environment
 		rgbGen lightingDiffuse
@@ -559,11 +559,11 @@ models/wop_players/padman/superpad_cape_red
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/superpad_body_red.tga
+                map models/wop_players/padman/superpad_body_red
 		alphaFunc ge128
                 rgbGen identity
         }
-	
+
 }
 
 models/wop_players/padman/superpad_head_red
@@ -572,19 +572,19 @@ models/wop_players/padman/superpad_head_red
 	nomipmaps
 	cull none
         {
-                map models/wop_players/padman/superpad_head_red.tga
+                map models/wop_players/padman/superpad_head_red
 	  //alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
         }
         {
-                map models/wop_players/padman/superpad_head_red.tga
+                map models/wop_players/padman/superpad_head_red
 	  alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
@@ -596,19 +596,19 @@ models/wop_players/padman/superpad_body_red
 	nomipmaps
 	cull none
         {
-                map models/wop_players/padman/superpad_body_red.tga
+                map models/wop_players/padman/superpad_body_red
 	  //alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
 	{
-		map textures/pad_gfx02/tinpad4.tga
+		map textures/pad_gfx02/tinpad4
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
         }
         {
-                map models/wop_players/padman/superpad_body_red.tga
+                map models/wop_players/padman/superpad_body_red
 	  alphaFunc ge128
 	  rgbGen lightingDiffuse
         }
@@ -623,29 +623,29 @@ models/wop_players/monster/monsterhawk_body
 {
      cull disable
         {
-                map models/wop_players/monster/monsterhawk_body.tga
+                map models/wop_players/monster/monsterhawk_body
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/monster/monsterhawk_body_blue
 {
      	cull disable
         {
-                map models/wop_players/monster/monsterhawk_body_blue.tga
+                map models/wop_players/monster/monsterhawk_body_blue
 		alphaFunc ge128
                 rgbGen lightingDiffuse
         }
-	
+
 }
 
 models/wop_players/monster/monsterhawk_body_red
 {
      cull disable
         {
-                map models/wop_players/monster/monsterhawk_body_red.tga
+                map models/wop_players/monster/monsterhawk_body_red
 		alphaFunc ge128
      	        rgbGen lightingDiffuse
         }
@@ -656,18 +656,18 @@ models/wop_players/monster/monsterhawk_head
 {
      	cull disable
         {
-                map models/wop_players/monster/monsterhawk_head.tga
+                map models/wop_players/monster/monsterhawk_head
 		alphaFunc ge128
                 rgbGen lightingDiffuse
         }
-	
+
 }
 
 models/wop_players/monster/monsterhawk_head_blue
 {
      cull disable
         {
-                map models/wop_players/monster/monsterhawk_head_blue.tga
+                map models/wop_players/monster/monsterhawk_head_blue
 		alphaFunc ge128
                 rgbGen lightingDiffuse
         }
@@ -678,11 +678,11 @@ models/wop_players/monster/monsterhawk_head_red
 {
      	cull disable
         {
-                map models/wop_players/monster/monsterhawk_head_red.tga
+                map models/wop_players/monster/monsterhawk_head_red
 		alphaFunc ge128
                 rgbGen lightingDiffuse
         }
-	
+
 }
 
 
@@ -694,11 +694,11 @@ models/wop_players/monster/monsterhawk_head_red
 //{
 //     cull disable
 //        {
-//                map models/wop_players/monsterpad/monsterhawk_upper.tga
+//                map models/wop_players/monsterpad/monsterhawk_upper
 //		alphaFunc ge128
 //		rgbGen lightingDiffuse
 //        }
-// 
+//
 //}
 //
 //
@@ -706,11 +706,11 @@ models/wop_players/monster/monsterhawk_head_red
 //{
 //     	cull disable
 //        {
-//                map models/wop_players/monsterpad/monsterhawk_upper_blue.tga
+//                map models/wop_players/monsterpad/monsterhawk_upper_blue
 //		alphaFunc ge128
 //                rgbGen lightingDiffuse
 //        }
-//	
+//
 //}
 //
 //
@@ -718,7 +718,7 @@ models/wop_players/monster/monsterhawk_head_red
 //{
 //     cull disable
 //        {
-//                map models/wop_players/monsterpad/monsterhawk_upper_red.tga
+//                map models/wop_players/monsterpad/monsterhawk_upper_red
 //		alphaFunc ge128
 //     	        rgbGen lightingDiffuse
 //        }
@@ -728,11 +728,11 @@ models/wop_players/monster/monsterhawk_head_red
 //{
 //     	cull disable
 //        {
-//                map models/wop_players/monsterpad/monsterhawk_head.tga
+//                map models/wop_players/monsterpad/monsterhawk_head
 //		alphaFunc ge128
 //                rgbGen lightingDiffuse
 //        }
-//	
+//
 //}
 //
 //
@@ -741,7 +741,7 @@ models/wop_players/monster/monsterhawk_head_red
 //{
 //     cull disable
 //        {
-//                map models/wop_players/monsterpad/monsterhawk_head_blue.tga
+//                map models/wop_players/monsterpad/monsterhawk_head_blue
 //		alphaFunc ge128
 //                rgbGen lightingDiffuse
 //        }
@@ -752,11 +752,11 @@ models/wop_players/monster/monsterhawk_head_red
 //{
 //     	cull disable
 //        {
-//                map models/wop_players/monsterpad/monsterhawk_head_red.tga
+//                map models/wop_players/monsterpad/monsterhawk_head_red
 //		alphaFunc ge128
 //                rgbGen lightingDiffuse
 //        }
-//	
+//
 //}
 
 
@@ -768,99 +768,99 @@ models/wop_players/padking/default_head
 {
      cull disable
         {
-                map models/wop_players/padking/default_head.tga
+                map models/wop_players/padking/default_head
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/default_lower
 {
      cull disable
         {
-                map models/wop_players/padking/default_lower.tga
+                map models/wop_players/padking/default_lower
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/default_upper
 {
      cull disable
         {
-                map models/wop_players/padking/default_upper.tga
+                map models/wop_players/padking/default_upper
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/head_red
 {
      cull disable
         {
-                map models/wop_players/padking/head_red.tga
+                map models/wop_players/padking/head_red
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/lower_red
 {
      cull disable
         {
-                map models/wop_players/padking/lower_red.tga
+                map models/wop_players/padking/lower_red
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/upper_red
 {
      cull disable
         {
-                map models/wop_players/padking/upper_red.tga
+                map models/wop_players/padking/upper_red
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/head_blue
 {
      cull disable
         {
-                map models/wop_players/padking/head_blue.tga
+                map models/wop_players/padking/head_blue
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/lower_blue
 {
      cull disable
         {
-                map models/wop_players/padking/lower_blue.tga
+                map models/wop_players/padking/lower_blue
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/upper_blue
 {
      cull disable
         {
-                map models/wop_players/padking/upper_blue.tga
+                map models/wop_players/padking/upper_blue
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 
@@ -872,47 +872,47 @@ models/wop_players/padking/head_padknight
 {
      cull disable
         {
-                map models/wop_players/padking/head_padknight.tga
+                map models/wop_players/padking/head_padknight
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/padknight_feather
 {
      cull none
         {
-                map models/wop_players/padking/head_padknight.tga
+                map models/wop_players/padking/head_padknight
 		alphaFunc GE128
 		rgbGen identityLighting
         }
         {
-                map models/wop_players/padking/head_padknight.tga
+                map models/wop_players/padking/head_padknight
 		blendfunc gl_src_alpha gl_one_minus_src_alpha
 		//rgbGen lightingDiffuse
 		rgbGen identityLighting
         }
- 
+
 }
 
 models/wop_players/padking/lower_padknight
 {
      cull disable
         {
-                map models/wop_players/padking/lower_padknight.tga
+                map models/wop_players/padking/lower_padknight
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/upper_padknight
 {
      cull disable
         {
-                map models/wop_players/padking/upper_padknight.tga
+                map models/wop_players/padking/upper_padknight
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 
@@ -920,47 +920,47 @@ models/wop_players/padking/padknight_head_red
 {
      cull disable
         {
-                map 	models/wop_players/padking/padknight_head_red.tga
+                map 	models/wop_players/padking/padknight_head_red
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/padknight_feather_red
 {
      cull none
         {
-                map models/wop_players/padking/padknight_head_red.tga
+                map models/wop_players/padking/padknight_head_red
 		alphaFunc GE128
 		rgbGen identityLighting
         }
         {
-                map models/wop_players/padking/padknight_head_red.tga
+                map models/wop_players/padking/padknight_head_red
 		blendfunc gl_src_alpha gl_one_minus_src_alpha
 		//rgbGen lightingDiffuse
 		rgbGen identityLighting
         }
- 
+
 }
 
 models/wop_players/padking/padknight_lower_red
 {
      cull disable
         {
-                map models/wop_players/padking/padknight_lower_red.tga
+                map models/wop_players/padking/padknight_lower_red
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/padknight_upper_red
 {
      cull disable
         {
-                map models/wop_players/padking/padknight_upper_red.tga
+                map models/wop_players/padking/padknight_upper_red
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 
@@ -968,47 +968,47 @@ models/wop_players/padking/padknight_head_blue
 {
      cull disable
         {
-                map models/wop_players/padking/padknight_head_blue.tga
+                map models/wop_players/padking/padknight_head_blue
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/padknight_feather_blue
 {
      cull none
         {
-                map models/wop_players/padking/padknight_head_blue.tga
+                map models/wop_players/padking/padknight_head_blue
 		alphaFunc GE128
 		rgbGen identityLighting
         }
         {
-                map models/wop_players/padking/padknight_head_blue.tga
+                map models/wop_players/padking/padknight_head_blue
 		blendfunc gl_src_alpha gl_one_minus_src_alpha
 		//rgbGen lightingDiffuse
 		rgbGen identityLighting
         }
- 
+
 }
 
 models/wop_players/padking/padknight_lower_blue
 {
      cull disable
         {
-                map models/wop_players/padking/padknight_lower_blue.tga
+                map models/wop_players/padking/padknight_lower_blue
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padking/padknight_upper_blue
 {
      cull disable
         {
-                map models/wop_players/padking/padknight_upper_blue.tga
+                map models/wop_players/padking/padknight_upper_blue
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 
@@ -1020,12 +1020,12 @@ models/wop_players/padpunk/default_goggles
 {
      cull disable
         {
-                map models/wop_players/padpunk/default_legs.tga
+                map models/wop_players/padpunk/default_legs
 		alphaFunc ge128
 	        rgbGen lightingDiffuse
         }
 	{
-                map models/wop_players/padman/pad_fx.tga
+                map models/wop_players/padman/pad_fx
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
                 tcgen environment
 		rgbGen lightingDiffuse
@@ -1043,33 +1043,33 @@ models/wop_players/padcho/lower_default
 {
      cull disable
         {
-                map models/wop_players/padcho/lower_default.tga
+                map models/wop_players/padcho/lower_default
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padcho/lower_red
 {
      cull disable
         {
-                map models/wop_players/padcho/lower_red.tga
+                map models/wop_players/padcho/lower_red
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 models/wop_players/padcho/lower_blue
 {
      cull disable
         {
-                map models/wop_players/padcho/lower_blue.tga
+                map models/wop_players/padcho/lower_blue
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
- 
+
 }
 
 
@@ -1081,19 +1081,19 @@ models/wop_players/piratepad/spooky_head_default
 {
      cull disable
         {
-                map models/wop_players/piratepad/spooky_head_default.tga
+                map models/wop_players/piratepad/spooky_head_default
 	blendfunc GL_ONE GL_ZERO
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		
-                map models/wop_players/piratepad/beam.tga
+
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen lightingDiffuse
-	}    
+	}
 
 
 }
@@ -1102,38 +1102,38 @@ models/wop_players/piratepad/spooky_head_red
 {
      cull disable
         {
-                map models/wop_players/piratepad/spooky_head_red.tga
+                map models/wop_players/piratepad/spooky_head_red
 	blendfunc GL_ONE GL_ZERO
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		
-                map models/wop_players/piratepad/beam.tga
+
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen lightingDiffuse
-	}    
+	}
 }
 
 models/wop_players/piratepad/spooky_head_blue
 {
      cull disable
         {
-                map models/wop_players/piratepad/spooky_head_blue.tga
+                map models/wop_players/piratepad/spooky_head_blue
 	blendfunc GL_ONE GL_ZERO
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		
-                map models/wop_players/piratepad/beam.tga
+
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen lightingDiffuse
-	}    
+	}
 }
 
 models/wop_players/piratepad/spooky_torso_default
@@ -1141,19 +1141,19 @@ models/wop_players/piratepad/spooky_torso_default
 
     cull disable
         {
-                map models/wop_players/piratepad/spooky_torso_default.tga
+                map models/wop_players/piratepad/spooky_torso_default
 	blendfunc GL_ONE GL_ZERO
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		
-                map models/wop_players/piratepad/beam.tga
+
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen lightingDiffuse
-	}    
+	}
 }
 
 models/wop_players/piratepad/spooky_torso_red
@@ -1161,19 +1161,19 @@ models/wop_players/piratepad/spooky_torso_red
 
     cull disable
         {
-                map models/wop_players/piratepad/spooky_torso_red.tga
+                map models/wop_players/piratepad/spooky_torso_red
 	blendfunc GL_ONE GL_ZERO
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		
-                map models/wop_players/piratepad/beam.tga
+
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen lightingDiffuse
-	}    
+	}
 }
 
 models/wop_players/piratepad/spooky_torso_blue
@@ -1181,79 +1181,79 @@ models/wop_players/piratepad/spooky_torso_blue
 
     cull disable
         {
-                map models/wop_players/piratepad/spooky_torso_blue.tga
+                map models/wop_players/piratepad/spooky_torso_blue
 	blendfunc GL_ONE GL_ZERO
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		
-                map models/wop_players/piratepad/beam.tga
+
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen lightingDiffuse
-	}    
+	}
 }
 
 models/wop_players/piratepad/spooky_legs_default
 {
-    
+
     cull disable
         {
-                map models/wop_players/piratepad/spooky_legs_default.tga
+                map models/wop_players/piratepad/spooky_legs_default
 	blendfunc GL_ONE GL_ZERO
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		
-                map models/wop_players/piratepad/beam.tga
+
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen lightingDiffuse
-	}    
+	}
 }
 
 models/wop_players/piratepad/spooky_legs_red
 {
-    
+
     cull disable
         {
-                map models/wop_players/piratepad/spooky_legs_red.tga
+                map models/wop_players/piratepad/spooky_legs_red
 	blendfunc GL_ONE GL_ZERO
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		
-                map models/wop_players/piratepad/beam.tga
+
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen lightingDiffuse
-	}    
+	}
 }
 
 models/wop_players/piratepad/spooky_legs_blue
 {
-    
+
     cull disable
         {
-                map models/wop_players/piratepad/spooky_legs_blue.tga
+                map models/wop_players/piratepad/spooky_legs_blue
 	blendfunc GL_ONE GL_ZERO
 		alphaFunc ge128
 		rgbGen lightingDiffuse
         }
         {
-		
-                map models/wop_players/piratepad/beam.tga
+
+                map models/wop_players/piratepad/beam
                 tcMod scroll -5 -.3
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen lightingDiffuse
-	}    
+	}
 }
 
 
@@ -1268,20 +1268,20 @@ models/wop_players/padgirl/padbabebody
 	nomipmaps
 	cull none
 	{
-		map models/wop_players/padgirl/padbabebody.tga
+		map models/wop_players/padgirl/padbabebody
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                             rgbGen lightingdiffuse
 	}
 	{
-		map models/wop_players/padgirl/padbabebody.tga
+		map models/wop_players/padgirl/padbabebody
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
@@ -1292,19 +1292,19 @@ models/wop_players/padgirl/padbabe_blue_body
               cull disable
 
 	{
-		map models/wop_players/padgirl/padbabe_blue_body.tga
+		map models/wop_players/padgirl/padbabe_blue_body
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                             rgbGen lightingdiffuse
 	}
 	{
-		map models/wop_players/padgirl/padbabe_blue_body.tga
+		map models/wop_players/padgirl/padbabe_blue_body
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
@@ -1316,19 +1316,19 @@ models/wop_players/padgirl/padbabe_red_body
 	nomipmaps
 
 	{
-		map models/wop_players/padgirl/padbabe_red_body.tga
+		map models/wop_players/padgirl/padbabe_red_body
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                             rgbGen lightingdiffuse
 	}
 	{
-		map models/wop_players/padgirl/padbabe_red_body.tga
+		map models/wop_players/padgirl/padbabe_red_body
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
@@ -1345,20 +1345,20 @@ models/wop_players/padgirl/padgrlbd
 	nomipmaps
 	cull none
 	{
-		map models/wop_players/padgirl/padgrlbd.tga
+		map models/wop_players/padgirl/padgrlbd
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
 		rgbGen lightingdiffuse
 	}
 	{
-		map models/wop_players/padgirl/padgrlbd.tga
+		map models/wop_players/padgirl/padgrlbd
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
@@ -1369,19 +1369,19 @@ models/wop_players/padgirl/padgrlbd_blue
         cull disable
 
 	{
-		map models/wop_players/padgirl/padgrlbd_blue.tga
+		map models/wop_players/padgirl/padgrlbd_blue
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                             rgbGen lightingdiffuse
 	}
 	{
-		map models/wop_players/padgirl/padgrlbd_blue.tga
+		map models/wop_players/padgirl/padgrlbd_blue
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
@@ -1392,19 +1392,19 @@ models/wop_players/padgirl/padgrlbd_red
 	nopicmip
 	nomipmaps
 	{
-		map models/wop_players/padgirl/padgrlbd_red.tga
+		map models/wop_players/padgirl/padgrlbd_red
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                             rgbGen lightingdiffuse
 	}
 	{
-		map models/wop_players/padgirl/padgrlbd_red.tga
+		map models/wop_players/padgirl/padgrlbd_red
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
@@ -1419,7 +1419,7 @@ models/wop_players/paddybell/default_wings
 {
      cull none
         {
-                map models/wop_players/paddybell/default_body.tga
+                map models/wop_players/paddybell/default_body
 		blendfunc blend
 		rgbGen lightingdiffuse
         }
@@ -1429,7 +1429,7 @@ models/wop_players/paddybell/default_wings_red
 {
      cull none
         {
-                map models/wop_players/paddybell/default_body_red.tga
+                map models/wop_players/paddybell/default_body_red
 		blendfunc blend
 		rgbGen lightingdiffuse
         }
@@ -1439,7 +1439,7 @@ models/wop_players/paddybell/default_wings_blue
 {
      cull none
         {
-                map models/wop_players/paddybell/default_body_blue.tga
+                map models/wop_players/paddybell/default_body_blue
 		blendfunc blend
 		rgbGen lightingdiffuse
         }
@@ -1454,7 +1454,7 @@ models/wop_players/paddybell/badpaddy_wings
 {
      cull none
         {
-                map models/wop_players/paddybell/badpaddy_body.tga
+                map models/wop_players/paddybell/badpaddy_body
 		blendfunc blend
 		rgbGen lightingdiffuse
         }
@@ -1464,7 +1464,7 @@ models/wop_players/paddybell/badpaddy_wings_blue
 {
      cull none
         {
-                map models/wop_players/paddybell/badpaddy_body_blue.tga
+                map models/wop_players/paddybell/badpaddy_body_blue
 		blendfunc blend
 		rgbGen lightingdiffuse
         }
@@ -1480,18 +1480,18 @@ models/wop_players/paddybell/paddybee_head
 	nopicmip
 	nomipmaps
 	{
-		map models/wop_players/paddybell/paddybee_head.tga
+		map models/wop_players/paddybell/paddybee_head
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3a.tga
+		map textures/pad_gfx02/tinpad3a
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/wop_players/paddybell/paddybee_head.tga
+		map models/wop_players/paddybell/paddybee_head
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
@@ -1503,18 +1503,18 @@ models/wop_players/paddybell/paddybee_head_red
 	nopicmip
 	nomipmaps
 	{
-		map models/wop_players/paddybell/paddybee_head_red.tga
+		map models/wop_players/paddybell/paddybee_head_red
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3a.tga
+		map textures/pad_gfx02/tinpad3a
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/wop_players/paddybell/paddybee_head_red.tga
+		map models/wop_players/paddybell/paddybee_head_red
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
@@ -1525,18 +1525,18 @@ models/wop_players/paddybell/paddybee_head_blue
 	nopicmip
 	nomipmaps
 	{
-		map models/wop_players/paddybell/paddybee_head_blue.tga
+		map models/wop_players/paddybell/paddybee_head_blue
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3a.tga
+		map textures/pad_gfx02/tinpad3a
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/wop_players/paddybell/paddybee_head_blue.tga
+		map models/wop_players/paddybell/paddybee_head_blue
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
@@ -1546,7 +1546,7 @@ models/wop_players/paddybell/paddybee_wings
 {
      cull disable
         {
-                map models/wop_players/paddybell/paddybee_body.tga
+                map models/wop_players/paddybell/paddybee_body
 		blendfunc blend
 		rgbGen lightingdiffuse
         }
@@ -1556,7 +1556,7 @@ models/wop_players/paddybell/paddybee_wings_red
 {
      cull disable
         {
-                map models/wop_players/paddybell/paddybee_body_red.tga
+                map models/wop_players/paddybell/paddybee_body_red
 		blendfunc blend
 		rgbGen lightingdiffuse
         }
@@ -1566,7 +1566,7 @@ models/wop_players/paddybell/paddybee_wings_blue
 {
      cull disable
         {
-                map models/wop_players/paddybell/paddybee_body_blue.tga
+                map models/wop_players/paddybell/paddybee_body_blue
 		blendfunc blend
 		rgbGen lightingdiffuse
         }

--- a/wop/scripts.pk3dir/scripts/wop_powerups.shader
+++ b/wop/scripts.pk3dir/scripts/wop_powerups.shader
@@ -6,7 +6,7 @@ models/powerups/armor/pad_shield_front
 
 {
 	{
-		map textures/pad_gfx02/padmapred.tga
+		map textures/pad_gfx02/padmapred
 		tcGen environment
                 rgbGen identity
 	}
@@ -16,10 +16,10 @@ models/powerups/armor/pad_shield_front
 
 models/powerups/armor/pad_shield_back
 
-{	
+{
 
 	{
-		map textures/pad_gfx02/padmapyel3.tga
+		map textures/pad_gfx02/padmapyel3
 		tcGen environment
                 rgbGen identity
 	}
@@ -27,10 +27,10 @@ models/powerups/armor/pad_shield_back
 
 models/powerups/armor/pad_shield_logo
 
-{	
+{
 
 	{
-		map textures/pad_gfx02/padmapyel3c.tga
+		map textures/pad_gfx02/padmapyel3c
 		tcGen environment
                 rgbGen identity
 	}
@@ -43,7 +43,7 @@ models/powerups/armor/pad_shard_bott
 	nopicmip
 	nomipmaps
 	{
-		map textures/pad_gfx02/padmapyel3c.tga
+		map textures/pad_gfx02/padmapyel3c
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
                 rgbGen identity
@@ -56,7 +56,7 @@ models/powerups/armor/pad_shard_top
 	nopicmip
 	nomipmaps
 	{
-		map textures/pad_gfx02/padmapred.tga
+		map textures/pad_gfx02/padmapred
 		tcGen environment
                 rgbGen identity
 	}
@@ -68,16 +68,16 @@ models/powerups/armor/pad_shard_top
 // =================
 
 models/weapons2/killerducks/teeth
-{	
+{
 	nopicmip
 	nomipmaps
 	cull none
 	surfaceparm nolightmap
 	{
-		map models/weapons2/killerducks/teeth.tga
+		map models/weapons2/killerducks/teeth
 		alphaFunc ge128
 		rgbGen lightingdiffuse
-		
+
 	}
 }
 
@@ -88,7 +88,7 @@ models/weapons2/killerducks/key
 	cull none
 	surfaceparm nolightmap
 	{
-		map models/weapons2/killerducks/key.tga
+		map models/weapons2/killerducks/key
 		//blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		alphaFunc ge128
 		//depthWrite
@@ -98,16 +98,16 @@ models/weapons2/killerducks/key
 
 
 models/weapons2/killerducks/duckwheel
-{	
+{
 	nopicmip
 	nomipmaps
 	surfaceparm nolightmap
 	{
-		map models/weapons2/killerducks/duckwheel.tga
+		map models/weapons2/killerducks/duckwheel
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -121,12 +121,12 @@ models/weapons2/killerducks/duckbody
 	nomipmaps
 	surfaceparm nolightmap
 	{
-		map models/weapons2/killerducks/duckbody.tga
+		map models/weapons2/killerducks/duckbody
                 blendfunc GL_ONE GL_ZERO
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -142,12 +142,12 @@ models/weapons2/killerducks/duckbody_maskties
 	surfaceparm nolightmap
 	cull disable
 	{
-		map models/weapons2/killerducks/duckbody.tga
+		map models/weapons2/killerducks/duckbody
                 blendfunc GL_ONE GL_ZERO
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -158,34 +158,34 @@ models/weapons2/killerducks/duckbody_maskties
 //powerup model
 
 models/weapons2/killerducks/killerduck_up
-{	
+{
 	nopicmip
 	nomipmaps
 	surfaceparm nolightmap
 	{
-		map textures/pad_gfx02/padmapyel3.tga
+		map textures/pad_gfx02/padmapyel3
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
 }
 
 //just add cull disable for the maskties only to save on polys :)
 models/weapons2/killerducks/killerduck_up_maskties
-{	
+{
 	nopicmip
 	nomipmaps
 	surfaceparm nolightmap
 	cull disable
 	{
-		map textures/pad_gfx02/padmapyel3.tga
+		map textures/pad_gfx02/padmapyel3
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
 }
 
@@ -198,7 +198,7 @@ models/powerups/instant/yellflare
     		surfaceparm nolightmap
     		cull none
         {
-            	clampmap models/powerups/instant/yellflare.tga
+            	clampmap models/powerups/instant/yellflare
             	blendFunc GL_ONE GL_ONE
         }
 }
@@ -218,8 +218,8 @@ powerups/berserkerAura
 	deformVertexes wave 400 inversesawtooth 0.1 3 0 2
 	{
 		//map $whiteimage
-		//map textures/pad_gfx02/invispad.tga
-		map textures/effects/berserkerAura.jpg
+		//map textures/pad_gfx02/invispad
+		map textures/effects/berserkerAura
 		blendfunc add
 		tcMod turb 0 0.15 0 0.25
 		//rgbGen entity
@@ -233,7 +233,7 @@ deadfadeSkin
 {
 	{
 //		map $whiteimage
-		animmap 10 textures/effects/death1.jpg textures/effects/death2.jpg textures/effects/death3.jpg
+		animmap 10 textures/effects/death1 textures/effects/death2 textures/effects/death3
 		rgbGen const ( 0.411765 0.580392 0.992157 )
 		alphaGen entity
 		blendfunc blend
@@ -249,13 +249,13 @@ punchySkins/padPowerpunchy_teeth
 	nomipmaps
 	cull none
 	{
-                map punchySkins/padPowerTeeth.tga
+                map punchySkins/padPowerTeeth
 		alphaFunc GE128
 		depthWrite
 		rgbGen lightingdiffuse
         }
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .3 .3
 		tcGen environment
@@ -271,18 +271,18 @@ punchySkins/padPowerpunchy_teeth
 // (1) PadPower Shader by SLoB 2002
 
 models/powerups/instant/quad
-{	
+{
 	nopicmip
 	nomipmaps
 	surfaceparm nolightmap
 	cull disable
 	{
-		map textures/pad_gfx02/tinpad2d.tga
+		map textures/pad_gfx02/tinpad2d
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
 }
 
@@ -291,7 +291,7 @@ models/powerups/instant/quad
 models/powerups/instant/cone
 {
 	{
-		map textures/pad_gfx02/padmappurp01.tga
+		map textures/pad_gfx02/padmappurp01
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
                 rgbGen identity
@@ -300,18 +300,18 @@ models/powerups/instant/cone
 models/powerups/instant/hrocket
 {
 	{
-		map textures/pad_gfx02/padmapyel3b.tga
+		map textures/pad_gfx02/padmapyel3b
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
                 rgbGen identity
-		
+
 	}
 }
 
 models/powerups/instant/wings
 {
 	{
-		map textures/pad_gfx02/padmapyel3b.tga
+		map textures/pad_gfx02/padmapyel3b
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
                 rgbGen identity
@@ -327,14 +327,14 @@ models/powerups/instant/fuseflare
     	surfaceparm nolightmap
     	cull none
         {
-            	clampmap models/powerups/instant/fuseflare.tga
+            	clampmap models/powerups/instant/fuseflare
             	blendFunc GL_ONE GL_ONE
         }
 }
 
 models/powerups/instant/fuse
 {
-	
+
 	deformVertexes autoSprite2
     	surfaceparm trans
     	surfaceparm nomarks
@@ -342,7 +342,7 @@ models/powerups/instant/fuse
     	cull none
 
 	{
-		map models/powerups/instant/fuse.tga
+		map models/powerups/instant/fuse
 		alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -353,7 +353,7 @@ models/powerups/instant/fuse
 models/powerups/instant/wwwings
 {
 	{
-		map textures/pad_gfx02/padmappurp.jpg
+		map textures/pad_gfx02/padmappurp
 		blendfunc GL_ONE GL_ZERO
 		tcGen environment
                 rgbGen identity
@@ -363,7 +363,7 @@ models/powerups/instant/wwwings
 models/powerups/instant/plunger
 {
 	{
-		map textures/pad_gfx02/padmappurp.jpg
+		map textures/pad_gfx02/padmappurp
 		blendfunc GL_ONE GL_ZERO
 		tcGen environment
                 //rgbGen identity
@@ -375,10 +375,10 @@ models/powerups/instant/plunger
 
 // (4) Floater Shader by SLoB 2002
 models/powerups/instant/floater
-{   	                 
+{
 	q3map_surfacelight 250
 	{
-		map textures/pad_gfx02/padmapblue.jpg
+		map textures/pad_gfx02/padmapblue
 		blendfunc GL_ONE GL_ZERO
 		tcGen environment
                 rgbGen lightingDiffuse //makes effect darker
@@ -389,7 +389,7 @@ models/powerups/instant/floater
 models/powerups/instant/jumper
 {
 	{
-		map textures/pad_gfx02/padmaprail2.tga
+		map textures/pad_gfx02/padmaprail2
 		blendfunc GL_ONE GL_ZERO
 		tcGen environment
                 rgbGen identity
@@ -399,7 +399,7 @@ models/powerups/instant/jumper
 models/powerups/instant/jboot
 {
 	{
-		map textures/pad_gfx02/padmaprail3.tga
+		map textures/pad_gfx02/padmaprail3
 		blendfunc GL_ONE GL_ZERO
 		tcGen environment
                 //rgbGen identity
@@ -411,7 +411,7 @@ models/powerups/instant/jboot
 models/powerups/instant/regen
 {
 	{
-		map textures/pad_gfx02/padmapred.tga
+		map textures/pad_gfx02/padmapred
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
                 rgbGen identity
@@ -423,8 +423,8 @@ models/powerups/instant/regen
 models/powerups/instant/padinvisible
 {
 	{
-		map textures/pad_gfx02/tinpad2c.tga
-                //map textures/sfx/specular.tga
+		map textures/pad_gfx02/tinpad2c
+                //map textures/sfx/specular
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
 	}
@@ -443,7 +443,7 @@ models/powerups/instant/invisflare
     		surfaceparm nolightmap
     		cull none
         {
-            	clampmap models/powerups/instant/invisflare.tga
+            	clampmap models/powerups/instant/invisflare
             	blendFunc GL_ONE GL_ONE
         }
 }
@@ -457,7 +457,7 @@ models/powerups/instant/redflare
     		surfaceparm nolightmap
     		cull none
         {
-            	clampmap models/powerups/instant/redflare.tga
+            	clampmap models/powerups/instant/redflare
             	blendFunc GL_ONE GL_ONE
         }
 }
@@ -471,7 +471,7 @@ models/powerups/instant/purpflare
     		surfaceparm nolightmap
     		cull none
         {
-            	clampmap models/powerups/instant/purpflare.tga
+            	clampmap models/powerups/instant/purpflare
             	blendFunc GL_ONE GL_ONE
         }
 }
@@ -485,7 +485,7 @@ models/powerups/instant/flightflare
     		surfaceparm nolightmap
     		cull none
         {
-            	clampmap models/powerups/instant/flightflare.tga
+            	clampmap models/powerups/instant/flightflare
             	blendFunc GL_ONE GL_ONE
         }
 }
@@ -499,7 +499,7 @@ models/powerups/instant/greenflare
     		surfaceparm nolightmap
     		cull none
         {
-            	clampmap models/powerups/instant/greenflare.tga
+            	clampmap models/powerups/instant/greenflare
             	blendFunc GL_ONE GL_ONE
         }
 }
@@ -509,8 +509,8 @@ powerups/padpower
 {
 	cull disable
 	{
-//		map textures/pad_gfx02/tinpad.tga
-		map textures/pad_gfx02/tinpad2d.tga
+//		map textures/pad_gfx02/tinpad
+		map textures/pad_gfx02/tinpad2d
 		tcMod turb 0 0.15 0 0.25
 		tcGen environment
 		rgbGen entity
@@ -520,7 +520,7 @@ powerups/padpower
 sprites/star01
 {
 	{
-		map sprites/star01.tga
+		map sprites/star01
 		blendfunc blend
 		alphaGen vertex
 	}
@@ -529,7 +529,7 @@ sprites/star01
 sprites/star02
 {
 	{
-		map sprites/star02.tga
+		map sprites/star02
 		blendfunc blend
 		alphaGen vertex
 	}
@@ -538,7 +538,7 @@ sprites/star02
 sprites/star03
 {
 	{
-		map sprites/star03.tga
+		map sprites/star03
 		blendfunc blend
 		alphaGen vertex
 	}
@@ -547,8 +547,8 @@ sprites/star03
 powerups/invisibility
 {
 	{
-		map textures/pad_gfx02/invispad.tga
-                //map textures/sfx/specular.tga
+		map textures/pad_gfx02/invispad
+                //map textures/sfx/specular
 		blendfunc GL_ONE GL_ONE
 		tcMod turb 0 0.15 0 0.25
 		tcGen environment
@@ -566,14 +566,14 @@ powerups/invisibility
 models/powerups/ammo/bottom
 {
 	nopicmip
-	nomipmaps	
+	nomipmaps
 	{
-		map models/powerups/ammo/bottom.tga
+		map models/powerups/ammo/bottom
 		rgbGen lightingDiffuse
 	}
 		//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -586,14 +586,14 @@ models/powerups/ammo/bottom
 models/powerups/ammo/top
 {
 	nopicmip
-	nomipmaps	
+	nomipmaps
 	{
-		map models/powerups/ammo/top.tga
+		map models/powerups/ammo/top
 		rgbGen lightingDiffuse
 	}
 		//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -606,13 +606,13 @@ models/powerups/ammo/waterbottle_nipper
 	nopicmip
 	nomipmaps
 	{
-		map models/powerups/ammo/waterbottle_nipper.tga
-		 
+		map models/powerups/ammo/waterbottle_nipper
+
 		rgbGen lightingDiffuse
         }
 	//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -625,13 +625,13 @@ models/powerups/ammo/waterbottle_balloony
 	nopicmip
 	nomipmaps
 	{
-		map models/powerups/ammo/waterbottle_balloony.tga
-		 
+		map models/powerups/ammo/waterbottle_balloony
+
 		rgbGen lightingDiffuse
         }
 	//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -644,13 +644,13 @@ models/powerups/ammo/waterbottle_bubbleg
 	nopicmip
 	nomipmaps
 	{
-		map models/powerups/ammo/waterbottle_bubbleg.tga
-		
+		map models/powerups/ammo/waterbottle_bubbleg
+
 		rgbGen lightingDiffuse //makes effect darker
         }
 	//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -663,13 +663,13 @@ models/powerups/ammo/waterbottle_boaster
 	nopicmip
 	nomipmaps
 	{
-		map models/powerups/ammo/waterbottle_boaster.tga
-		
+		map models/powerups/ammo/waterbottle_boaster
+
 		rgbGen lightingDiffuse //makes effect darker
         }
 	//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -682,13 +682,13 @@ models/powerups/ammo/waterbottle_betty
 	nopicmip
 	nomipmaps
 	{
-		map models/powerups/ammo/waterbottle_betty.tga
-		 
+		map models/powerups/ammo/waterbottle_betty
+
 		rgbGen lightingDiffuse //makes effect darker
         }
 	//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -701,13 +701,13 @@ models/powerups/ammo/waterbottle_imperius
 	nopicmip
 	nomipmaps
 	{
-		map models/powerups/ammo/waterbottle_imperius.tga
-		
+		map models/powerups/ammo/waterbottle_imperius
+
 		rgbGen lightingDiffuse //makes effect darker
         }
 	//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -720,13 +720,13 @@ models/powerups/ammo/waterbottle_pumper
 	nopicmip
 	nomipmaps
 	{
-		map models/powerups/ammo/waterbottle_pumper.tga
-		
+		map models/powerups/ammo/waterbottle_pumper
+
 		rgbGen lightingDiffuse //makes effect darker
         }
 	//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -739,13 +739,13 @@ models/powerups/ammo/waterbottle_splasher
 	nopicmip
 	nomipmaps
 	{
-		map models/powerups/ammo/waterbottle_splasher.tga
-		 
+		map models/powerups/ammo/waterbottle_splasher
+
 		rgbGen lightingDiffuse //makes effect darker
         }
 	//slight sheen effect
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -760,7 +760,7 @@ models/powerups/ammo/waterbottle_splasher
 models/powerups/instant/bambam
 {
 	{
-		map textures/pad_gfx02/padmappurp02.tga
+		map textures/pad_gfx02/padmappurp02
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
                 rgbGen identity
@@ -775,24 +775,24 @@ models/powerups/instant/bamflare
     		surfaceparm nolightmap
     		cull none
         {
-            	clampmap models/powerups/instant/bamflare.tga
+            	clampmap models/powerups/instant/bamflare
             	blendFunc GL_ONE GL_ONE
         }
 }
 
 models/powerups/instant/bambam_teeth
-{	
+{
 	nopicmip
 	nomipmaps
 	surfaceparm nolightmap
 	cull disable
 	{
-		map textures/pad_gfx02/padmapblue4.tga
+		map textures/pad_gfx02/padmapblue4
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
 }
 
@@ -802,7 +802,7 @@ models/weapons2/bambam/bambam_zzz
 	surfaceparm nolightmap
 	deformVertexes autoSprite
 	{
-		map models/weapons2/bambam/bambam_zzz.tga
+		map models/weapons2/bambam/bambam_zzz
 		rgbGen identity
 		alphaFunc GE128
 	}
@@ -811,7 +811,7 @@ models/weapons2/bambam/bambam_zzz
 models/weapons2/bambam/bambam_redfx
 {
 	{
-        map models/weapons2/bambam/redpainti.jpg
+        map models/weapons2/bambam/redpainti
 	tcGen environment
 	tcMod turb .1 0 .3 .2
         tcMod scroll .1 .09
@@ -822,7 +822,7 @@ models/weapons2/bambam/bambam_redfx
 models/weapons2/bambam/bambam_bluefx
 {
 	{
-        map models/weapons2/bambam/bluepainti.jpg
+        map models/weapons2/bambam/bluepainti
 	tcGen environment
 	tcMod turb .1 0 .3 .2
         tcMod scroll .1 .09
@@ -833,7 +833,7 @@ models/weapons2/bambam/bambam_bluefx
 models/weapons2/bambam/bambam_burnoutfx
 {
 	{
-        map models/weapons2/bambam/burnout.jpg
+        map models/weapons2/bambam/burnout
 	tcGen environment
 	tcMod turb 0 .5 0 .3
         tcMod scroll .1 .09
@@ -848,19 +848,19 @@ models/weapons2/bambam/bambam
 	nopicmip
 	nomipmaps
 	{
-                map textures/pad_gfx02/padmapblack.tga
+                map textures/pad_gfx02/padmapblack
 		tcGen environment
 		tcMod turb 0 .5 0 .3
                		 tcMod scroll .1 .09
 		rgbGen lightingdiffuse
 		        	}
 	{
-		map models/weapons2/bambam/bambam.tga
+		map models/weapons2/bambam/bambam
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -871,7 +871,7 @@ models/weapons2/bambam/bambam
 bambamBall
 {
 	{
-		map models/weaponsfx/bambamball.jpg
+		map models/weaponsfx/bambamball
 		blendFunc add
 	}
 }
@@ -881,7 +881,7 @@ models/weaponsfx/bambamdrop
 {
 	cull none
 	{
-		map models/weaponsfx/bambamdrop.jpg
+		map models/weaponsfx/bambamdrop
 		blendFunc add
 		rgbGen wave inversesawtooth 0 1 0 1.2
 	}
@@ -891,7 +891,7 @@ models/weaponsfx/bambamdrop_blue
 {
 	cull none
 	{
-		map models/weaponsfx/bambamdrop_blue.jpg
+		map models/weaponsfx/bambamdrop_blue
 		blendFunc add
 		rgbGen wave inversesawtooth 0 1 0 1.2
 	}
@@ -901,7 +901,7 @@ models/weaponsfx/bambamdrop_red
 {
 	cull none
 	{
-		map models/weaponsfx/bambamdrop_red.jpg
+		map models/weaponsfx/bambamdrop_red
 		blendFunc add
 		rgbGen wave inversesawtooth 0 1 0 1.2
 	}
@@ -915,11 +915,11 @@ models/weaponsfx/bambamdrop_red
 models/powerups/instant/boomies
 {
 	{
-		map textures/pad_gfx02/padmaplil.tga
+		map textures/pad_gfx02/padmaplil
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
                 rgbGen identity
-		
+
 	}
 }
 
@@ -931,24 +931,24 @@ models/powerups/instant/blueflare
     		surfaceparm nolightmap
     		cull none
         {
-            	clampmap models/powerups/instant/blueflare.tga
+            	clampmap models/powerups/instant/blueflare
             	blendFunc GL_ONE GL_ONE
         }
 }
 
 models/powerups/instant/boomies_arc
-{	
+{
 	nopicmip
 	nomipmaps
 	surfaceparm nolightmap
 	cull disable
 	{
-		map textures/pad_gfx02/padmappurp01.tga
+		map textures/pad_gfx02/padmappurp01
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
 }
 
@@ -960,20 +960,20 @@ models/weapons2/boomies/boomies_red
 	surfaceparm nolightmap
 	cull disable
 	{
-                map models/weapons2/spraypistol/redpaint.jpg
+                map models/weapons2/spraypistol/redpaint
 		tcGen environment
 		tcMod turb 0 .5 0 .3
                 tcMod scroll .1 .09
 		rgbGen identity
 	}
 	{
-		map models/weapons2/boomies/boomies_red.tga
+		map models/weapons2/boomies/boomies_red
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 
   	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -989,20 +989,20 @@ models/weapons2/boomies/boomies_blue
 	surfaceparm nolightmap
 	cull disable
 	{
-                map models/weapons2/spraypistol/bluepaint.jpg
+                map models/weapons2/spraypistol/bluepaint
 		tcGen environment
 		tcMod turb 0 .5 0 .3
                		 tcMod scroll .1 .09
 		rgbGen identity
 		        	}
 	{
-		map models/weapons2/boomies/boomies_blue.tga
+		map models/weapons2/boomies/boomies_blue
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 
   	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -1014,7 +1014,7 @@ boomiesCore
 {
 	cull none
 	{
-		map models/weaponsfx/boomiescore.tga
+		map models/weaponsfx/boomiescore
 		blendFunc add
 		rgbGen entity
 	}
@@ -1023,7 +1023,7 @@ boomiesCore
 models/weaponsfx/boomiessphere
 {
 	{
-		map models/weaponsfx/boomiessphere.tga
+		map models/weaponsfx/boomiessphere
 		blendFunc add
 		rgbGen entity
 		tcMod scroll 0.5 0.7

--- a/wop/scripts.pk3dir/scripts/wop_weapons.shader
+++ b/wop/scripts.pk3dir/scripts/wop_weapons.shader
@@ -4,24 +4,24 @@
 
 models/weapons2/boaster/boaster
 {
-	qer_editorimage models/weapons2/boaster/boaster.tga
+	qer_editorimage models/weapons2/boaster/boaster
 
 	nopicmip
 	nomipmaps
 	{
-		map models/weapons2/boaster/tubew.tga
+		map models/weapons2/boaster/tubew
 		blendfunc GL_ONE GL_ZERO
 		tcMod scroll .07 .0
 		rgbGen lightingdiffuse
-		
+
 	}
 	{
-		map models/weapons2/boaster/boaster.tga
+		map models/weapons2/boaster/boaster
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -34,17 +34,17 @@ models/weapons2/boaster/boaster_flash
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/boaster/f_boaster.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/boaster/f_boaster
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/boaster/f_boaster.jpg
+		clampmap models/weapons2/boaster/f_boaster
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 // =================
@@ -56,55 +56,55 @@ models/weapons2/betty/betty_flash
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/betty/f_betty.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/betty/f_betty
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/betty/f_betty.jpg
+		clampmap models/weapons2/betty/f_betty
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 models/weapons2/betty/betty
 {
 	nopicmip
 	nomipmaps
-	
+
 	{
-	        map models/weapons2/betty/fir02.tga
-		blendfunc GL_ONE GL_ZERO                   
+	        map models/weapons2/betty/fir02
+		blendfunc GL_ONE GL_ZERO
                 tcMod turb 0 .2 0 .2
                 tcmod scale .4 .4
-                tcMod scroll .09 -.1.1         
+                tcMod scroll .09 -.1.1
                 rgbGen lightingdiffuse
-        }	
+        }
         {
-                map models/weapons2/betty/fir01.tga
-		blendfunc GL_ONE GL_ONE                   
+                map models/weapons2/betty/fir01
+		blendfunc GL_ONE GL_ONE
                 tcMod turb 0 .1 0 .3
                 tcmod scale .2 .2
-                tcMod scroll .1 .09         
+                tcMod scroll .1 .09
                 rgbGen lightingdiffuse
-		
+
         }
-	
+
 	{
-		map models/weapons2/betty/betty.tga
+		map models/weapons2/betty/betty
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
-	
+
 }
 
 // =================
@@ -116,93 +116,93 @@ models/weapons2/nipper/f_nipper
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/nipper/f_nipper.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/nipper/f_nipper
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/nipper/f_nipper.jpg
+		clampmap models/weapons2/nipper/f_nipper
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 models/weapons2/nipper/nipper2_trans
 {
 	nopicmip
 	nomipmaps
-	
+
 	{
-	        map models/weapons2/nipper/water01.tga
-		blendfunc GL_ONE GL_ZERO                   
+	        map models/weapons2/nipper/water01
+		blendfunc GL_ONE GL_ZERO
                 tcMod turb 0 .2 0 .2
                 tcmod scale .4 .4
-                tcMod scroll .09 -.1.1         
+                tcMod scroll .09 -.1.1
                 rgbGen lightingdiffuse
-        }	
+        }
         {
-                map models/weapons2/nipper/water02.tga
-		blendfunc GL_ONE GL_ONE                   
+                map models/weapons2/nipper/water02
+		blendfunc GL_ONE GL_ONE
                 tcMod turb 0 .1 0 .3
                 tcmod scale .2 .2
-                tcMod scroll .1 .09         
+                tcMod scroll .1 .09
                 rgbGen lightingdiffuse
-		
+
         }
-	
+
 	{
-		map models/weapons2/nipper/nipper2_trans.tga
+		map models/weapons2/nipper/nipper2_trans
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
-	
+
 }
 
 models/weapons2/nipper/nipper
 {
 	nopicmip
 	nomipmaps
-	
+
 	{
-	        map models/weapons2/nipper/water01.tga
-		blendfunc GL_ONE GL_ZERO                   
+	        map models/weapons2/nipper/water01
+		blendfunc GL_ONE GL_ZERO
                 tcMod turb 0 .2 0 .2
                 tcmod scale .4 .4
-                tcMod scroll .09 -.1.1         
+                tcMod scroll .09 -.1.1
                 rgbGen lightingdiffuse
-        }	
+        }
         {
-                map models/weapons2/nipper/water02.tga
-		blendfunc GL_ONE GL_ONE                   
+                map models/weapons2/nipper/water02
+		blendfunc GL_ONE GL_ONE
                 tcMod turb 0 .1 0 .3
                 tcmod scale .2 .2
-                tcMod scroll .1 .09         
+                tcMod scroll .1 .09
                 rgbGen lightingdiffuse
-		
+
         }
-	
+
 	{
-		map models/weapons2/nipper/nipper.tga
+		map models/weapons2/nipper/nipper
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
-	
+
 }
 
 // =================
@@ -211,17 +211,17 @@ models/weapons2/nipper/nipper
 
 models/weapons2/pumper/pumper
 {
-	qer_editorimage models/weapons2/pumper/pumper.tga
+	qer_editorimage models/weapons2/pumper/pumper
 
 	nopicmip
 	nomipmaps
 	{
-		map models/weapons2/pumper/pumper.tga
+		map models/weapons2/pumper/pumper
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -231,17 +231,17 @@ models/weapons2/pumper/pumper
 
 models/weapons2/pumper/tubes
 {
-	qer_editorimage models/weapons2/pumper/tubes.tga
+	qer_editorimage models/weapons2/pumper/tubes
 
 	nopicmip
 	nomipmaps
 	{
-		map models/weapons2/pumper/tubes.tga
+		map models/weapons2/pumper/tubes
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -255,17 +255,17 @@ models/weapons2/pumper/f_pumper
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/pumper/f_pumper.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/pumper/f_pumper
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/pumper/f_pumper.jpg
+		clampmap models/weapons2/pumper/f_pumper
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 // =================
@@ -274,25 +274,25 @@ models/weapons2/pumper/f_pumper
 
 models/weapons2/splasher/splasher
 {
-	qer_editorimage models/weapons2/splasher/splasher.tga
+	qer_editorimage models/weapons2/splasher/splasher
 
 	nopicmip
 	nomipmaps
 	{
-		map textures/pad_gfx02/tinpad2d.tga
+		map textures/pad_gfx02/tinpad2d
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
 	{
-		map models/weapons2/splasher/splasher.tga
+		map models/weapons2/splasher/splasher
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -302,17 +302,17 @@ models/weapons2/splasher/splasher
 
 models/weapons2/splasher/new_frontface
 {
-	qer_editorimage models/weapons2/splasher/new_frontface.tga
+	qer_editorimage models/weapons2/splasher/new_frontface
 
 	nopicmip
 	nomipmaps
 	{
-		map models/weapons2/splasher/new_frontface.tga
+		map models/weapons2/splasher/new_frontface
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -325,45 +325,45 @@ models/weapons2/splasher/splasher_flash
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/splasher/f_splasher.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/splasher/f_splasher
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/splasher/f_splasher.jpg
+		clampmap models/weapons2/splasher/f_splasher
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 models/weapons2/splasher/splasherwater
-{	                 
+{
 	{
-		
-                map textures/pad_gfx02/padmapplas.jpg
-		blendfunc GL_ONE GL_ZERO                   
+
+                map textures/pad_gfx02/padmapplas
+		blendfunc GL_ONE GL_ZERO
                 tcMod turb 0 .6 0 .2
                 tcmod scale .4 .4
-                tcMod scroll .09 -.1.1         
-                //rgbGen lightingdiffuse //identity             
-        }	
+                tcMod scroll .09 -.1.1
+                //rgbGen lightingdiffuse //identity
+        }
         {
-                map textures/pad_gfx02/padmapblue2.jpg
-		blendfunc GL_ONE GL_ONE                   
+                map textures/pad_gfx02/padmapblue2
+		blendfunc GL_ONE GL_ONE
                 tcMod turb 0 .7 0 .3
                 tcmod scale .2 .2
-                tcMod scroll .1 .09         
+                tcMod scroll .1 .09
                 //rgbGen lightingdiffuse
-        }	
+        }
         {
-		map textures/pad_gfx02/padmapblue.jpg
+		map textures/pad_gfx02/padmapblue
                 blendFunc GL_ONE GL_ONE
 		tcGen environment
 		tcMod scroll -.3 0
 		//rgbGen lightingDiffuse
-	}     	
+	}
 }
 
 
@@ -377,17 +377,17 @@ models/weapons2/bubbleg/bubbleg_flash
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/bubbleg/f_bubbleg.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/bubbleg/f_bubbleg
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/bubbleg/f_bubbleg.jpg
+		clampmap models/weapons2/bubbleg/f_bubbleg
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 
@@ -395,38 +395,38 @@ models/weapons2/bubbleg/bubbleg
 {
 	nopicmip
 	nomipmaps
-	
+
 	{
-	        map models/weapons2/bubbleg/watbub02.tga
-		blendfunc GL_ONE GL_ZERO                   
+	        map models/weapons2/bubbleg/watbub02
+		blendfunc GL_ONE GL_ZERO
                 tcMod turb 0 .2 0 .2
 
-                tcMod scroll .09 -.1.1         
+                tcMod scroll .09 -.1.1
                 rgbGen lightingdiffuse
-        }	
+        }
         {
-                map models/weapons2/bubbleg/watbub.tga
-		blendfunc GL_ONE GL_ONE                   
+                map models/weapons2/bubbleg/watbub
+		blendfunc GL_ONE GL_ONE
                 tcMod turb 0 .1 0 .3
 
-                tcMod scroll .1 .09         
+                tcMod scroll .1 .09
                 rgbGen lightingdiffuse
-		
+
         }
-	
+
 	{
-		map models/weapons2/bubbleg/bubbleg.tga
+		map models/weapons2/bubbleg/bubbleg
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
-	
+
 }
 
 // =================
@@ -435,17 +435,17 @@ models/weapons2/bubbleg/bubbleg
 
 models/weapons2/balloony/balloony
 {
-	qer_editorimage models/weapons2/balloony/balloony.tga
+	qer_editorimage models/weapons2/balloony/balloony
 
 	nopicmip
 	nomipmaps
 	{
-		map models/weapons2/balloony/balloony.tga
+		map models/weapons2/balloony/balloony
 		//alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -455,41 +455,41 @@ models/weapons2/balloony/balloony
 
 models/weapons2/balloony/stripemove
 {
-	qer_editorimage models/weapons2/balloony/stripemove_l2.tga
+	qer_editorimage models/weapons2/balloony/stripemove_l2
 
 	nopicmip
 	nomipmaps
 
 	{
-		map models/weapons2/balloony/stripemove.tga
+		map models/weapons2/balloony/stripemove
 		//blendfunc add
 		tcMod scroll .6 .0
 		rgbGen lightingdiffuse
-		
+
 	}
 	{
-		map models/weapons2/balloony/stripemove_l2.tga
+		map models/weapons2/balloony/stripemove_l2
 		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 		rgbGen lightingdiffuse
-		
+
 	}
-	
+
 }
 
 models/weapons2/balloony/tubemove
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/weapons2/balloony/balloony.tga
+	qer_editorimage models/weapons2/balloony/balloony
 
 	deformVertexes bulge .11 .08 3
-	
+
 	{
-		map models/weapons2/balloony/balloony.tga
+		map models/weapons2/balloony/balloony
 		rgbGen lightingdiffuse
-		
+
 	}
-	
+
 }
 
 
@@ -498,17 +498,17 @@ models/weapons2/balloony/balloony_flash
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/balloony/f_balloony.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/balloony/f_balloony
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/balloony/f_balloony.jpg
+		clampmap models/weapons2/balloony/f_balloony
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 
@@ -521,55 +521,55 @@ models/weapons2/imperius/imperius_flash
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/imperius/f_imperius.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/imperius/f_imperius
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/imperius/f_imperius.jpg
+		clampmap models/weapons2/imperius/f_imperius
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 models/weapons2/imperius/imperius
 {
 	nopicmip
 	nomipmaps
-	
+
 	{
-	        map models/weapons2/imperius/watpurp02.tga
-		blendfunc GL_ONE GL_ZERO                   
+	        map models/weapons2/imperius/watpurp02
+		blendfunc GL_ONE GL_ZERO
                 tcMod turb 0 .2 0 .2
                 tcmod scale .4 .4
-                tcMod scroll .09 -.1.1         
+                tcMod scroll .09 -.1.1
                 rgbGen lightingdiffuse
-        }	
+        }
         {
-                map models/weapons2/imperius/watpurp.tga
-		blendfunc GL_ONE GL_ONE                   
+                map models/weapons2/imperius/watpurp
+		blendfunc GL_ONE GL_ONE
                 tcMod turb 0 .1 0 .3
                 tcmod scale .2 .2
-                tcMod scroll .1 .09         
+                tcMod scroll .1 .09
                 rgbGen lightingdiffuse
-		
+
         }
-	
+
 	{
-		map models/weapons2/imperius/imperius.tga
+		map models/weapons2/imperius/imperius
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
-	
+
 }
 
 
@@ -582,15 +582,15 @@ models/weapons2/punchy/punchy_teeth
 	nopicmip
 	nomipmaps
 	cull none
-	qer_editorimage models/weapons2/punchy/teeth.tga
+	qer_editorimage models/weapons2/punchy/teeth
 	{
-                map models/weapons2/punchy/teeth.tga
+                map models/weapons2/punchy/teeth
 		alphaFunc GE128
 		depthWrite
 		rgbGen lightingdiffuse
         }
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .3 .3
 		tcGen environment
@@ -602,13 +602,13 @@ models/weapons2/punchy/punchy
 {
 	nopicmip
 	nomipmaps
-	
+
 	{
-                map models/weapons2/punchy/punchy.tga
+                map models/weapons2/punchy/punchy
 		rgbGen lightingdiffuse
         }
 	{
-		map textures/pad_gfx02/invispad.jpg
+		map textures/pad_gfx02/invispad
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .3 .3
 		tcGen environment
@@ -620,13 +620,13 @@ models/weapons2/punchy/eyes
 {
 	nopicmip
 	nomipmaps
-	
+
 	{
-                map models/weapons2/punchy/eyes.tga
+                map models/weapons2/punchy/eyes
 		rgbGen lightingdiffuse
         }
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .3 .3
 		tcGen environment
@@ -644,41 +644,41 @@ models/weapons2/spraypistol/f_spraypistolflash
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/spraypistol/f_spraypistolflash.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/spraypistol/f_spraypistolflash
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/spraypistol/f_spraypistolflash.jpg
+		clampmap models/weapons2/spraypistol/f_spraypistolflash
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 
 models/weapons2/spraypistol/spraypistol
 {
-	qer_editorimage models/weapons2/spraypistol/spraypistol.tga
+	qer_editorimage models/weapons2/spraypistol/spraypistol
 
 	nopicmip
 	nomipmaps
 	{
-		map textures/pad_gfx02/tinpad2d.tga
+		map textures/pad_gfx02/tinpad2d
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
 	{
-		map models/weapons2/spraypistol/spraypistol.tga
+		map models/weapons2/spraypistol/spraypistol
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -693,21 +693,21 @@ models/weapons2/spraypistol/cartridge_red
 	nopicmip
 	sort 9
 	{
-                map models/weapons2/spraypistol/redpaint.jpg
+                map models/weapons2/spraypistol/redpaint
 		tcGen environment
 		tcMod turb 0 .5 0 .3
                 tcMod scroll .1 .09
 		rgbGen identity
-		
+
         }
 	{
-		map models/weapons2/spraypistol/padcart_r.tga
+		map models/weapons2/spraypistol/padcart_r
 		alphaFunc ge128
 		rgbGen identity
 
   	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -722,21 +722,21 @@ models/weapons2/spraypistol/cartridge_blue
 	nopicmip
 	sort 9
 	{
-                map models/weapons2/spraypistol/bluepaint.jpg
+                map models/weapons2/spraypistol/bluepaint
 		tcGen environment
 		tcMod turb 0 .5 0 .3
                 tcMod scroll .1 .09
 		rgbGen identity
-		
+
         }
 	{
-		map models/weapons2/spraypistol/padcart_b.tga
+		map models/weapons2/spraypistol/padcart_b
 		alphaFunc ge128
 		rgbGen identity
 
   	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -751,21 +751,21 @@ models/weapons2/spraypistol/cartridge_neutral
 	nopicmip
 	sort 9
 	{
-                map models/weapons2/spraypistol/greenpaint.jpg
+                map models/weapons2/spraypistol/greenpaint
 		tcGen environment
 		tcMod turb 0 .5 0 .3
                 tcMod scroll .1 .09
 		rgbGen identity
-		
+
         }
 	{
-		map models/weapons2/spraypistol/padcart_n.tga
+		map models/weapons2/spraypistol/padcart_n
 		alphaFunc ge128
 		rgbGen identity
 
   	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -779,16 +779,16 @@ models/weapons2/spraypistol/cartridge_neutral
 
 models/weapons2/kma97/kma97
 {
-	qer_editorimage models/weapons2/kma97/kma97.tga
+	qer_editorimage models/weapons2/kma97/kma97
 
 	nopicmip
 	nomipmaps
 	{
-		map models/weapons2/kma97/kma97.tga
+		map models/weapons2/kma97/kma97
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment

--- a/wop/scripts.pk3dir/scripts/wop_weaponsfx.shader
+++ b/wop/scripts.pk3dir/scripts/wop_weaponsfx.shader
@@ -5,12 +5,12 @@
 waterExplosion
 {
 	{
-		animmap 5 models/weaponsfx/waterboom1.jpg models/weaponsfx/waterboom2.jpg models/weaponsfx/waterboom3.jpg
+		animmap 5 models/weaponsfx/waterboom1 models/weaponsfx/waterboom2 models/weaponsfx/waterboom3
 		blendFunc add
 		rgbGen wave inversesawtooth 0 1 0 5
 	}
 	{
-		animmap 5 models/weaponsfx/waterboom2.jpg models/weaponsfx/waterboom3.jpg models/weaponsfx/waterboom1.jpg
+		animmap 5 models/weaponsfx/waterboom2 models/weaponsfx/waterboom3 models/weaponsfx/waterboom1
 		blendFunc add
 		rgbGen wave sawtooth 0 1 0 5
 	}
@@ -20,7 +20,7 @@ models/weaponsfx/drop
 {
 	cull none
 	{
-		map models/weaponsfx/drop.jpg
+		map models/weaponsfx/drop
 		blendFunc add
 		rgbGen wave inversesawtooth 0 1 0 1.2
 	}
@@ -31,12 +31,12 @@ waterSplash
 {
 	cull disable
 	{
-		animmap 5 models/weaponsfx/water_splash_1.jpg models/weaponsfx/water_splash_2.jpg models/weaponsfx/water_splash_3.jpg gfx/colors/black.tga
+		animmap 5 models/weaponsfx/water_splash_1 models/weaponsfx/water_splash_2 models/weaponsfx/water_splash_3 gfx/colors/black
 		rgbGen wave inversesawtooth 0 1 0 5
 		blendfunc add
 	}
 	{
-		animmap 5 models/weaponsfx/water_splash_2.jpg models/weaponsfx/water_splash_3.jpg gfx/colors/black.tga gfx/colors/black.tga
+		animmap 5 models/weaponsfx/water_splash_2 models/weaponsfx/water_splash_3 gfx/colors/black gfx/colors/black
 		rgbGen wave sawtooth 0 1 0 5
 		blendfunc add
 	}
@@ -46,7 +46,7 @@ models/weaponsfx/balloony_drop
 {
 	cull none
 	{
-		map models/weaponsfx/balloony_drop.tga
+		map models/weaponsfx/balloony_drop
 		blendFunc add
 		rgbGen wave inversesawtooth 0 1 0 1.2
 	}
@@ -59,12 +59,12 @@ models/weaponsfx/balloony_drop
 fireBall
 {
 	{
-		animmap 10 models/weaponsfx/fireballs1.jpg models/weaponsfx/fireballs2.jpg models/weaponsfx/fireballs3.jpg
+		animmap 10 models/weaponsfx/fireballs1 models/weaponsfx/fireballs2 models/weaponsfx/fireballs3
 		blendFunc add
 		rgbGen wave inversesawtooth 0 1 0 10
 	}
 	{
-		animmap 3 models/weaponsfx/fireballs2.jpg models/weaponsfx/fireballs3.jpg models/weaponsfx/fireballs1.jpg
+		animmap 3 models/weaponsfx/fireballs2 models/weaponsfx/fireballs3 models/weaponsfx/fireballs1
 		blendFunc add
 		rgbGen wave sawtooth 0 1 0 10
 	}
@@ -73,13 +73,13 @@ fireBall
 fireTrail
 {
 	{
-		map models/weaponsfx/firetrail.jpg
+		map models/weaponsfx/firetrail
 		blendFunc add
 		rgbGen vertex
 		tcMod scroll 1.6 0
 	}
 	{
-		map models/weaponsfx/firetrail.jpg
+		map models/weaponsfx/firetrail
 		blendFunc add
 		rgbGen vertex
 		tcMod scale 2.1 1
@@ -93,12 +93,12 @@ fireExplosion
 {
 	cull disable
 	{
-		animmap 8 models/weaponsfx/bettyboom_1.tga models/weaponsfx/bettyboom_2.tga models/weaponsfx/bettyboom_3.tga models/weaponsfx/bettyboom_4.tga models/weaponsfx/bettyboom_5.tga models/weaponsfx/bettyboom_6.tga models/weaponsfx/bettyboom_7.tga models/weaponsfx/bettyboom_8.tga
+		animmap 8 models/weaponsfx/bettyboom_1 models/weaponsfx/bettyboom_2 models/weaponsfx/bettyboom_3 models/weaponsfx/bettyboom_4 models/weaponsfx/bettyboom_5 models/weaponsfx/bettyboom_6 models/weaponsfx/bettyboom_7 models/weaponsfx/bettyboom_8
 		rgbGen wave inversesawtooth 0 1 0 8
 		blendfunc add
 	}
 	{
-		animmap 8 models/weaponsfx/bettyboom_2.tga models/weaponsfx/bettyboom_3.tga models/weaponsfx/bettyboom_4.tga models/weaponsfx/bettyboom_5.tga models/weaponsfx/bettyboom_6.tga models/weaponsfx/bettyboom_7.tga models/weaponsfx/bettyboom_8.tga models/weaponsfx/black.tga
+		animmap 8 models/weaponsfx/bettyboom_2 models/weaponsfx/bettyboom_3 models/weaponsfx/bettyboom_4 models/weaponsfx/bettyboom_5 models/weaponsfx/bettyboom_6 models/weaponsfx/bettyboom_7 models/weaponsfx/bettyboom_8 models/weaponsfx/black
 		rgbGen wave sawtooth 0 1 0 8
 		blendfunc add
 	}
@@ -109,7 +109,7 @@ models/weaponsfx/firedrop
 {
 	cull none
 	{
-		map models/weaponsfx/firedrop.jpg
+		map models/weaponsfx/firedrop
 		blendFunc add
 	}
 }
@@ -124,7 +124,7 @@ waterBeam
 	nopicmip
 	nomipmaps
 	{
-		map models/weaponsfx/waterbeam.jpg
+		map models/weaponsfx/waterbeam
 		blendFunc add
 		rgbGen vertex
 	}
@@ -134,7 +134,7 @@ boasterExplosion
 {
 	cull none
 	{
-		clampmap models/weaponsfx/boasterboom.jpg
+		clampmap models/weaponsfx/boasterboom
 		blendfunc add
         tcMod stretch sawtooth .2 1.2 0 2.0
         rgbGen wave inversesawtooth 0 1 0 2.0
@@ -151,17 +151,17 @@ pumperTrail
 	nopicmip
 	nomipmaps
 	{
-		map models/weaponsfx/pumpertrail.jpg
+		map models/weaponsfx/pumpertrail
 		blendFunc add
 		rgbGen vertex
 	}
-}		
+}
 
 models/weaponsfx/flash
 {
 	cull none
 	{
-		animmap 9 models/weaponsfx/flash0.tga models/weaponsfx/flash1.tga models/weaponsfx/flash2.tga
+		animmap 9 models/weaponsfx/flash0 models/weaponsfx/flash1 models/weaponsfx/flash2
 		blendFunc add
 		tcMod turb 0 0.01 0 11
 		rgbGen wave inversesawtooth 0 1 0 1.2
@@ -176,17 +176,17 @@ models/weaponsfx/flash
 waterTrail
 {
 	{
-		map models/weaponsfx/watertrail.jpg
+		map models/weaponsfx/watertrail
 		blendFunc add
 		rgbGen vertex
 		tcMod scroll 1.6 0
 	}
 }
-	
+
 waterBall
 {
 	{
-		map models/weaponsfx/waterball.jpg
+		map models/weaponsfx/waterball
 		blendFunc add
 	}
 }
@@ -195,13 +195,13 @@ waterMark
 {
 	polygonOffset
 	{
-		map models/weaponsfx/waterball.tga
+		map models/weaponsfx/waterball
 		blendfunc add
 		rgbGen vertex
 	}
 }
-	
-	
+
+
 // =================
 // NIPPER
 // =================
@@ -209,7 +209,7 @@ waterMark
 nipperBall
 {
 	{
-		map models/weaponsfx/nipperball.jpg
+		map models/weaponsfx/nipperball
 		blendFunc add
 	}
 }
@@ -217,7 +217,7 @@ nipperBall
 nipperWave
 {
 	{
-		map models/weaponsfx/nipperwave.tga
+		map models/weaponsfx/nipperwave
 		blendFunc add
         rgbGen wave inversesawtooth 0 1 0 1.5
 	}
@@ -230,7 +230,7 @@ nipperWave
 models/weaponsfx/impsphere
 {
 	{
-		map models/weaponsfx/impsphere.tga
+		map models/weaponsfx/impsphere
 		blendFunc add
 		rgbGen entity
 		tcMod scroll 0.5 0.7
@@ -241,7 +241,7 @@ models/weaponsfx/impring
 {
 	cull none
 	{
-		map models/weaponsfx/impring.tga
+		map models/weaponsfx/impring
 		blendFunc add
 		rgbGen entity
 	}
@@ -251,7 +251,7 @@ models/weaponsfx/impbeam
 {
 	cull none
 	{
-		map models/weaponsfx/impbeam.tga
+		map models/weaponsfx/impbeam
 		blendFunc add
 		rgbGen entity
 	}
@@ -261,7 +261,7 @@ imperiusCore
 {
 	cull none
 	{
-		map models/weaponsfx/impcore.tga
+		map models/weaponsfx/impcore
 		blendFunc add
 		rgbGen entity
 	}
@@ -271,7 +271,7 @@ imperiusRing
 {
 	cull none
 	{
-		map models/weaponsfx/impring.tga
+		map models/weaponsfx/impring
 		blendFunc add
 		rgbGen entity
 	}
@@ -286,7 +286,7 @@ models/weaponsfx/gum
 {
 	cull none
 	{
-		map models/weaponsfx/gum.tga
+		map models/weaponsfx/gum
 		rgbGen entity
 	}
 }
@@ -300,7 +300,7 @@ kmaTrail
 	sort nearest
 	cull disable
 	{
-		map models/weaponsfx/kmatrail.jpg
+		map models/weaponsfx/kmatrail
 		blendfunc add
 		rgbGen Vertex
 	}
@@ -310,7 +310,7 @@ kmaMark
 {
 	polygonOffset
 	{
-		map gfx/damage/kma_mrk.tga
+		map gfx/damage/kma_mrk
 		blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR
 		rgbGen exactVertex
 	}
@@ -321,7 +321,7 @@ models/weaponsfx/smallkmadrop
 {
 	cull none
 	{
-		map models/weaponsfx/smallkmadrop.jpg
+		map models/weaponsfx/smallkmadrop
 		blendFunc add
 		rgbGen wave inversesawtooth 0 1 0 1.2
 	}
@@ -333,19 +333,19 @@ models/weapons2/kma97/kma97_flash
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/kma97/f_kma97.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/kma97/f_kma97
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
 		rgbGen entity
         }
         {
-		clampmap models/weapons2/kma97/f_kma97.jpg
+		clampmap models/weapons2/kma97/f_kma97
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
 		//tcMod stretch sin .8 0.10 0 .7
 		rgbGen entity
         }
-     
+
 }
 
 // =================
@@ -356,7 +356,7 @@ models/weaponsfx/star
 {
 	cull none
 	{
-		map models/weaponsfx/star.tga
+		map models/weaponsfx/star
 		blendFunc blend
 	}
 }
@@ -365,14 +365,14 @@ teleEffect
 {
 	cull none
 	{
-		map models/weaponsfx/teleflash.tga
+		map models/weaponsfx/teleflash
 		blendFunc add
 		rgbGen entity
 		tcMod scale 3 3
 		tcMod scroll 1.2 1.9
 	}
 	{
-		map models/weaponsfx/teleflash.tga
+		map models/weaponsfx/teleflash
 		blendFunc add
 		rgbGen entity
 		tcMod scale 4 4
@@ -388,14 +388,14 @@ teleEffectRed
 {
 	cull none
 	{
-		map models/weaponsfx/redteleflash.tga
+		map models/weaponsfx/redteleflash
 		blendFunc add
 		rgbGen entity
 		tcMod scale 3 3
 		tcMod scroll 1.2 1.9
 	}
 	{
-		map models/weaponsfx/redteleflash.tga
+		map models/weaponsfx/redteleflash
 		blendFunc add
 		rgbGen entity
 		tcMod scale 4 4
@@ -408,14 +408,14 @@ teleEffectGreen
 {
 	cull none
 	{
-		map models/weaponsfx/greenteleflash.tga
+		map models/weaponsfx/greenteleflash
 		blendFunc add
 		rgbGen entity
 		tcMod scale 3 3
 		tcMod scroll 1.2 1.9
 	}
 	{
-		map models/weaponsfx/greenteleflash.tga
+		map models/weaponsfx/greenteleflash
 		blendFunc add
 		rgbGen entity
 		tcMod scale 4 4
@@ -432,13 +432,13 @@ newDuckExplosion
 {
 	cull disable
 	{
-		animmap 10 models/weaponsfx/duckexp_1.jpg models/weaponsfx/duckexp_2.jpg models/weaponsfx/duckexp_3.jpg models/weaponsfx/duckexp_4.jpg models/weaponsfx/duckexp_5.jpg models/weaponsfx/duckexp_6.jpg models/weaponsfx/duckexp_7.jpg models/weaponsfx/duckexp_8.jpg
+		animmap 10 models/weaponsfx/duckexp_1 models/weaponsfx/duckexp_2 models/weaponsfx/duckexp_3 models/weaponsfx/duckexp_4 models/weaponsfx/duckexp_5 models/weaponsfx/duckexp_6 models/weaponsfx/duckexp_7 models/weaponsfx/duckexp_8
 		rgbGen wave inversesawtooth 0 1 0 10
 		blendfunc add
 	}
 	cull disable
 	{
-		animmap 10 models/weaponsfx/duckexp_2.jpg models/weaponsfx/duckexp_3.jpg models/weaponsfx/duckexp_4.jpg models/weaponsfx/duckexp_5.jpg models/weaponsfx/duckexp_6.jpg models/weaponsfx/duckexp_7.jpg models/weaponsfx/duckexp_8.jpg gfx/colors/black.jpg
+		animmap 10 models/weaponsfx/duckexp_2 models/weaponsfx/duckexp_3 models/weaponsfx/duckexp_4 models/weaponsfx/duckexp_5 models/weaponsfx/duckexp_6 models/weaponsfx/duckexp_7 models/weaponsfx/duckexp_8 gfx/colors/black
 		rgbGen wave sawtooth 0 1 0 10
 		blendfunc add
 	}
@@ -448,14 +448,14 @@ newDuckExplosion
 // BAMBAM
 bambamMissileRed {
 	{
-		map "models/weaponsfx/bambamball_red.jpg"
+		map "models/weaponsfx/bambamball_red"
 		blendFunc add
 	}
 }
 
 bambamMissileBlue {
 	{
-		map "models/weaponsfx/bambamball_blue.jpg"
+		map "models/weaponsfx/bambamball_blue"
 		blendFunc add
 	}
 }

--- a/xmas/scripts.pk3dir/scripts/freeztag.shader
+++ b/xmas/scripts.pk3dir/scripts/freeztag.shader
@@ -3,83 +3,83 @@
 // =================
 
 models/hats/elvehat
-{	
+{
 	cull none
 	{
-                map models/hats/elvehat.tga
+                map models/hats/elvehat
 		rgbGen lightingDiffuse
         }
-	
+
 }
 
 models/hats/reindeer
-{	
-		
+{
+
 	{
-                map models/hats/reindeer.tga
+                map models/hats/reindeer
 		rgbGen lightingDiffuse
         }
-	
+
 }
 
 models/hats/halo
-{	
-	cull none	
+{
+	cull none
 	{
-                map models/hats/halo.tga
+                map models/hats/halo
 		blendfunc GL_ONE GL_ONE
 		blendfunc add
         }
-	
+
 }
 
 models/hats/irish
-{	
-		
+{
+
 	{
-                map models/hats/irish.tga
+                map models/hats/irish
 		rgbGen lightingDiffuse
         }
-	
+
 }
 
 models/hats/tophat
-{	
-		
+{
+
 	{
-                map models/hats/tophat.tga
+                map models/hats/tophat
 		rgbGen lightingDiffuse
         }
-	
+
 }
 
 models/hats/nikolaus
-{	
-	cull none	
+{
+	cull none
 	{
-                map models/hats/nikolaus.tga
+                map models/hats/nikolaus
 		rgbGen lightingDiffuse
         }
-	
+
 }
 
 // with alpha
 
 models/hats/hking1
-{	
+{
 	cull disable
         {
-                map models/hats/hking1.tga
+                map models/hats/hking1
 		alphaFunc ge128
 	        rgbGen lightingDiffuse
         }
 	{
-                //map models/wop_players/padman/pad_fx.tga
-		map textures/pad_gfx02/tinpad.tga
+                //map models/wop_players/padman/pad_fx
+		map textures/pad_gfx02/tinpad
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
                 tcgen environment
 		rgbGen lightingDiffuse
 		depthfunc equal
         }
-	
+
 }

--- a/xmas/scripts.pk3dir/scripts/healthstation.shader
+++ b/xmas/scripts.pk3dir/scripts/healthstation.shader
@@ -2,18 +2,18 @@ models/mapobjects/pad_healthstation/HS_ring
 
 {
 	cull none
-	
+
 	{
-		map textures/pad_gfx02/padmapyel3.tga
+		map textures/pad_gfx02/padmapyel3
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
-	
+
 	{
-		map models/mapobjects/pad_healthstation/HS_ring.tga
+		map models/mapobjects/pad_healthstation/HS_ring
 		rgbGen lightingDiffuse
 		alphaFunc Ge128
 	}
@@ -23,18 +23,18 @@ models/mapobjects/pad_healthstation/HS_base
 
 {
 	cull none
-	
+
 	{
-		map textures/pad_gfx02/padmapyel3.tga
+		map textures/pad_gfx02/padmapyel3
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
-	
+
 	{
-		map models/mapobjects/pad_healthstation/HS_base.tga
+		map models/mapobjects/pad_healthstation/HS_base
 		rgbGen lightingDiffuse
 		alphaFunc Ge128
 	}
@@ -44,9 +44,9 @@ models/mapobjects/pad_healthstation/HS_base
 models/mapobjects/pad_healthstation/star
 
 {
-	
+
 	{
-	map models/mapobjects/pad_healthstation/star.tga
+	map models/mapobjects/pad_healthstation/star
 	rgbGen identity
 	}
 }

--- a/xmas/scripts.pk3dir/scripts/lightstringhat.shader
+++ b/xmas/scripts.pk3dir/scripts/lightstringhat.shader
@@ -2,7 +2,7 @@ models/hats/lightstringhat
 {
 	cull none
 	{
-	map models/hats/lightstringhat.tga
+	map models/hats/lightstringhat
 	rgbGen lightingDiffuse
 	}
 }
@@ -10,7 +10,7 @@ models/hats/lightstringhat
 models/hats/light01
 {
 	{
-	animMap 1 models/hats/light01.tga models/hats/light02.tga
+	animMap 1 models/hats/light01 models/hats/light02
 	rgbGen identity
 	}
 }

--- a/xmas/scripts.pk3dir/scripts/monster.shader
+++ b/xmas/scripts.pk3dir/scripts/monster.shader
@@ -2,11 +2,11 @@ models/wop_players/monster/mhead
 {
      cull disable
         {
-                map models/wop_players/monster/mnose.tga
+                map models/wop_players/monster/mnose
 		rgbGen wave sin 1 .5 0 1
         }
         {
-                map models/wop_players/monster/mhead.tga
+                map models/wop_players/monster/mhead
 		alphaFunc ge128
 	        rgbGen lightingDiffuse
         }
@@ -16,11 +16,11 @@ models/wop_players/monster/mhead_red
 {
      cull disable
         {
-                map models/wop_players/monster/mnose.tga
+                map models/wop_players/monster/mnose
 		rgbGen wave sin 1 .5 0 1
         }
         {
-                map models/wop_players/monster/mhead.tga
+                map models/wop_players/monster/mhead
 		alphaFunc ge128
 	        rgbGen lightingDiffuse
         }
@@ -30,11 +30,11 @@ models/wop_players/monster/mhead_blue
 {
      cull disable
         {
-                map models/wop_players/monster/mnose_blue.tga
+                map models/wop_players/monster/mnose_blue
 		rgbGen wave sin 1 .5 0 1
         }
         {
-                map models/wop_players/monster/mhead.tga
+                map models/wop_players/monster/mhead
 		alphaFunc ge128
 	        rgbGen lightingDiffuse
         }

--- a/xmas/scripts.pk3dir/scripts/pad_armour.shader
+++ b/xmas/scripts.pk3dir/scripts/pad_armour.shader
@@ -1,9 +1,9 @@
 models/powerups/armor/holly
 {
 	cull none
-	
+
 	{
-		map models/powerups/armor/holly.tga
+		map models/powerups/armor/holly
 		alphaFunc ge128
 		rgbGen identity
 	}
@@ -14,7 +14,7 @@ models/powerups/armor/ribbon
 {
 	cull none
 	{
-		map textures/pad_gfx02/padmapred.jpg
+		map textures/pad_gfx02/padmapred
 		blendfunc GL_ONE GL_ZERO
 		tcGen environment
                 rgbGen identity

--- a/xmas/scripts.pk3dir/scripts/pad_balloonbox.shader
+++ b/xmas/scripts.pk3dir/scripts/pad_balloonbox.shader
@@ -3,7 +3,7 @@ models/special/ballon
 {
 	nomipmaps
 	{
-		map models/special/ballon.tga
+		map models/special/ballon
 		rgbGen entity        }
 	{
 		map $lightmap
@@ -12,15 +12,15 @@ models/special/ballon
 	}
 
 	{
-		map models/special/balloon_color.tga
+		map models/special/balloon_color
 		rgbGen lightingDiffuse
 		alphaFunc Ge128
-		
+
 	}
 
 	{
-		map textures/pad_gfx02/tinpad3.tga
-		blendfunc GL_ONE GL_ONE 
+		map textures/pad_gfx02/tinpad3
+		blendfunc GL_ONE GL_ONE
 		tcGen environment
                 rgbGen entity //lightingDiffuse //vertex //identity //makes effect darker
 	}
@@ -28,14 +28,14 @@ models/special/ballon
 
 
 models/special/box
-{	
+{
 	nopicmip
 	nomipmaps
-	qer_editorimage models/special/box.tga
+	qer_editorimage models/special/box
 	{
-		map models/special/box.tga
+		map models/special/box
 		rgbGen lightingdiffuse
-		
+
 	}
 
 }

--- a/xmas/scripts.pk3dir/scripts/pad_garden.shader
+++ b/xmas/scripts.pk3dir/scripts/pad_garden.shader
@@ -1,7 +1,7 @@
 textures/pad_garden/jail_alpha_000 // Primary texture ONLY
 {
 
-qer_editorimage textures/pad_garden/jail_alpha_000.jpg
+qer_editorimage textures/pad_garden/jail_alpha_000
 
 q3map_alphaMod volume
 q3map_alphaMod set 0.00
@@ -14,7 +14,7 @@ qer_trans 0.75
 
 textures/pad_garden/jail_alpha_025
 {
-qer_editorimage textures/pad_garden/jail_alpha_025.jpg
+qer_editorimage textures/pad_garden/jail_alpha_025
 q3map_alphaMod volume
 q3map_alphaMod set 0.25
 surfaceparm nodraw
@@ -25,7 +25,7 @@ qer_trans 0.75
 
 textures/pad_garden/jail_alpha_050 // Perfect mix of both Primary + Secondary
 {
-qer_editorimage textures/pad_garden/jail_alpha_050.jpg
+qer_editorimage textures/pad_garden/jail_alpha_050
 q3map_alphaMod volume
 q3map_alphaMod set 0.50
 surfaceparm nodraw
@@ -35,7 +35,7 @@ qer_trans 0.75
 }
 textures/pad_garden/jail_alpha_075
 {
-qer_editorimage textures/pad_garden/jail_alpha_075.jpg
+qer_editorimage textures/pad_garden/jail_alpha_075
 q3map_alphaMod volume
 q3map_alphaMod set 0.75
 surfaceparm nodraw
@@ -46,7 +46,7 @@ qer_trans 0.75
 
 textures/pad_garden/jail_alpha_085
 {
-qer_editorimage textures/pad_garden/jail_alpha_085.jpg
+qer_editorimage textures/pad_garden/jail_alpha_085
 q3map_alphaMod volume
 q3map_alphaMod set 0.85
 surfaceparm nodraw
@@ -57,7 +57,7 @@ qer_trans 0.75
 
 textures/pad_garden/jail_alpha_100 // Secondary texture ONLY
 {
-qer_editorimage textures/pad_garden/jail_alpha_100.jpg
+qer_editorimage textures/pad_garden/jail_alpha_100
 q3map_alphaMod volume
 q3map_alphaMod set 1.0
 surfaceparm nodraw
@@ -69,14 +69,14 @@ qer_trans 0.75
 
 textures/pad_garden/vines
 {
-        qer_editorimage textures/pad_garden/vines.tga
+        qer_editorimage textures/pad_garden/vines
     	surfaceparm trans
 	surfaceparm alphashadow
    	surfaceparm nonsolid
 	cull none
         nopicmip
 	{
-		map textures/pad_garden/vines.tga
+		map textures/pad_garden/vines
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -92,14 +92,14 @@ textures/pad_garden/vines
 
 textures/pad_garden/vines2
 {
-        qer_editorimage textures/pad_garden/vines2.tga
+        qer_editorimage textures/pad_garden/vines2
     	surfaceparm trans
 	surfaceparm alphashadow
    	surfaceparm nonsolid
 	cull none
         nopicmip
 	{
-		map textures/pad_garden/vines2.tga
+		map textures/pad_garden/vines2
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -114,63 +114,63 @@ textures/pad_garden/vines2
 }
 
 
-textures/pad_garden/schilf01 
-{ 
-        qer_editorimage textures/pad_garden/schilf01.tga 
-      //q3map_lightimage textures/pad_garden/schilf01.tga 
-        qer_trans 0.5 
-        q3map_globaltexture 
-        surfaceparm trans 
-        surfaceparm nolightmap 
-        surfaceparm nonsolid 
-        surfaceparm water 
-        cull disable 
-        
-
-        { 
-               map textures/pad_garden/schilf01.tga 
-               tcMod turb 0.2 0.1 1 0.05 
-               tcMod scale 0.5 0.5 
-               tcMod scroll 0.01 0.01 
-               blendfunc add 
-               rgbGen vertex 
-
-        } 
-
-} 
+textures/pad_garden/schilf01
+{
+        qer_editorimage textures/pad_garden/schilf01
+      //q3map_lightimage textures/pad_garden/schilf01
+        qer_trans 0.5
+        q3map_globaltexture
+        surfaceparm trans
+        surfaceparm nolightmap
+        surfaceparm nonsolid
+        surfaceparm water
+        cull disable
 
 
-textures/pad_garden/schilf02 
-{ 
-        qer_editorimage textures/pad_garden/schilf02.tga 
-      //q3map_lightimage textures/pad_garden/schilf02.tga 
-        qer_trans 0.5 
-        q3map_globaltexture 
-        surfaceparm trans 
-        surfaceparm nonsolid 
-        surfaceparm water 
-        cull disable 
-        
+        {
+               map textures/pad_garden/schilf01
+               tcMod turb 0.2 0.1 1 0.05
+               tcMod scale 0.5 0.5
+               tcMod scroll 0.01 0.01
+               blendfunc add
+               rgbGen vertex
 
-        { 
-               map textures/pad_garden/schilf02.tga 
-               tcMod turb 0.2 0.1 1 0.05 
-               tcMod scale 0.5 0.5 
-               tcMod scroll 0.01 0.01 
+        }
+
+}
+
+
+textures/pad_garden/schilf02
+{
+        qer_editorimage textures/pad_garden/schilf02
+      //q3map_lightimage textures/pad_garden/schilf02
+        qer_trans 0.5
+        q3map_globaltexture
+        surfaceparm trans
+        surfaceparm nonsolid
+        surfaceparm water
+        cull disable
+
+
+        {
+               map textures/pad_garden/schilf02
+               tcMod turb 0.2 0.1 1 0.05
+               tcMod scale 0.5 0.5
+               tcMod scroll 0.01 0.01
 	       blendFunc filter
 	       rgbGen identity
 
-        } 
+        }
 
-        { 
-               map textures/pad_garden/schilf03.tga 
-               tcMod turb 0.2 0.1 1 0.05 
-               tcMod scale -0.5 -0.5 
-               tcMod scroll .025 -.001 
+        {
+               map textures/pad_garden/schilf03
+               tcMod turb 0.2 0.1 1 0.05
+               tcMod scale -0.5 -0.5
+               tcMod scroll .025 -.001
 	       blendFunc add
 	       rgbGen identity
 
-        } 
+        }
 
 	{
 		map $lightmap
@@ -183,43 +183,43 @@ textures/pad_garden/schilf02
 
 textures/pad_garden/schilf05
 	{
-		qer_editorimage textures/pad_garden/schilf05.tga 
+		qer_editorimage textures/pad_garden/schilf05
 		qer_trans 0.5
 		q3map_globaltexture
 		surfaceparm trans
 		surfaceparm nonsolid
 		surfaceparm water
-	
+
 		cull disable
 
                             fogparms ( .211 .231 .094 ) 650
 
-		deformVertexes wave 128 sin .65 .65 0 .5	
-		{ 
-			map textures/pad_garden/schilf05.tga 
+		deformVertexes wave 128 sin .65 .65 0 .5
+		{
+			map textures/pad_garden/schilf05
 			blendFunc GL_one GL_one
 			rgbgen identity
-                                          tcMod turb 0.1 0.1 1 0.05 
-                                          tcMod scale 0.4 0.4 
-                                          tcMod scroll 0.01 0.01 
-		}
-	
-		{ 
-			map textures/pad_garden/schilf05.tga 
-			blendFunc GL_one GL_one
-                                          tcMod turb 0.05 0.05 0.5 0.05 
-                                          tcMod scale 0.5 0.5 
-                                          tcMod scroll 0.01 0.01 
+                                          tcMod turb 0.1 0.1 1 0.05
+                                          tcMod scale 0.4 0.4
+                                          tcMod scroll 0.01 0.01
 		}
 
-	
+		{
+			map textures/pad_garden/schilf05
+			blendFunc GL_one GL_one
+                                          tcMod turb 0.05 0.05 0.5 0.05
+                                          tcMod scale 0.5 0.5
+                                          tcMod scroll 0.01 0.01
+		}
+
+
 		{
 			map $lightmap
 			blendFunc GL_dst_color GL_zero
-			rgbgen identity		
+			rgbgen identity
 		}
-	
-	
+
+
 
 }
 
@@ -228,7 +228,7 @@ textures/pad_garden/gardine
 	q3map_nolightmap
 	q3map_onlyvertexlighting
     {
-        map textures/pad_garden/gardine.tga
+        map textures/pad_garden/gardine
         blendFunc GL_ONE GL_ONE
     }
 }
@@ -236,12 +236,12 @@ textures/pad_garden/gardine
 
 textures/pad_garden/tuereglass
 {
-        surfaceparm trans	
+        surfaceparm trans
 	cull none
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_garden/tuereglass.tga
+		map textures/pad_garden/tuereglass
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -251,18 +251,18 @@ textures/pad_garden/tuereglass
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_garden/fensterglass
 {
-        surfaceparm trans	
+        surfaceparm trans
 	cull none
 	qer_trans 	0.5
-     
+
         {
-		map textures/pad_garden/fensterglass.tga
+		map textures/pad_garden/fensterglass
                 tcgen environment
 		blendFunc GL_ONE GL_ONE
 		rgbGen identity
@@ -272,13 +272,13 @@ textures/pad_garden/fensterglass
 		rgbGen identity
 		blendFunc filter
 	}
-           
+
 }
 
 
 textures/pad_garden/firedrops01
 {
-qer_editorimage textures/pad_garden/firedrops.tga
+qer_editorimage textures/pad_garden/firedrops
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -288,7 +288,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 0.000043 0.000000 -1100 sawtooth 0 1 0.000000 3
 {
-clampmap textures/pad_garden/firedrops.tga
+clampmap textures/pad_garden/firedrops
 tcMod rotate 0.000000
 AlphaGen wave sawtooth 0.000000 8.000000 0.000000 0.129033
 rgbGen wave sawtooth 1.000000 0.000000 0.000000 0.129033
@@ -300,7 +300,7 @@ blendfunc blend
 
 textures/pad_garden/firedrops02
 {
-		qer_editorimage textures/pad_garden/firedrops.tga
+		qer_editorimage textures/pad_garden/firedrops
 		surfaceparm noimpact
 		surfaceparm nolightmap
 		cull none
@@ -310,7 +310,7 @@ textures/pad_garden/firedrops02
 		deformvertexes autosprite
 		deformvertexes move 0.000043 0.000000 -1100 sawtooth 0 1 0.800000 3
 	{
-		clampmap textures/pad_garden/firedrops.tga
+		clampmap textures/pad_garden/firedrops
 		tcMod rotate 0.000000
 		AlphaGen wave sawtooth 0.000000 8.000000 0.800000 0.129033
 		rgbGen wave sawtooth 1.000000 0.000000 0.800000 0.129033
@@ -324,14 +324,14 @@ textures/pad_garden/padflagred
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_garden/padflagred.tga
+                map textures/pad_garden/padflagred
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -351,14 +351,14 @@ textures/pad_garden/padflagblue
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
      deformVertexes wave 30 sin 0 3 0 .2
      deformVertexes wave 100 sin 0 3 0 .7
-     
+
         {
-                map textures/pad_garden/padflagblue.tga
+                map textures/pad_garden/padflagblue
                 alphaFunc GE128
 		depthWrite
 		rgbGen vertex
@@ -375,18 +375,18 @@ textures/pad_garden/padflagblue
 
 textures/pad_garden/fort-pad
 {
-        qer_editorimage textures/pad_garden/fort-pad.tga
+        qer_editorimage textures/pad_garden/fort-pad
 
 
 	surfaceparm noimpact
 	surfaceparm nolightmap
-        q3map_lightimage textures/pad_garden/white.tga
+        q3map_lightimage textures/pad_garden/white
 	q3map_sun	0.266383 0.274632 0.358662 100 50 55
 	q3map_surfacelight 230
 
         skyparms env/fort-pad512 - -
 //       {
-//		map textures/pad_garden/fort-pad.tga
+//		map textures/pad_garden/fort-pad
 //		blendfunc GL_ONE GL_ONE
 //		tcMod scroll 0.05 0.06
 //		tcMod scale 3 2
@@ -405,12 +405,12 @@ textures/pad_garden/redpoints01
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/redpoints01.tga
+		map textures/pad_garden/redpoints01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/redpoints01_blend.tga
+		map textures/pad_garden/redpoints01_blend
 		rgbGen wave sin 0.5 0.5 1 1
 		blendfunc GL_ONE GL_ONE
 	}
@@ -426,12 +426,12 @@ textures/pad_garden/redpoints02
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/redpoints02.tga
+		map textures/pad_garden/redpoints02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/redpoints02_blend.tga
+		map textures/pad_garden/redpoints02_blend
 		rgbGen wave sin 0.7 0.7 1 1
 		blendfunc GL_ONE GL_ONE
 	}
@@ -439,13 +439,13 @@ textures/pad_garden/redpoints02
 
 
 textures/pad_garden/kreidemotiv01
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_garden/kreidemotiv01.tga
+		map textures/pad_garden/kreidemotiv01
                		blendFunc add
 		rgbGen vertex
 	}
@@ -453,13 +453,13 @@ textures/pad_garden/kreidemotiv01
 
 
 textures/pad_garden/kreidemotiv02
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_garden/kreidemotiv02.tga
+		map textures/pad_garden/kreidemotiv02
                		blendFunc add
 		rgbGen vertex
 	}
@@ -467,13 +467,13 @@ textures/pad_garden/kreidemotiv02
 
 
 textures/pad_garden/kreidemotiv03
-{    
-     surfaceparm	nomarks   
+{
+     surfaceparm	nomarks
      surfaceparm	trans
      surfaceparm pointlight
      polygonOffset
         {
-		map textures/pad_garden/kreidemotiv03.tga
+		map textures/pad_garden/kreidemotiv03
                		blendFunc add
 		rgbGen vertex
 	}
@@ -481,7 +481,7 @@ textures/pad_garden/kreidemotiv03
 
 textures/pad_garden/neon01
 {
-	qer_editorimage textures/pad_garden/neon01.tga
+	qer_editorimage textures/pad_garden/neon01
 	surfaceparm nomarks
 	q3map_surfacelight 300
         {
@@ -489,12 +489,12 @@ textures/pad_garden/neon01
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/neon01.tga
+		map textures/pad_garden/neon01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/neon01_blend.tga
+		map textures/pad_garden/neon01_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -509,12 +509,12 @@ textures/pad_garden/light01
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light01.tga
+		map textures/pad_garden/light01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light01_blend.tga
+		map textures/pad_garden/light01_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -529,12 +529,12 @@ textures/pad_garden/light02
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light02.tga
+		map textures/pad_garden/light02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light02_blend.tga
+		map textures/pad_garden/light02_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -549,12 +549,12 @@ textures/pad_garden/light03
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light03.tga
+		map textures/pad_garden/light03
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light03_blend.tga
+		map textures/pad_garden/light03_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -569,12 +569,12 @@ textures/pad_garden/light04
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light04.tga
+		map textures/pad_garden/light04
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light04_blend.tga
+		map textures/pad_garden/light04_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -589,12 +589,12 @@ textures/pad_garden/light05
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light05.tga
+		map textures/pad_garden/light05
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light05_blend.tga
+		map textures/pad_garden/light05_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -609,12 +609,12 @@ textures/pad_garden/light06
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light06.tga
+		map textures/pad_garden/light06
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light06_blend.tga
+		map textures/pad_garden/light06_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -629,12 +629,12 @@ textures/pad_garden/light07
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light07.tga
+		map textures/pad_garden/light07
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/light07_blend.tga
+		map textures/pad_garden/light07_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -642,8 +642,8 @@ textures/pad_garden/light07
 
 textures/pad_garden/lightlamp01
 {
-	qer_editorimage textures/pad_garden/lightlamp01.tga
-	q3map_lightimage textures/pad_garden/lightlamp01_blend.tga
+	qer_editorimage textures/pad_garden/lightlamp01
+	q3map_lightimage textures/pad_garden/lightlamp01_blend
 	surfaceparm nomarks
 	q3map_surfacelight 400
 	{
@@ -651,12 +651,12 @@ textures/pad_garden/lightlamp01
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/lightlamp01.tga
+		map textures/pad_garden/lightlamp01
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-	{	
-		map textures/pad_garden/lightlamp01_blend.tga
+	{
+		map textures/pad_garden/lightlamp01_blend
 		blendfunc GL_ONE GL_ONE
 	}
 }
@@ -664,7 +664,7 @@ textures/pad_garden/lightlamp01
 
 textures/pad_garden/lightlamp02
 {
-	q3map_lightimage textures/pad_garden/lightlamp02_blend.tga
+	q3map_lightimage textures/pad_garden/lightlamp02_blend
 	surfaceparm nomarks
 	q3map_surfacelight 500
         {
@@ -672,22 +672,22 @@ textures/pad_garden/lightlamp02
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/lightlamp02.tga
+		map textures/pad_garden/lightlamp02
 		blendFunc GL_DST_COLOR GL_ZERO
 		rgbGen identity
 	}
-	{	
-		map textures/pad_garden/lightlamp02_blend.tga
+	{
+		map textures/pad_garden/lightlamp02_blend
 		blendfunc GL_ONE GL_ONE
                 rgbGen wave sin .5 0.5 1 .1
 	}
-        {	
-		map textures/pad_garden/lightlamp02b.tga
+        {
+		map textures/pad_garden/lightlamp02b
 		blendfunc GL_ONE GL_ONE
                 rgbgen wave triangle 1 5 1 3
 	}
-        {	
-		map textures/pad_garden/lightlamp02b.tga
+        {
+		map textures/pad_garden/lightlamp02b
 		blendfunc GL_ONE GL_ONE
                 tcmod scale -1 -1
                  rgbgen wave triangle 1 2 0 7
@@ -697,7 +697,7 @@ textures/pad_garden/lightlamp02
 
 textures/pad_garden/lightred
 {
-	q3map_lightimage textures/pad_garden/lightred.tga
+	q3map_lightimage textures/pad_garden/lightred
 	surfaceparm nomarks
 	q3map_surfacelight 300
 	{
@@ -705,15 +705,15 @@ textures/pad_garden/lightred
 		rgbGen identity
 	}
 	{
-		map textures/pad_garden/lightred.tga
+		map textures/pad_garden/lightred
 		blendFunc filter
 		rgbGen identity
 	}
         {
-		map textures/pad_garden/lightred.tga
+		map textures/pad_garden/lightred
 		blendFunc add
 	}
-	
+
 }
 
 
@@ -722,7 +722,7 @@ textures/pad_garden/lightred
 
 textures/pad_garden/bubbles2_1
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -732,7 +732,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -1.093287 -41.198784 141.500214 sawtooth 0 1 1.000725 0.195925
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 20.229958
 AlphaGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
 rgbGen wave sawtooth 1.000000 0.000000 1.000725 0.195925
@@ -743,7 +743,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_2
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -753,7 +753,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -2.769913 -21.519264 169.001572 sawtooth 0 1 0.622631 0.252309
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 2.200842
 AlphaGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
 rgbGen wave sawtooth 1.000000 0.000000 0.622631 0.252309
@@ -764,7 +764,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_3
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -774,7 +774,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 1.625161 -6.980746 87.586830 sawtooth 0 1 1.213530 0.445164
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 19.405041
 AlphaGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
 rgbGen wave sawtooth 1.000000 0.000000 1.213530 0.445164
@@ -785,7 +785,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_4
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -795,7 +795,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -8.668365 -12.663155 109.066895 sawtooth 0 1 1.085688 0.300365
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 11.414990
 AlphaGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
 rgbGen wave sawtooth 1.000000 0.000000 1.085688 0.300365
@@ -806,7 +806,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_5
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -816,7 +816,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -12.763139 -30.482132 151.611313 sawtooth 0 1 0.288759 0.189146
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 1.619465
 AlphaGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
 rgbGen wave sawtooth 1.000000 0.000000 0.288759 0.189146
@@ -827,7 +827,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_6
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -837,7 +837,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 7.834942 -10.679131 100.490509 sawtooth 0 1 1.237915 0.365962
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate -2.907956
 AlphaGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
 rgbGen wave sawtooth 1.000000 0.000000 1.237915 0.365962
@@ -848,7 +848,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_7
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -858,7 +858,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 5.454388 -41.883984 127.730408 sawtooth 0 1 0.402287 0.207241
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 3.890042
 AlphaGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
 rgbGen wave sawtooth 1.000000 0.000000 0.402287 0.207241
@@ -869,7 +869,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_8
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -879,7 +879,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move -9.112141 -36.627399 116.117142 sawtooth 0 1 0.784623 0.218790
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 24.587999
 AlphaGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
 rgbGen wave sawtooth 1.000000 0.000000 0.784623 0.218790
@@ -890,7 +890,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_9
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -900,7 +900,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 13.988351 -11.087501 103.268707 sawtooth 0 1 1.044519 0.235235
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 12.468795
 AlphaGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
 rgbGen wave sawtooth 1.000000 0.000000 1.044519 0.235235
@@ -911,7 +911,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_10
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -921,7 +921,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 10.265741 7.714635 131.291351 sawtooth 0 1 0.524331 0.144779
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 12.796563
 AlphaGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
 rgbGen wave sawtooth 1.000000 0.000000 0.524331 0.144779
@@ -932,7 +932,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_11
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -942,7 +942,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 25.100649 4.780672 156.159500 sawtooth 0 1 0.907308 0.255448
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate 16.214331
 AlphaGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
 rgbGen wave sawtooth 1.000000 0.000000 0.907308 0.255448
@@ -953,7 +953,7 @@ blendfunc add
 
 textures/pad_garden/bubbles2_12
 {
-qer_editorimage textures/pad_garden/bubbles2.tga
+qer_editorimage textures/pad_garden/bubbles2
 surfaceparm noimpact
 surfaceparm nolightmap
 cull none
@@ -963,7 +963,7 @@ surfaceparm nodlight
 deformvertexes autosprite
 deformvertexes move 12.983425 -1.691125 95.949432 sawtooth 0 1 0.845538 0.495670
 {
-clampmap textures/pad_garden/bubbles2.tga
+clampmap textures/pad_garden/bubbles2
 tcMod rotate -2.724845
 AlphaGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
 rgbGen wave sawtooth 1.000000 0.000000 0.845538 0.495670
@@ -972,247 +972,247 @@ blendfunc add
 }
 }
 
-textures/pad_garden/wellen3_1 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
-surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.758238 0.386510 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 13.147161 
-AlphaGen wave sawtooth 1.083261 -1.083261 0.758238 0.386510 
-rgbGen wave sawtooth 0.651039 -0.651039 0.758238 0.386510 
-tcMod stretch sawtooth 0.496692 0.396280 0.758238 0.386510 
-blendfunc add 
-} 
-} 
-
-textures/pad_garden/wellen3_2 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
-surfaceparm nolightmap 
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.550810 0.215062 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 12.292642 
-AlphaGen wave sawtooth 1.012714 -1.012714 0.550810 0.215062 
-rgbGen wave sawtooth 0.747148 -0.747148 0.550810 0.215062 
-tcMod stretch sawtooth 0.488470 0.418503 0.550810 0.215062 
-blendfunc add 
-} 
-} 
-
-textures/pad_garden/wellen3_3 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_1
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
 nomipmaps
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.093259 0.268482 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 7.173833 
-AlphaGen wave sawtooth 0.962444 -0.962444 1.093259 0.268482 
-rgbGen wave sawtooth 0.716947 -0.716947 1.093259 0.268482 
-tcMod stretch sawtooth 0.399271 0.423142 1.093259 0.268482 
-blendfunc add 
-} 
-} 
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.758238 0.386510
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 13.147161
+AlphaGen wave sawtooth 1.083261 -1.083261 0.758238 0.386510
+rgbGen wave sawtooth 0.651039 -0.651039 0.758238 0.386510
+tcMod stretch sawtooth 0.496692 0.396280 0.758238 0.386510
+blendfunc add
+}
+}
 
-textures/pad_garden/wellen3_4 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_2
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.669686 0.210215 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 21.939421 
-AlphaGen wave sawtooth 1.023920 -1.023920 0.669686 0.210215 
-rgbGen wave sawtooth 0.638075 -0.638075 0.669686 0.210215 
-tcMod stretch sawtooth 0.391726 0.652324 0.669686 0.210215 
-blendfunc add 
-} 
-} 
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.550810 0.215062
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 12.292642
+AlphaGen wave sawtooth 1.012714 -1.012714 0.550810 0.215062
+rgbGen wave sawtooth 0.747148 -0.747148 0.550810 0.215062
+tcMod stretch sawtooth 0.488470 0.418503 0.550810 0.215062
+blendfunc add
+}
+}
 
-textures/pad_garden/wellen3_5 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_3
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.228907 0.215789 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 15.530046 
-AlphaGen wave sawtooth 0.950432 -0.950432 1.228907 0.215789 
-rgbGen wave sawtooth 0.785540 -0.785540 1.228907 0.215789 
-tcMod stretch sawtooth 0.325874 0.732252 1.228907 0.215789 
-blendfunc add 
-} 
-} 
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.093259 0.268482
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 7.173833
+AlphaGen wave sawtooth 0.962444 -0.962444 1.093259 0.268482
+rgbGen wave sawtooth 0.716947 -0.716947 1.093259 0.268482
+tcMod stretch sawtooth 0.399271 0.423142 1.093259 0.268482
+blendfunc add
+}
+}
 
-textures/pad_garden/wellen3_6 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_4
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.527409 0.303915 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 8.849666 
-AlphaGen wave sawtooth 1.098447 -1.098447 0.527409 0.303915 
-rgbGen wave sawtooth 0.905087 -0.905087 0.527409 0.303915 
-tcMod stretch sawtooth 0.395859 0.421647 0.527409 0.303915 
-blendfunc add 
-} 
-} 
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.669686 0.210215
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 21.939421
+AlphaGen wave sawtooth 1.023920 -1.023920 0.669686 0.210215
+rgbGen wave sawtooth 0.638075 -0.638075 0.669686 0.210215
+tcMod stretch sawtooth 0.391726 0.652324 0.669686 0.210215
+blendfunc add
+}
+}
 
-textures/pad_garden/wellen3_7 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
-surfaceparm nolightmap 
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.650606 0.368229 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 10.157323 
-AlphaGen wave sawtooth 0.910831 -0.910831 0.650606 0.368229 
-rgbGen wave sawtooth 0.628663 -0.628663 0.650606 0.368229 
-tcMod stretch sawtooth 0.396371 0.581820 0.650606 0.368229 
-blendfunc add 
-} 
-} 
-
-textures/pad_garden/wellen3_8 
-{ 
-qer_editorimage textures/pad_garden/wellen.tga 
-surfaceparm noimpact 
+textures/pad_garden/wellen3_5
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
 surfaceparm nolightmap
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.134458 0.217227 
-{ 
-clampmap textures/pad_garden/wellen.tga 
-tcMod rotate 9.057192 
-AlphaGen wave sawtooth 1.037141 -1.037141 1.134458 0.217227 
-rgbGen wave sawtooth 0.722733 -0.722733 1.134458 0.217227 
-tcMod stretch sawtooth 0.388113 0.698187 1.134458 0.217227 
-blendfunc add 
-} 
-} 
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.228907 0.215789
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 15.530046
+AlphaGen wave sawtooth 0.950432 -0.950432 1.228907 0.215789
+rgbGen wave sawtooth 0.785540 -0.785540 1.228907 0.215789
+tcMod stretch sawtooth 0.325874 0.732252 1.228907 0.215789
+blendfunc add
+}
+}
+
+textures/pad_garden/wellen3_6
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
+surfaceparm nolightmap
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.527409 0.303915
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 8.849666
+AlphaGen wave sawtooth 1.098447 -1.098447 0.527409 0.303915
+rgbGen wave sawtooth 0.905087 -0.905087 0.527409 0.303915
+tcMod stretch sawtooth 0.395859 0.421647 0.527409 0.303915
+blendfunc add
+}
+}
+
+textures/pad_garden/wellen3_7
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
+surfaceparm nolightmap
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.650606 0.368229
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 10.157323
+AlphaGen wave sawtooth 0.910831 -0.910831 0.650606 0.368229
+rgbGen wave sawtooth 0.628663 -0.628663 0.650606 0.368229
+tcMod stretch sawtooth 0.396371 0.581820 0.650606 0.368229
+blendfunc add
+}
+}
+
+textures/pad_garden/wellen3_8
+{
+qer_editorimage textures/pad_garden/wellen
+surfaceparm noimpact
+surfaceparm nolightmap
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 1.134458 0.217227
+{
+clampmap textures/pad_garden/wellen
+tcMod rotate 9.057192
+AlphaGen wave sawtooth 1.037141 -1.037141 1.134458 0.217227
+rgbGen wave sawtooth 0.722733 -0.722733 1.134458 0.217227
+tcMod stretch sawtooth 0.388113 0.698187 1.134458 0.217227
+blendfunc add
+}
+}
 
 
-textures/pad_garden/wave0 
-{ 
-qer_editorimage textures/pad_garden/wave0.tga 
-surfaceparm noimpact 
-surfaceparm nolightmap 
-nomipmaps 
-cull none 
-surfaceparm trans 
-surfaceparm nonsolid 
-surfaceparm nodlight 
-deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.765160 0.500000 
-{ 
-clampmap textures/pad_garden/wave1.tga 
-tcMod rotate 5.752586 
-AlphaGen wave sawtooth 1.000000 -0.421894 0.765160 0.500000 
-rgbGen wave sawtooth 1.000000 -0.720054 0.765160 0.500000 
-tcMod stretch sawtooth 0 0 0 0 
-blendfunc add 
-} 
-{ 
-clampmap textures/pad_garden/wave2.tga 
-tcMod rotate 5.752586 
-AlphaGen wave sawtooth 1.000000 -0.421894 0.765160 0.500000 
-rgbGen wave sawtooth 1.000000 -0.720054 0.765160 0.500000 
-tcMod stretch sawtooth 0.177834 0.822166 0.765160 0.500000 
-blendfunc add 
-} 
-} 
+textures/pad_garden/wave0
+{
+qer_editorimage textures/pad_garden/wave0
+surfaceparm noimpact
+surfaceparm nolightmap
+nomipmaps
+cull none
+surfaceparm trans
+surfaceparm nonsolid
+surfaceparm nodlight
+deformvertexes move 0.000000 0.000000 0.000000 sawtooth 0 1 0.765160 0.500000
+{
+clampmap textures/pad_garden/wave1
+tcMod rotate 5.752586
+AlphaGen wave sawtooth 1.000000 -0.421894 0.765160 0.500000
+rgbGen wave sawtooth 1.000000 -0.720054 0.765160 0.500000
+tcMod stretch sawtooth 0 0 0 0
+blendfunc add
+}
+{
+clampmap textures/pad_garden/wave2
+tcMod rotate 5.752586
+AlphaGen wave sawtooth 1.000000 -0.421894 0.765160 0.500000
+rgbGen wave sawtooth 1.000000 -0.720054 0.765160 0.500000
+tcMod stretch sawtooth 0.177834 0.822166 0.765160 0.500000
+blendfunc add
+}
+}
 
-textures/pad_garden/waterfall2 
-{ 
-qer_editorimage textures/pad_garden/waterstream.tga 
-q3map_globaltexture 
-surfaceparm nonsolid 
-surfaceparm nolightmap 
-surfaceparm trans 
-surfaceparm noimpact 
-surfaceparm water 
-tessSize 32 
-//deformVertexes move 2 1 0 sin 0 1 0.2 0.2 
-//deformVertexes move .6 3.3 0 sin 0 1 0 0.4 
-//deformVertexes wave 32 sin 0 10 0 .2 
-cull disable 
-{ 
-map textures/pad_garden/waterstream.tga 
-blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR 
-tcMod scale 0.4 0.55 
-tcMod turb .1 .08 .25 .08 
-tcMod scroll 0.005 -1 
-} 
-{ 
-map textures/pad_garden/waterstream.tga 
-blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR 
-tcMod scale 0.5 0.45 
-tcMod turb .1 .05 .25 .08 
-tcMod scroll 0.008 -0.6 
-} 
-} 
+textures/pad_garden/waterfall2
+{
+qer_editorimage textures/pad_garden/waterstream
+q3map_globaltexture
+surfaceparm nonsolid
+surfaceparm nolightmap
+surfaceparm trans
+surfaceparm noimpact
+surfaceparm water
+tessSize 32
+//deformVertexes move 2 1 0 sin 0 1 0.2 0.2
+//deformVertexes move .6 3.3 0 sin 0 1 0 0.4
+//deformVertexes wave 32 sin 0 10 0 .2
+cull disable
+{
+map textures/pad_garden/waterstream
+blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
+tcMod scale 0.4 0.55
+tcMod turb .1 .08 .25 .08
+tcMod scroll 0.005 -1
+}
+{
+map textures/pad_garden/waterstream
+blendfunc GL_ONE GL_ONE_MINUS_SRC_COLOR
+tcMod scale 0.5 0.45
+tcMod turb .1 .05 .25 .08
+tcMod scroll 0.008 -0.6
+}
+}
 
 
 textures/pad_garden/gardengrass
 {
 q3map_nonplanar
-q3map_shadeangle 60 l	
+q3map_shadeangle 60 l
 surfaceparm sandsteps
-qer_editorimage textures/pad_garden/gardengrass.tga
+qer_editorimage textures/pad_garden/gardengrass
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/gardengrass.tga
+map textures/pad_garden/gardengrass
 blendFunc filter
 }
 }
@@ -1222,13 +1222,13 @@ textures/pad_garden/gardensand01
 q3map_nonplanar
 q3map_shadeangle 60 l
 surfaceparm sandsteps
-qer_editorimage textures/pad_garden/gardensand01.tga
+qer_editorimage textures/pad_garden/gardensand01
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/gardensand01.tga
+map textures/pad_garden/gardensand01
 blendFunc filter
 }
 }
@@ -1238,13 +1238,13 @@ textures/pad_garden/gardensand02
 q3map_nonplanar
 q3map_shadeangle 60 l
 surfaceparm sandsteps
-qer_editorimage textures/pad_garden/gardensand02.tga
+qer_editorimage textures/pad_garden/gardensand02
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/gardensand02.tga
+map textures/pad_garden/gardensand02
 blendFunc filter
 }
 }
@@ -1254,13 +1254,13 @@ textures/pad_garden/sand003a
 q3map_nonplanar
 q3map_shadeangle 60 l
 surfaceparm sandsteps
-qer_editorimage textures/pad_garden/sand003a.tga
+qer_editorimage textures/pad_garden/sand003a
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/sand003a.tga
+map textures/pad_garden/sand003a
 blendFunc filter
 }
 }
@@ -1269,14 +1269,14 @@ textures/pad_garden/algen
 {
 q3map_nonplanar
 q3map_shadeangle 60 l
-qer_editorimage textures/pad_garden/algen.tga
+qer_editorimage textures/pad_garden/algen
 surfaceparm sandsteps
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/algen.tga
+map textures/pad_garden/algen
 blendFunc filter
 }
 }
@@ -1286,14 +1286,14 @@ textures/pad_garden/ashes_256
 {
 q3map_nonplanar
 q3map_shadeangle 60 l
-qer_editorimage textures/pad_garden/ashes_256.tga
+qer_editorimage textures/pad_garden/ashes_256
 surfaceparm sandsteps
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/ashes_256.tga
+map textures/pad_garden/ashes_256
 blendFunc filter
 }
 }
@@ -1303,14 +1303,14 @@ textures/pad_garden/ashes_512
 {
 q3map_nonplanar
 q3map_shadeangle 60 l
-qer_editorimage textures/pad_garden/ashes_512.tga
+qer_editorimage textures/pad_garden/ashes_512
 surfaceparm sandsteps
 {
 map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/ashes_512.tga
+map textures/pad_garden/ashes_512
 blendFunc filter
 }
 }
@@ -1322,13 +1322,13 @@ textures/pad_garden/nail
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_garden/nail.tga
+                map textures/pad_garden/nail
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -1348,13 +1348,13 @@ textures/pad_garden/kaktus002
 {
      cull disable
      surfaceparm alphashadow
-     surfaceparm trans	
+     surfaceparm trans
      surfaceparm nomarks
      tessSize 64
-    
-     
+
+
         {
-                map textures/pad_garden/kaktus002.tga
+                map textures/pad_garden/kaktus002
                 alphaFunc GE128
 		depthWrite
 		rgbGen identity
@@ -1373,7 +1373,7 @@ textures/pad_garden/kaktus002
 
 textures/pad_garden/grasground
 {
-qer_editorimage textures/pad_garden/grasground.tga
+qer_editorimage textures/pad_garden/grasground
 surfaceparm snowsteps
 
 q3map_nonplanar
@@ -1386,11 +1386,11 @@ q3map_alphaMod dotproduct2 ( 0.0 0.0 0.75 )
 q3map_lightmapSampleSize 16
 
 {
-map textures/pad_garden/sandground.tga // Primary
+map textures/pad_garden/sandground // Primary
 rgbGen identity
 }
 {
-map textures/pad_garden/grasground.tga // Secondary
+map textures/pad_garden/grasground // Secondary
 blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
 //alphaFunc GE128
 rgbGen identity
@@ -1406,7 +1406,7 @@ rgbGen identity
 
 textures/pad_garden/seerosenblatt_move
 {
-	qer_editorimage textures/pad_garden/seerosenblatt.tga
+	qer_editorimage textures/pad_garden/seerosenblatt
 	deformVertexes wave 194 sin 0 2 0 .2
 	deformVertexes wave 30 sin 0 1 0 .3
 	deformVertexes wave 194 sin 0 1 0 .1
@@ -1416,7 +1416,7 @@ textures/pad_garden/seerosenblatt_move
 	cull none
 
 	{
-		map textures/pad_garden/seerosenblatt.tga
+		map textures/pad_garden/seerosenblatt
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1438,11 +1438,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/fussmatte01.tga
+map textures/pad_garden/fussmatte01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/liegestoff02
 {
@@ -1452,11 +1452,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/liegestoff02.tga
+map textures/pad_garden/liegestoff02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/lochgitter02
 {
@@ -1466,11 +1466,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/lochgitter02.tga
+map textures/pad_garden/lochgitter02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/lochgitter03
 {
@@ -1480,11 +1480,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/lochgitter03.tga
+map textures/pad_garden/lochgitter03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/lochgitter04
 {
@@ -1494,11 +1494,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/lochgitter04.tga
+map textures/pad_garden/lochgitter04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/lochgitter05
 {
@@ -1508,11 +1508,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/lochgitter05.tga
+map textures/pad_garden/lochgitter05
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/rostblack
 {
@@ -1522,11 +1522,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostblack.tga
+map textures/pad_garden/rostblack
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/rostborderbig
 {
@@ -1536,11 +1536,11 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostborderbig.tga
+map textures/pad_garden/rostborderbig
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
-} 
+}
 
 textures/pad_garden/rostbordersmall
 {
@@ -1550,7 +1550,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostbordersmall.tga
+map textures/pad_garden/rostbordersmall
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1564,7 +1564,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostbdoorbig.tga
+map textures/pad_garden/rostbdoorbig
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1578,7 +1578,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostdoorsmall.tga
+map textures/pad_garden/rostdoorsmall
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1592,7 +1592,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/faltblech.tga
+map textures/pad_garden/faltblech
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1600,14 +1600,14 @@ rgbGen identity
 
 textures/pad_garden/purpleflow
 {
-        qer_editorimage textures/pad_garden/purpleflow.tga
+        qer_editorimage textures/pad_garden/purpleflow
     	surfaceparm trans
 	surfaceparm alphashadow
    	surfaceparm nonsolid
 	cull none
         nopicmip
 	{
-		map textures/pad_garden/purpleflow.tga
+		map textures/pad_garden/purpleflow
 		blendFunc GL_ONE GL_ZERO
 		alphaFunc GE128
 		depthWrite
@@ -1624,19 +1624,19 @@ textures/pad_garden/purpleflow
 
 textures/pad_garden/rocket
 {
-	qer_editorimage textures/pad_garden/rocket.tga
+	qer_editorimage textures/pad_garden/rocket
 	{
-		map textures/pad_garden/rocket.tga
+		map textures/pad_garden/rocket
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -1650,7 +1650,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/metalwhite001big.tga
+map textures/pad_garden/metalwhite001big
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1665,7 +1665,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/birdfloor_big.tga
+map textures/pad_garden/birdfloor_big
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1679,7 +1679,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/birdfloor_small.tga
+map textures/pad_garden/birdfloor_small
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1693,7 +1693,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/teichbrett2_512.tga
+map textures/pad_garden/teichbrett2_512
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1707,7 +1707,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rost003csmall.tga
+map textures/pad_garden/rost003csmall
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1721,7 +1721,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rost003bsmall.tga
+map textures/pad_garden/rost003bsmall
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1735,7 +1735,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostsoft.tga
+map textures/pad_garden/rostsoft
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1749,7 +1749,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostrough.tga
+map textures/pad_garden/rostrough
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1763,7 +1763,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostred.tga
+map textures/pad_garden/rostred
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1777,7 +1777,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/rostblack.tga
+map textures/pad_garden/rostblack
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1792,7 +1792,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/sunchairwood.tga
+map textures/pad_garden/sunchairwood
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1807,7 +1807,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/liegestoff.tga
+map textures/pad_garden/liegestoff
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1821,7 +1821,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/liegestoff02.tga
+map textures/pad_garden/liegestoff02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1835,7 +1835,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/liegestoff03.tga
+map textures/pad_garden/liegestoff03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1849,7 +1849,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/liegestoff04.tga
+map textures/pad_garden/liegestoff04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1863,7 +1863,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/toyblock01.tga
+map textures/pad_garden/toyblock01
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1877,7 +1877,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/toyblock02.tga
+map textures/pad_garden/toyblock02
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1891,7 +1891,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/toyblock03.tga
+map textures/pad_garden/toyblock03
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1905,7 +1905,7 @@ map $lightmap
 rgbGen identity
 }
 {
-map textures/pad_garden/toyblock04.tga
+map textures/pad_garden/toyblock04
 blendFunc GL_DST_COLOR GL_ZERO
 rgbGen identity
 }
@@ -1917,28 +1917,28 @@ textures/pad_garden/big_flameblue256
 		surfaceparm trans
 		surfaceparm nomarks
 		surfaceparm nonsolid
-		qer_editorimage textures/pad_garden/bflame1.tga
+		qer_editorimage textures/pad_garden/bflame1
 		q3map_surfacelight 200
 		surfaceparm nolightmap
 		cull none
 
 	{
-		animMap 10 textures/pad_garden/bflame1.tga textures/pad_garden/bflame2.tga textures/pad_garden/bflame3.tga textures/pad_garden/bflame4.tga textures/pad_garden/bflame5.tga textures/pad_garden/bflame6.tga textures/pad_garden/bflame7.tga textures/pad_garden/bflame8.tga
+		animMap 10 textures/pad_garden/bflame1 textures/pad_garden/bflame2 textures/pad_garden/bflame3 textures/pad_garden/bflame4 textures/pad_garden/bflame5 textures/pad_garden/bflame6 textures/pad_garden/bflame7 textures/pad_garden/bflame8
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 10
-		
-	}	
+
+	}
 	{
-		animMap 10 textures/pad_garden/bflame2.tga textures/pad_garden/bflame3.tga textures/pad_garden/bflame4.tga textures/pad_garden/bflame5.tga textures/pad_garden/bflame6.tga textures/pad_garden/bflame7.tga textures/pad_garden/bflame8.tga textures/pad_garden/bflame1.tga
+		animMap 10 textures/pad_garden/bflame2 textures/pad_garden/bflame3 textures/pad_garden/bflame4 textures/pad_garden/bflame5 textures/pad_garden/bflame6 textures/pad_garden/bflame7 textures/pad_garden/bflame8 textures/pad_garden/bflame1
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave sawtooth 0 1 0 10
-	}	
+	}
 
 
 	{
-		map textures/pad_garden/bflameball.tga
+		map textures/pad_garden/bflameball
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+		rgbGen wave sin .6 .2 0 .6
 	}
 
 }
@@ -1950,28 +1950,28 @@ textures/pad_garden/red_flame256
 		surfaceparm trans
 		surfaceparm nomarks
 		surfaceparm nonsolid
-		qer_editorimage textures/pad_garden/sflame1.tga
+		qer_editorimage textures/pad_garden/sflame1
 		q3map_surfacelight 200
 		surfaceparm nolightmap
 		cull none
 
 	{
-		animMap 10 textures/pad_garden/sflame1.tga textures/pad_garden/sflame2.tga textures/pad_garden/sflame3.tga textures/pad_garden/sflame4.tga textures/pad_garden/sflame5.tga textures/pad_garden/sflame6.tga textures/pad_garden/sflame7.tga textures/pad_garden/sflame8.tga
+		animMap 10 textures/pad_garden/sflame1 textures/pad_garden/sflame2 textures/pad_garden/sflame3 textures/pad_garden/sflame4 textures/pad_garden/sflame5 textures/pad_garden/sflame6 textures/pad_garden/sflame7 textures/pad_garden/sflame8
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave inverseSawtooth 0 1 0 10
-		
-	}	
+
+	}
 	{
-		animMap 10 textures/pad_garden/sflame2.tga textures/pad_garden/sflame3.tga textures/pad_garden/sflame4.tga textures/pad_garden/sflame5.tga textures/pad_garden/sflame6.tga textures/pad_garden/sflame7.tga textures/pad_garden/sflame8.tga textures/pad_garden/sflame1.tga
+		animMap 10 textures/pad_garden/sflame2 textures/pad_garden/sflame3 textures/pad_garden/sflame4 textures/pad_garden/sflame5 textures/pad_garden/sflame6 textures/pad_garden/sflame7 textures/pad_garden/sflame8 textures/pad_garden/sflame1
 		blendFunc GL_ONE GL_ONE
 		rgbGen wave sawtooth 0 1 0 10
-	}	
+	}
 
 
 	{
-		map textures/pad_garden/sflameball.tga
+		map textures/pad_garden/sflameball
 		blendFunc GL_ONE GL_ONE
-		rgbGen wave sin .6 .2 0 .6	
+		rgbGen wave sin .6 .2 0 .6
 	}
 
 }
@@ -1979,7 +1979,7 @@ textures/pad_garden/red_flame256
 
 textures/pad_garden/poolfog_green
 {
-		qer_editorimage textures/pad_gfx02b/padfog_green.tga
+		qer_editorimage textures/pad_gfx02b/padfog_green
 		surfaceparm	trans
 		surfaceparm	nonsolid
 		surfaceparm	fog
@@ -1991,19 +1991,19 @@ textures/pad_garden/poolfog_green
 
 textures/pad_garden/ship00
 {
-	qer_editorimage textures/pad_garden/ship00.tga
+	qer_editorimage textures/pad_garden/ship00
 	{
-		map textures/pad_garden/ship00.tga
+		map textures/pad_garden/ship00
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2013,19 +2013,19 @@ textures/pad_garden/ship00
 
 textures/pad_garden/ship01
 {
-	qer_editorimage textures/pad_garden/ship01.tga
+	qer_editorimage textures/pad_garden/ship01
 	{
-		map textures/pad_garden/ship01.tga
+		map textures/pad_garden/ship01
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2034,19 +2034,19 @@ textures/pad_garden/ship01
 
 textures/pad_garden/ship02
 {
-	qer_editorimage textures/pad_garden/ship02.tga
+	qer_editorimage textures/pad_garden/ship02
 	{
-		map textures/pad_garden/ship02.tga
+		map textures/pad_garden/ship02
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2056,19 +2056,19 @@ textures/pad_garden/ship02
 textures/pad_garden/ship04
 {
                 surfaceparm metalsteps
-	qer_editorimage textures/pad_garden/ship04.tga
+	qer_editorimage textures/pad_garden/ship04
 	{
-		map textures/pad_garden/ship04.tga
+		map textures/pad_garden/ship04
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2077,19 +2077,19 @@ textures/pad_garden/ship04
 
 textures/pad_garden/ship05
 {
-	qer_editorimage textures/pad_garden/ship05.tga
+	qer_editorimage textures/pad_garden/ship05
 	{
-		map textures/pad_garden/ship05.tga
+		map textures/pad_garden/ship05
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2099,19 +2099,19 @@ textures/pad_garden/ship05
 textures/pad_garden/ship06
 {
 
-	qer_editorimage textures/pad_garden/ship06.tga
+	qer_editorimage textures/pad_garden/ship06
 	{
-		map textures/pad_garden/ship06.tga
+		map textures/pad_garden/ship06
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2120,19 +2120,19 @@ textures/pad_garden/ship06
 
 textures/pad_garden/ship07
 {
-	qer_editorimage textures/pad_garden/ship07.tga
+	qer_editorimage textures/pad_garden/ship07
 	{
-		map textures/pad_garden/ship07.tga
+		map textures/pad_garden/ship07
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2141,19 +2141,19 @@ textures/pad_garden/ship07
 
 textures/pad_garden/ship08
 {
-	qer_editorimage textures/pad_garden/ship08.tga
+	qer_editorimage textures/pad_garden/ship08
 	{
-		map textures/pad_garden/ship08.tga
+		map textures/pad_garden/ship08
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad.tga
+		map textures/pad_gfx02/tinpad
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2162,19 +2162,19 @@ textures/pad_garden/ship08
 
 textures/pad_garden/ship10
 {
-	qer_editorimage textures/pad_garden/ship10.tga
+	qer_editorimage textures/pad_garden/ship10
 	{
-		map textures/pad_garden/ship10.tga
+		map textures/pad_garden/ship10
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad2c.tga
+		map textures/pad_gfx02/tinpad2c
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2183,19 +2183,19 @@ textures/pad_garden/ship10
 
 textures/pad_garden/radio002
 {
-	qer_editorimage textures/pad_garden/radio002.tga
+	qer_editorimage textures/pad_garden/radio002
 	{
-		map textures/pad_garden/radio002.tga
+		map textures/pad_garden/radio002
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2204,19 +2204,19 @@ textures/pad_garden/radio002
 
 textures/pad_garden/radio003
 {
-	qer_editorimage textures/pad_garden/radio003.tga
+	qer_editorimage textures/pad_garden/radio003
 	{
-		map textures/pad_garden/radio003.tga
+		map textures/pad_garden/radio003
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2225,19 +2225,19 @@ textures/pad_garden/radio003
 
 textures/pad_garden/radio004
 {
-	qer_editorimage textures/pad_garden/radio004.tga
+	qer_editorimage textures/pad_garden/radio004
 	{
-		map textures/pad_garden/radio004.tga
+		map textures/pad_garden/radio004
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}
@@ -2246,19 +2246,19 @@ textures/pad_garden/radio004
 
 textures/pad_garden/radio005
 {
-	qer_editorimage textures/pad_garden/radio005.tga
+	qer_editorimage textures/pad_garden/radio005
 	{
-		map textures/pad_garden/radio005.tga
+		map textures/pad_garden/radio005
 		rgbGen identity
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc add
 		rgbGen identity
-		tcGen environment 
+		tcGen environment
 	}
 	{
-		map $lightmap 
+		map $lightmap
 		blendfunc filter
 		rgbGen identity
 	}

--- a/xmas/scripts.pk3dir/scripts/pad_teleporter.shader
+++ b/xmas/scripts.pk3dir/scripts/pad_teleporter.shader
@@ -5,34 +5,34 @@ models/mapobjects/pad_teleporter/pad_baseglow
 {
 	nopicmip
 	nomipmaps
-	qer_editorimage models/mapobjects/pad_teleporter/padlogo.tga
+	qer_editorimage models/mapobjects/pad_teleporter/padlogo
 	{
-		map models/mapobjects/pad_teleporter/padlogo.tga
+		map models/mapobjects/pad_teleporter/padlogo
 		rgbGen lightingDiffuse
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_baseglow.tga
+		map models/mapobjects/pad_teleporter/pad_baseglow
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
                 rgbGen lightingdiffuse
 	}
 	{
-		map models/mapobjects/pad_teleporter/padlogo.tga
+		map models/mapobjects/pad_teleporter/padlogo
 		blendFunc add
 		rgbGen wave sin .5 .5 0 .35
-		
+
 	}
 	{
-		map models/mapobjects/pad_teleporter/pad_baseglow.tga
+		map models/mapobjects/pad_teleporter/pad_baseglow
 		blendFunc add
 		rgbGen wave sin .5 .5 0 .35
-		
+
 	}
 }
 
@@ -43,20 +43,20 @@ models/mapobjects/pad_teleporter/padsphere_orange
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_teleporter/padsphereor.tga
+	q3map_lightimage models/mapobjects/pad_teleporter/padsphereor
 	q3map_surfacelight 200
 
-	cull disable 
+	cull disable
     	{
-		map models/mapobjects/pad_teleporter/padsphereor.tga
+		map models/mapobjects/pad_teleporter/padsphereor
                	blendfunc GL_ONE GL_ONE
-		tcMod scale 2 2	
+		tcMod scale 2 2
                	tcMod scroll .2 .2
 		rgbGen lightingdiffuse
        }
 
 	{
-               	map textures/pad_gfx02/padmapsphere01.jpg
+               	map textures/pad_gfx02/padmapsphere01
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll .1 -.1
@@ -64,7 +64,7 @@ models/mapobjects/pad_teleporter/padsphere_orange
        	}
 
 	{
-               	map textures/pad_gfx02/padmapsphere02.jpg
+               	map textures/pad_gfx02/padmapsphere02
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll -.1 .1
@@ -78,8 +78,8 @@ models/mapobjects/pad_teleporter/padsphere_orange
 models/mapobjects/pad_teleporter/padsphere_blue
 {
 	{
-		map textures/pad_gfx02/tinpad2c.tga
-                //map textures/sfx/specular.tga
+		map textures/pad_gfx02/tinpad2c
+                //map textures/sfx/specular
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
 	}
@@ -93,20 +93,20 @@ models/mapobjects/pad_teleporter/padsphere_purple
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_teleporter/padspherepu.tga
+	q3map_lightimage models/mapobjects/pad_teleporter/padspherepu
 	q3map_surfacelight 200
 
-	cull disable 
+	cull disable
     	{
-		map models/mapobjects/pad_teleporter/padspherepu.tga
+		map models/mapobjects/pad_teleporter/padspherepu
                	blendfunc GL_ONE GL_ONE
-		tcMod scale 2 2	
+		tcMod scale 2 2
                	tcMod scroll .2 .2
 		rgbGen lightingdiffuse
        }
 
 	{
-               	map textures/pad_gfx02/padmapspherepu01.jpg
+               	map textures/pad_gfx02/padmapspherepu01
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll .1 -.1
@@ -114,7 +114,7 @@ models/mapobjects/pad_teleporter/padsphere_purple
        	}
 
 	{
-               	map textures/pad_gfx02/padmapspherepu02.jpg
+               	map textures/pad_gfx02/padmapspherepu02
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll -.1 .1
@@ -132,20 +132,20 @@ models/mapobjects/pad_teleporter/padsphere_pink
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_teleporter/padspherepi.tga
+	q3map_lightimage models/mapobjects/pad_teleporter/padspherepi
 	q3map_surfacelight 200
 
-	cull disable 
+	cull disable
     	{
-		map models/mapobjects/pad_teleporter/padspherepi.tga
+		map models/mapobjects/pad_teleporter/padspherepi
                	blendfunc GL_ONE GL_ONE
-		tcMod scale 2 2	
+		tcMod scale 2 2
                	tcMod scroll .2 .2
 		rgbGen lightingdiffuse
        }
 
 	{
-               	map textures/pad_gfx02/padmapspherepi01.jpg
+               	map textures/pad_gfx02/padmapspherepi01
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll .1 -.1
@@ -153,7 +153,7 @@ models/mapobjects/pad_teleporter/padsphere_pink
        	}
 
 	{
-               	map textures/pad_gfx02/padmapspherepi02.jpg
+               	map textures/pad_gfx02/padmapspherepi02
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll -.1 .1
@@ -171,20 +171,20 @@ models/mapobjects/pad_teleporter/padsphere_yellow
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	surfaceparm nonsolid
-	q3map_lightimage models/mapobjects/pad_teleporter/padsphereyel.tga
+	q3map_lightimage models/mapobjects/pad_teleporter/padsphereyel
 	q3map_surfacelight 200
 
-	cull disable 
+	cull disable
     	{
-		map models/mapobjects/pad_teleporter/padsphereyel.tga
+		map models/mapobjects/pad_teleporter/padsphereyel
                	blendfunc GL_ONE GL_ONE
-		tcMod scale 2 2	
+		tcMod scale 2 2
                	tcMod scroll .2 .2
 		rgbGen lightingdiffuse
        }
 
 	{
-               	map textures/pad_gfx02/padmapsphereyel01.jpg
+               	map textures/pad_gfx02/padmapsphereyel01
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll .1 -.1
@@ -192,7 +192,7 @@ models/mapobjects/pad_teleporter/padsphere_yellow
        	}
 
 	{
-               	map textures/pad_gfx02/padmapsphereyel02.jpg
+               	map textures/pad_gfx02/padmapsphereyel02
 		blendfunc GL_ONE GL_ONE
 		tcGen environment
                	tcMod scroll -.1 .1
@@ -205,15 +205,15 @@ models/mapobjects/pad_teleporter/padsphere_yellow
 models/mapobjects/pad_teleporter/pad_base
 {
 	nopicmip
-	nomipmaps 
-	qer_editorimage models/mapobjects/pad_teleporter/pad_base.tga
+	nomipmaps
+	qer_editorimage models/mapobjects/pad_teleporter/pad_base
 	{
-		map models/mapobjects/pad_teleporter/pad_base.tga
+		map models/mapobjects/pad_teleporter/pad_base
 		alphaFunc ge128
 		rgbGen lightingDiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -229,7 +229,7 @@ models/mapobjects/pad_teleporter/snow
 {
 	cull none
 	{
-		map models/mapobjects/pad_teleporter/snow.tga
+		map models/mapobjects/pad_teleporter/snow
 		blendfunc add
 		tcMod scroll -.25 0
 	}
@@ -239,12 +239,12 @@ models/mapobjects/pad_teleporter/pad_teleporter_base
 {
 
 	{
-		map textures/pad_gfx02/padmapyel3.tga
+		map textures/pad_gfx02/padmapyel3
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
 	{
 		map models/mapobjects/pad_teleporter/pad_teleporter_base
@@ -252,7 +252,7 @@ models/mapobjects/pad_teleporter/pad_teleporter_base
 		alphaFunc Ge128
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment

--- a/xmas/scripts.pk3dir/scripts/pad_waterbottle.shader
+++ b/xmas/scripts.pk3dir/scripts/pad_waterbottle.shader
@@ -5,7 +5,7 @@ models/powerups/ammo/waterbottle_nipper
 {
 	cull disable
 	{
-		map models/powerups/ammo/ammo_nipper.tga
+		map models/powerups/ammo/ammo_nipper
 		rgbGen lightingDiffuse
        	}
 }
@@ -14,7 +14,7 @@ models/powerups/ammo/waterbottle_balloony
 {
 	cull disable
 	{
-		map models/powerups/ammo/ammo_balloony.tga
+		map models/powerups/ammo/ammo_balloony
 		rgbGen lightingDiffuse
        	}
 }
@@ -23,7 +23,7 @@ models/powerups/ammo/waterbottle_bubbleg
 {
 	cull disable
 	{
-		map models/powerups/ammo/ammo_bubbleg.tga
+		map models/powerups/ammo/ammo_bubbleg
 		rgbGen lightingDiffuse
        	}
 }
@@ -32,7 +32,7 @@ models/powerups/ammo/waterbottle_boaster
 {
 	cull disable
 	{
-		map models/powerups/ammo/ammo_boaster.tga
+		map models/powerups/ammo/ammo_boaster
 		rgbGen lightingDiffuse
        	}
 }
@@ -41,7 +41,7 @@ models/powerups/ammo/waterbottle_betty
 {
 	cull disable
 	{
-		map models/powerups/ammo/ammo_betty.tga
+		map models/powerups/ammo/ammo_betty
 		rgbGen lightingDiffuse
        	}
 }
@@ -50,7 +50,7 @@ models/powerups/ammo/waterbottle_imperius
 {
 	cull disable
 	{
-		map models/powerups/ammo/ammo_imperius.tga
+		map models/powerups/ammo/ammo_imperius
 		rgbGen lightingDiffuse
        	}
 }
@@ -60,7 +60,7 @@ models/powerups/ammo/waterbottle_pumper
 {
 	cull disable
 	{
-		map models/powerups/ammo/ammo_pumper.tga
+		map models/powerups/ammo/ammo_pumper
 		rgbGen lightingDiffuse
        	}
 }
@@ -69,7 +69,7 @@ models/powerups/ammo/waterbottle_splasher
 {
 	cull disable
 	{
-		map models/powerups/ammo/ammo_splasher.tga
+		map models/powerups/ammo/ammo_splasher
 		rgbGen lightingDiffuse
        	}
 }

--- a/xmas/scripts.pk3dir/scripts/padmodel.shader
+++ b/xmas/scripts.pk3dir/scripts/padmodel.shader
@@ -2,13 +2,13 @@ models/wop_players/padman/default_goggles
 {
      cull disable
         {
-                map models/wop_players/padman/default_head.tga
+                map models/wop_players/padman/default_head
 		alphaFunc ge128
 	        rgbGen lightingDiffuse
         }
 	{
-                map models/wop_players/padman/pad_fx.tga
-		//map textures/effects/envmapdimb.tga
+                map models/wop_players/padman/pad_fx
+		//map textures/effects/envmapdimb
 		blendfunc GL_DST_ALPHA GL_DST_ALPHA
                 tcgen environment
 		rgbGen lightingDiffuse
@@ -22,11 +22,11 @@ models/wop_players/padman/default_cape
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/default_body.tga
+                map models/wop_players/padman/default_body
 		alphaFunc ge128
                 rgbGen lightingDiffuse
         }
-	
+
 }
 
 models/wop_players/padman/cape_blue
@@ -34,11 +34,11 @@ models/wop_players/padman/cape_blue
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/body_blue.tga
+                map models/wop_players/padman/body_blue
 		alphaFunc ge128
                 rgbGen lightingDiffuse
         }
-	
+
 }
 
 models/wop_players/padman/cape_red
@@ -46,9 +46,9 @@ models/wop_players/padman/cape_red
      	cull disable
 	deformVertexes wave 100 sin 0 0.2 3 1
         {
-                map models/wop_players/padman/body_red.tga
+                map models/wop_players/padman/body_red
 		alphaFunc ge128
                 rgbGen lightingDiffuse
         }
-	
+
 }

--- a/xmas/scripts.pk3dir/scripts/sometestlogos.shader
+++ b/xmas/scripts.pk3dir/scripts/sometestlogos.shader
@@ -2,7 +2,7 @@
 {
 	nopicmip
 	{
-		map "spraylogos/01_wop.tga"
+		map "spraylogos/01_wop"
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -13,7 +13,7 @@
 {
 	nopicmip
 	{
-		map "spraylogos/02_cross.tga"
+		map "spraylogos/02_cross"
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -24,7 +24,7 @@
 {
 	nopicmip
 	{
-		map "spraylogos/03_smile.tga"
+		map "spraylogos/03_smile"
 		blendfunc blend
 		rgbGen Vertex
 		alphaGen Vertex
@@ -35,7 +35,7 @@
 {
 	nopicmip
 	{
-		map "spraylogos/04_padman.tga"
+		map "spraylogos/04_padman"
 		blendfunc blend
 		rgbGen Vertex
 		alphaGen Vertex
@@ -46,7 +46,7 @@ spraylogos/05_fish
 {
 	nopicmip
 	{
-		map spraylogos/05_fish.tga
+		map spraylogos/05_fish
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -57,7 +57,7 @@ spraylogos/06_finger
 {
 	nopicmip
 	{
-		map spraylogos/06_finger.tga
+		map spraylogos/06_finger
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -68,7 +68,7 @@ spraylogos/07_skull
 {
 	nopicmip
 	{
-		map spraylogos/07_skull.tga
+		map spraylogos/07_skull
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -80,7 +80,7 @@ spraylogos/08_clowns
 {
 	nopicmip
 	{
-		map spraylogos/08_clowns.tga
+		map spraylogos/08_clowns
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -92,7 +92,7 @@ spraylogos/08_clowns
 {
 	nopicmip
 	{
-		map "spraylogos/09_sketch.tga"
+		map "spraylogos/09_sketch"
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -103,7 +103,7 @@ spraylogos/08_clowns
 {
 	nopicmip
 	{
-		map "spraylogos/10_yinyan.tga"
+		map "spraylogos/10_yinyan"
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -114,7 +114,7 @@ spraylogos/08_clowns
 {
 	nopicmip
 	{
-		map "spraylogos/11_splash.tga"
+		map "spraylogos/11_splash"
 		blendfunc blend
 		rgbGen Vertex
 		alphaGen Vertex
@@ -125,7 +125,7 @@ spraylogos/08_clowns
 {
 	nopicmip
 	{
-		map "spraylogos/12_heart.tga"
+		map "spraylogos/12_heart"
 		blendfunc blend
 		rgbGen Vertex
 		alphaGen Vertex
@@ -136,7 +136,7 @@ spraylogos/13_questman
 {
 	nopicmip
 	{
-		map spraylogos/13_questman.tga
+		map spraylogos/13_questman
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -147,7 +147,7 @@ spraylogos/14_badboy
 {
 	nopicmip
 	{
-		map spraylogos/14_badboy.tga
+		map spraylogos/14_badboy
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -158,7 +158,7 @@ spraylogos/15_padlogo
 {
 	nopicmip
 	{
-		map spraylogos/15_padlogo.tga
+		map spraylogos/15_padlogo
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -170,7 +170,7 @@ spraylogos/16_moon
 {
 	nopicmip
 	{
-		map spraylogos/16_moon.tga
+		map spraylogos/16_moon
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -181,7 +181,7 @@ spraylogos/17_exp
 {
 	nopicmip
 	{
-		map spraylogos/17_exp.tga
+		map spraylogos/17_exp
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -193,7 +193,7 @@ spraylogos/18_padbunny
 {
 	nopicmip
 	{
-		map spraylogos/18_padbunny.tga
+		map spraylogos/18_padbunny
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -205,7 +205,7 @@ spraylogos/19_jason
 {
 	nopicmip
 	{
-		map spraylogos/19_jason.tga
+		map spraylogos/19_jason
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -217,7 +217,7 @@ spraylogos/20_quake3
 {
 	nopicmip
 	{
-		map spraylogos/20_quake3.tga
+		map spraylogos/20_quake3
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -229,7 +229,7 @@ spraylogos/21_apple
 {
 	nopicmip
 	{
-		map spraylogos/21_apple.tga
+		map spraylogos/21_apple
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -241,7 +241,7 @@ spraylogos/22_lips
 {
 	nopicmip
 	{
-		map spraylogos/22_lips.tga
+		map spraylogos/22_lips
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -252,7 +252,7 @@ spraylogos/23_alien
 {
 	nopicmip
 	{
-		map spraylogos/23_alien.tga
+		map spraylogos/23_alien
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -264,7 +264,7 @@ spraylogos/24_hand
 {
 	nopicmip
 	{
-		map spraylogos/24_hand.tga
+		map spraylogos/24_hand
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -276,7 +276,7 @@ spraylogos/25_hairspray
 {
 	nopicmip
 	{
-		map spraylogos/25_hairspray.tga
+		map spraylogos/25_hairspray
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -288,7 +288,7 @@ spraylogos/26_spooky
 {
 	nopicmip
 	{
-		map spraylogos/26_spooky.tga
+		map spraylogos/26_spooky
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -300,7 +300,7 @@ spraylogos/27_ugly
 {
 	nopicmip
 	{
-		map spraylogos/27_ugly.tga
+		map spraylogos/27_ugly
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -312,7 +312,7 @@ spraylogos/28_moddb
 {
 	nopicmip
 	{
-		map spraylogos/28_moddb.tga
+		map spraylogos/28_moddb
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -323,7 +323,7 @@ spraylogos/29_pqcom
 {
 	nopicmip
 	{
-		map spraylogos/29_pqcom.tga
+		map spraylogos/29_pqcom
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -335,7 +335,7 @@ spraylogos/30_dieselkopf
 {
 	nopicmip
 	{
-		map spraylogos/30_dieselkopf.tga
+		map spraylogos/30_dieselkopf
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -347,7 +347,7 @@ spraylogos/31_atom
 {
 	nopicmip
 	{
-		map spraylogos/31_atom.tga
+		map spraylogos/31_atom
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -359,7 +359,7 @@ spraylogos/32_padarmy
 {
 	nopicmip
 	{
-		map spraylogos/32_padarmy.tga
+		map spraylogos/32_padarmy
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -374,7 +374,7 @@ spraylogos/37_devilskull
 {
 	nopicmip
 	{
-		map spraylogos/37_devilskull.tga
+		map spraylogos/37_devilskull
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -386,7 +386,7 @@ spraylogos/38_padgirl
 {
 	nopicmip
 	{
-		map spraylogos/38_padgirl.tga
+		map spraylogos/38_padgirl
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -398,7 +398,7 @@ spraylogos/39_greensun
 {
 	nopicmip
 	{
-		map spraylogos/39_greensun.tga
+		map spraylogos/39_greensun
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -410,7 +410,7 @@ spraylogos/40_dog
 {
 	nopicmip
 	{
-		map spraylogos/40_dog.tga
+		map spraylogos/40_dog
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -422,7 +422,7 @@ spraylogos/41_vendetta
 {
 	nopicmip
 	{
-		map spraylogos/41_vendetta.tga
+		map spraylogos/41_vendetta
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex
@@ -433,7 +433,7 @@ spraylogos/42_water
 {
 	nopicmip
 	{
-		map spraylogos/42_water.tga
+		map spraylogos/42_water
 		blendFunc blend
 		rgbGen vertex
 		alphaGen vertex

--- a/xmas/scripts.pk3dir/scripts/spraypistol.shader
+++ b/xmas/scripts.pk3dir/scripts/spraypistol.shader
@@ -3,41 +3,41 @@ models/weapons2/spraypistol/f_spraypistolflash
 	sort additive
 	cull disable
 	{
-		clampmap models/weapons2/spraypistol/f_spraypistolflash.jpg
-		blendfunc GL_ONE GL_ONE         
-                tcmod rotate 360              
+		clampmap models/weapons2/spraypistol/f_spraypistolflash
+		blendfunc GL_ONE GL_ONE
+                tcmod rotate 360
         }
         {
-		clampmap models/weapons2/spraypistol/f_spraypistolflash.jpg
+		clampmap models/weapons2/spraypistol/f_spraypistolflash
 		blendfunc GL_ONE GL_ONE
                 tcmod rotate -129
                 //tcMod stretch sin .8 0.10 0 .7
         }
-     
+
 }
 
 
 models/weapons2/spraypistol/spraypistol
 {
-	qer_editorimage models/weapons2/spraypistol/spraypistol.tga
+	qer_editorimage models/weapons2/spraypistol/spraypistol
 
 	nopicmip
 	nomipmaps
 	{
-		map textures/pad_gfx02/tinpad2d.tga
+		map textures/pad_gfx02/tinpad2d
 		tcGen environment
 		blendfunc GL_ONE GL_ZERO
 		tcmod scale .8 .8
                 rgbGen identity
-		
+
 	}
 	{
-		map models/weapons2/spraypistol/spraypistol.tga
+		map models/weapons2/spraypistol/spraypistol
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 	}
 	{
-		map textures/pad_gfx02/tinpad3.tga
+		map textures/pad_gfx02/tinpad3
 		blendfunc GL_ONE GL_ONE
 		tcmod scale .5 .5
 		tcGen environment
@@ -54,15 +54,15 @@ models/weapons2/spraypistol/cartridge_red
 	nopicmip
 	sort 9
 	{
-                map textures/pad_gfx02/padmapyel2.tga
+                map textures/pad_gfx02/padmapyel2
 		tcGen environment
 		tcMod turb 0 .5 0 .3
                 tcMod scroll .1 .09
 		rgbGen lightingdiffuse
-		
+
         }
 	{
-		map models/weapons2/spraypistol/padcart_r.tga
+		map models/weapons2/spraypistol/padcart_r
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 
@@ -78,15 +78,15 @@ models/weapons2/spraypistol/cartridge_blue
 	nopicmip
 	sort 9
 	{
-                map textures/pad_gfx02/padmapyel2.tga
+                map textures/pad_gfx02/padmapyel2
 		tcGen environment
 		tcMod turb 0 .5 0 .3
                 tcMod scroll .1 .09
 		rgbGen lightingdiffuse
-		
+
         }
 	{
-		map models/weapons2/spraypistol/padcart_b.tga
+		map models/weapons2/spraypistol/padcart_b
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 
@@ -102,15 +102,15 @@ models/weapons2/spraypistol/cartridge_neutral
 	nopicmip
 	sort 9
 	{
-                map textures/pad_gfx02/padmapyel2.tga
+                map textures/pad_gfx02/padmapyel2
 		tcGen environment
 		tcMod turb 0 .5 0 .3
                 tcMod scroll .1 .09
 		rgbGen lightingdiffuse
-		
+
         }
 	{
-		map models/weapons2/spraypistol/padcart_n.tga
+		map models/weapons2/spraypistol/padcart_n
 		alphaFunc ge128
 		rgbGen lightingdiffuse
 


### PR DESCRIPTION
```bash
for e in tga jpg png; do for i in *.shader; do sed -i "s/.$e//g" $i; done; done
find . -name "*.shader" -exec sed -i 's/[ \t]*$//' {}\;
```