### PR TITLE
Fixed SuperPad anaglyph 3D glasses colors

### DIFF
--- a/wop/models.pk3dir/models/wop_players/padman/icon_superpad.tga
+++ b/wop/models.pk3dir/models/wop_players/padman/icon_superpad.tga
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46f00be77d532a30443b9be230553d9f23bd3e19f5f8cd24a9636c927a99a149
-size 49170
+oid sha256:d403bae7931f3ee0d735885f40a8b6f94154772107235a10bb94f57d9ddf42f8
+size 49196

--- a/wop/models.pk3dir/models/wop_players/padman/icon_superpad_blue.tga
+++ b/wop/models.pk3dir/models/wop_players/padman/icon_superpad_blue.tga
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ccad14c2339eab335ad06f0e58bbbe10ef297ee72a4b2f5f52f21295603c8316
-size 49170
+oid sha256:582bf43ca1b99468aab819638ca352a8dbe7b34bbb82c4ce726869e0f00a7e86
+size 49196

--- a/wop/models.pk3dir/models/wop_players/padman/icon_superpad_red.tga
+++ b/wop/models.pk3dir/models/wop_players/padman/icon_superpad_red.tga
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac001b9237f41bd4eec4e3bc8d7557c95ccd499f96ac0908abb1d7789d8abd9b
-size 49170
+oid sha256:61a0de73cc8a02a30650f47a2890b483a4618f56cf868ed91da341108b02fa2d
+size 49196

--- a/wop/models.pk3dir/models/wop_players/padman/superpad_head.tga
+++ b/wop/models.pk3dir/models/wop_players/padman/superpad_head.tga
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9ee67fc62cf1e1db5112162bf44024b4a87c1a4243811297db7a28c84c886b9
-size 1048594
+oid sha256:cf1f025b7b91101d8ed0e40c8f96ae976ef282e0e2c537a2381812806ac5833f
+size 1048620

--- a/wop/models.pk3dir/models/wop_players/padman/superpad_head_blue.tga
+++ b/wop/models.pk3dir/models/wop_players/padman/superpad_head_blue.tga
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:479c012d01558e8dec89390249b44e333f655b26d257b96e0a4f8f37f180552e
-size 1048594
+oid sha256:099799ebf6e89ba0e1289eec9d9b2782fd6cf6cfc81af90b6ccf152b606ab0bd
+size 1048620

--- a/wop/models.pk3dir/models/wop_players/padman/superpad_head_red.tga
+++ b/wop/models.pk3dir/models/wop_players/padman/superpad_head_red.tga
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15a91b9230bb4f6803235c6dd853647e3025262ac176be005a29d61fbdec01f6
-size 1048594
+oid sha256:a226ac3edaede15100d3465575f8aa91a7c1fa12e69d36bbd622d492bf215df9
+size 1048620


### PR DESCRIPTION
Anaglyph 3D glasses should be cyan-red when you're looking at the person who's wearing them. So I took the liberty to edit the 3 Superpad skin texture files and 3 portrait files and saved back as 32-bit TGA raw (uncompressed) with alpha channels intact when applicable, to match the source files.
Also, here are the Photoshop project files with non destructive layers in case you wanna inspect the changes or apply them to other relevant textures I missed: [Superpad3DGlassesFixPhotoshopFiles.zip](https://github.com/PadWorld-Entertainment/worldofpadman/files/8373296/Superpad3DGlassesFixPhotoshopFiles.zip)

Before:
![image](https://i.imgur.com/9ZG3onv.jpeg)

After:
![image](https://i.imgur.com/j8I0u4n.jpeg)
