### PR TITLE
Better vote feedback with announcer sounds

### DIFF
--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -763,6 +763,10 @@ static void CG_RegisterSounds(void) {
 	cgs.media.watchpadSound = trap_S_RegisterSound("sound/feedback/awards/watchpad", qtrue);
 	cgs.media.padstarSound = trap_S_RegisterSound("sound/feedback/awards/padstar", qtrue);
 
+	cgs.media.voteNow = trap_S_RegisterSound("sound/feedback/vote_now", qtrue);
+	cgs.media.votePassed = trap_S_RegisterSound("sound/feedback/vote_passed", qtrue);
+	cgs.media.voteFailed = trap_S_RegisterSound("sound/feedback/vote_failed", qtrue);
+
 	cgs.media.watrInSound = trap_S_RegisterSound("sound/padplayer/water_in", qfalse);
 	cgs.media.watrOutSound = trap_S_RegisterSound("sound/padplayer/water_out", qfalse);
 	cgs.media.watrUnSound = trap_S_RegisterSound("sound/padplayer/water_under", qfalse);

--- a/code/cgame/cg_servercmds.c
+++ b/code/cgame/cg_servercmds.c
@@ -349,6 +349,7 @@ static void CG_ConfigStringModified(void) {
 		cgs.voteModified = qtrue;
 	} else if (num == CS_VOTE_STRING) {
 		Q_strncpyz(cgs.voteString, str, sizeof(cgs.voteString));
+		trap_S_StartLocalSound(cgs.media.voteNow, CHAN_ANNOUNCER);
 	} else if (num >= CS_TEAMVOTE_TIME && num <= CS_TEAMVOTE_TIME + 1) {
 		cgs.teamVoteTime[num - CS_TEAMVOTE_TIME] = atoi(str);
 		cgs.teamVoteModified[num - CS_TEAMVOTE_TIME] = qtrue;
@@ -360,6 +361,7 @@ static void CG_ConfigStringModified(void) {
 		cgs.teamVoteModified[num - CS_TEAMVOTE_NO] = qtrue;
 	} else if (num >= CS_TEAMVOTE_STRING && num <= CS_TEAMVOTE_STRING + 1) {
 		Q_strncpyz(cgs.teamVoteString[num - CS_TEAMVOTE_STRING], str, sizeof(cgs.teamVoteString));
+		trap_S_StartLocalSound(cgs.media.voteNow, CHAN_ANNOUNCER);
 	} else if (num == CS_INTERMISSION) {
 		cg.intermissionStarted = atoi(str);
 	} else if (num >= CS_MODELS && num < CS_MODELS + MAX_MODELS) {
@@ -570,6 +572,13 @@ static void CG_ServerCommand(void) {
 
 	if (!strcmp(cmd, "print")) {
 		CG_Printf("%s", CG_Argv(1));
+		cmd = CG_Argv(1);			// yes, this is obviously a hack, but so is the way we hear about
+									// votes passing or failing
+		if (!Q_stricmpn(cmd, "vote failed", 11) || !Q_stricmpn(cmd, "team vote failed", 16)) {
+			trap_S_StartLocalSound(cgs.media.voteFailed, CHAN_ANNOUNCER);
+		} else if (!Q_stricmpn(cmd, "vote passed", 11) || !Q_stricmpn(cmd, "team vote passed", 16)) {
+			trap_S_StartLocalSound(cgs.media.votePassed, CHAN_ANNOUNCER);
+		}
 		return;
 	}
 


### PR DESCRIPTION
Q3 Team Arena provides additional code to inform the player via announcer when a vote is in progress, passed or failed. This helps to focus the player's attention on the vote during a match in addition to the visual information and improves the user experience in World of Padman. This would require three new announcer sounds: 
- "Vote now!" or "vote in progress!"
- "Vote passed!"
- "Vote failed!"

ToDo:

- [x] Apply the Q3 TA code (see cg_main.c and cg_servercmds.c).
- [ ] Provide three new and suitable announcer sound samples --> #19