### PR TITLE
Screenshot format and quality selection via menu

### DIFF
--- a/code/cgame/cg_spraylogo.c
+++ b/code/cgame/cg_spraylogo.c
@@ -722,7 +722,7 @@ void ActiveChooseLogoMenu(void) {
 			cg.wantSelectLogo = qfalse;
 		}
 	} else if (cgs.lastusedkey == K_F12) {
-		trap_SendConsoleCommand("screenshotJPEG\n");
+		trap_SendConsoleCommand("screenshot\n");
 	}
 
 	if (!cg.wantSelectLogo) {

--- a/code/renderer_vulkan/tr_cvar.c
+++ b/code/renderer_vulkan/tr_cvar.c
@@ -74,6 +74,7 @@ cvar_t *r_mode;
 
 cvar_t *r_aviMotionJpegQuality;
 cvar_t *r_screenshotJpegQuality;
+cvar_t *r_screenshotFormat;
 
 cvar_t *r_enablevalidationlayers;
 
@@ -165,5 +166,6 @@ void R_Register(void) {
 
 	r_aviMotionJpegQuality = ri.Cvar_Get("r_aviMotionJpegQuality", "100", CVAR_ARCHIVE);
 	r_screenshotJpegQuality = ri.Cvar_Get("r_screenshotJpegQuality", "100", CVAR_ARCHIVE);
+	r_screenshotFormat = ri.Cvar_Get("r_screenshotFormat", "2", CVAR_ARCHIVE);
 	r_enablevalidationlayers = ri.Cvar_Get("r_enablevalidationlayers", "0", CVAR_ARCHIVE);
 }

--- a/code/renderer_vulkan/tr_cvar.h
+++ b/code/renderer_vulkan/tr_cvar.h
@@ -84,6 +84,7 @@ extern cvar_t *r_displayRefresh;
 
 extern cvar_t *r_aviMotionJpegQuality;
 extern cvar_t *r_screenshotJpegQuality;
+extern cvar_t *r_screenshotFormat;
 extern cvar_t *r_enablevalidationlayers;
 
 void R_Register(void);

--- a/code/renderer_vulkan/tr_init.c
+++ b/code/renderer_vulkan/tr_init.c
@@ -84,9 +84,7 @@ static void R_Init(void) {
 	// make sure all the commands added here are also
 	// removed in R_Shutdown
 	ri.Cmd_AddCommand("modellist", R_Modellist_f);
-	ri.Cmd_AddCommand("screenshot", R_ScreenShotTGA_f);
-	ri.Cmd_AddCommand("screenshotJPEG", R_ScreenShotJPEG_f);
-	ri.Cmd_AddCommand("screenshotPNG", R_ScreenShotPNG_f);
+	ri.Cmd_AddCommand("screenshot", R_ScreenShot_f);
 	ri.Cmd_AddCommand("shaderlist", R_ShaderList_f);
 	ri.Cmd_AddCommand("skinlist", R_SkinList_f);
 
@@ -123,8 +121,6 @@ void RE_Shutdown(qboolean destroyWindow) {
 	ri.Printf(PRINT_ALL, "\nRE_Shutdown( %i )\n", destroyWindow);
 
 	ri.Cmd_RemoveCommand("modellist");
-	ri.Cmd_RemoveCommand("screenshotPNG");
-	ri.Cmd_RemoveCommand("screenshotJPEG");
 	ri.Cmd_RemoveCommand("screenshot");
 	ri.Cmd_RemoveCommand("shaderlist");
 	ri.Cmd_RemoveCommand("skinlist");

--- a/code/renderer_vulkan/vk_screenshot.c
+++ b/code/renderer_vulkan/vk_screenshot.c
@@ -388,16 +388,15 @@ screenshot [filename]
 Doesn't print the pacifier message if there is a second arg
 ==================
 */
-void R_ScreenShotTGA_f(void) {
-	R_Screenshot(ST_TGA);
-}
-
-void R_ScreenShotJPEG_f(void) {
-	R_Screenshot(ST_JPEG);
-}
-
-void R_ScreenShotPNG_f(void) {
-	R_Screenshot(ST_PNG);
+void R_ScreenShot_f(void) {
+	int type = r_screenshotFormat->integer;
+	if (type > 1) {
+		R_Screenshot(ST_PNG);
+	} else if (type == 1) {
+		R_Screenshot(ST_JPEG);
+	} else {
+		R_Screenshot(ST_TGA);
+	}
 }
 
 void RB_TakeVideoFrameCmd(const videoFrameCommand_t *cmd) {

--- a/code/renderer_vulkan/vk_screenshot.h
+++ b/code/renderer_vulkan/vk_screenshot.h
@@ -4,9 +4,7 @@
 #include "../qcommon/q_shared.h"
 #include "vulkan/vulkan_core.h"
 
-void R_ScreenShotJPEG_f(void);
-void R_ScreenShotPNG_f(void);
-void R_ScreenShotTGA_f(void);
+void R_ScreenShot_f(void);
 
 typedef struct {
 	int commandId;

--- a/code/renderergl1/tr_init.c
+++ b/code/renderergl1/tr_init.c
@@ -159,6 +159,7 @@ cvar_t *r_marksOnTriangleMeshes;
 
 cvar_t *r_aviMotionJpegQuality;
 cvar_t *r_screenshotJpegQuality;
+cvar_t *r_screenshotFormat;
 
 cvar_t *r_maxpolys;
 int max_polys;
@@ -620,16 +621,15 @@ static void R_ScreenShot(screenshotType_e type) {
 	}
 }
 
-static void R_ScreenShotTGA_f(void) {
-	R_ScreenShot(ST_TGA);
-}
-
-static void R_ScreenShotJPEG_f(void) {
-	R_ScreenShot(ST_JPEG);
-}
-
-static void R_ScreenShotPNG_f(void) {
-	R_ScreenShot(ST_PNG);
+static void R_ScreenShot_f(void) {
+	int type = r_screenshotFormat->integer;
+	if (type > 1) {
+		R_ScreenShot(ST_PNG);
+	} else if (type == 1) {
+		R_ScreenShot(ST_JPEG);
+	} else {
+		R_ScreenShot(ST_TGA);
+	}
 }
 
 /*
@@ -999,6 +999,7 @@ static void R_Register(void) {
 
 	r_aviMotionJpegQuality = ri.Cvar_Get("r_aviMotionJpegQuality", "100", CVAR_ARCHIVE);
 	r_screenshotJpegQuality = ri.Cvar_Get("r_screenshotJpegQuality", "100", CVAR_ARCHIVE);
+	r_screenshotFormat = ri.Cvar_Get("r_screenshotFormat", "2", CVAR_ARCHIVE);
 
 	r_maxpolys = ri.Cvar_Get("r_maxpolys", va("%d", MAX_POLYS), 0);
 	r_maxpolyverts = ri.Cvar_Get("r_maxpolyverts", va("%d", MAX_POLYVERTS), 0);
@@ -1010,9 +1011,7 @@ static void R_Register(void) {
 	ri.Cmd_AddCommand("skinlist", R_SkinList_f);
 	ri.Cmd_AddCommand("modellist", R_Modellist_f);
 	ri.Cmd_AddCommand("modelist", R_ModeList_f);
-	ri.Cmd_AddCommand("screenshot", R_ScreenShotTGA_f);
-	ri.Cmd_AddCommand("screenshotJPEG", R_ScreenShotJPEG_f);
-	ri.Cmd_AddCommand("screenshotPNG", R_ScreenShotPNG_f);
+	ri.Cmd_AddCommand("screenshot", R_ScreenShot_f);
 	ri.Cmd_AddCommand("gfxinfo", GfxInfo_f);
 	ri.Cmd_AddCommand("minimize", GLimp_Minimize);
 }
@@ -1117,8 +1116,6 @@ void RE_Shutdown(qboolean destroyWindow) {
 	ri.Cmd_RemoveCommand("skinlist");
 	ri.Cmd_RemoveCommand("modellist");
 	ri.Cmd_RemoveCommand("modelist");
-	ri.Cmd_RemoveCommand("screenshotPNG");
-	ri.Cmd_RemoveCommand("screenshotJPEG");
 	ri.Cmd_RemoveCommand("screenshot");
 	ri.Cmd_RemoveCommand("gfxinfo");
 	ri.Cmd_RemoveCommand("minimize");

--- a/code/renderergl1/tr_local.h
+++ b/code/renderergl1/tr_local.h
@@ -1136,7 +1136,6 @@ void R_ImageList_f(void);
 void R_SkinList_f(void);
 // https://zerowing.idsoftware.com/bugzilla/show_bug.cgi?id=516
 const void *RB_TakeScreenshotCmd(const void *data);
-void R_ScreenShot_f(void);
 
 void R_InitFogTable(void);
 float R_FogFactor(float s, float t);

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -225,6 +225,7 @@ cvar_t *r_marksOnTriangleMeshes;
 
 cvar_t *r_aviMotionJpegQuality;
 cvar_t *r_screenshotJpegQuality;
+cvar_t *r_screenshotFormat;
 
 cvar_t *r_maxpolys;
 int max_polys;
@@ -709,16 +710,15 @@ static void R_ScreenShot(screenshotType_e type) {
 	}
 }
 
-static void R_ScreenShotTGA_f(void) {
-	R_ScreenShot(ST_TGA);
-}
-
-static void R_ScreenShotJPEG_f(void) {
-	R_ScreenShot(ST_JPEG);
-}
-
-static void R_ScreenShotPNG_f(void) {
-	R_ScreenShot(ST_PNG);
+static void R_ScreenShot_f(void) {
+	int type = r_screenshotFormat->integer;
+	if (type > 1) {
+		R_ScreenShot(ST_PNG);
+	} else if (type == 1) {
+		R_ScreenShot(ST_JPEG);
+	} else {
+		R_ScreenShot(ST_TGA);
+	}
 }
 
 //============================================================================
@@ -1348,6 +1348,7 @@ static void R_Register(void) {
 	r_screenshotJpegQuality = ri.Cvar_Get("r_screenshotJpegQuality", "100", CVAR_ARCHIVE);
 	ri.Cvar_SetDescription(r_aviMotionJpegQuality, "Controls quality of Jpeg video capture when \\cl_aviMotionJpeg 1.");
 	ri.Cvar_SetDescription(r_screenshotJpegQuality, "Controls quality of Jpeg screenshots when using screenshotJpeg.");
+	r_screenshotFormat = ri.Cvar_Get("r_screenshotFormat", "2", CVAR_ARCHIVE);
 
 	r_maxpolys = ri.Cvar_Get("r_maxpolys", va("%d", MAX_POLYS), 0);
 	ri.Cvar_SetDescription(r_maxpolys, "Maximum number of polygons to draw in a scene.");
@@ -1361,9 +1362,7 @@ static void R_Register(void) {
 	ri.Cmd_AddCommand("skinlist", R_SkinList_f);
 	ri.Cmd_AddCommand("modellist", R_Modellist_f);
 	ri.Cmd_AddCommand("modelist", R_ModeList_f);
-	ri.Cmd_AddCommand("screenshot", R_ScreenShotTGA_f);
-	ri.Cmd_AddCommand("screenshotJPEG", R_ScreenShotJPEG_f);
-	ri.Cmd_AddCommand("screenshotPNG", R_ScreenShotPNG_f);
+	ri.Cmd_AddCommand("screenshot", R_ScreenShot_f);
 	ri.Cmd_AddCommand("gfxinfo", GfxInfo_f);
 	ri.Cmd_AddCommand("minimize", GLimp_Minimize);
 	ri.Cmd_AddCommand("gfxmeminfo", GfxMemInfo_f);
@@ -1495,8 +1494,6 @@ static void RE_Shutdown(qboolean destroyWindow) {
 	ri.Cmd_RemoveCommand("skinlist");
 	ri.Cmd_RemoveCommand("modellist");
 	ri.Cmd_RemoveCommand("modelist");
-	ri.Cmd_RemoveCommand("screenshotPNG");
-	ri.Cmd_RemoveCommand("screenshotJPEG");
 	ri.Cmd_RemoveCommand("screenshot");
 	ri.Cmd_RemoveCommand("gfxinfo");
 	ri.Cmd_RemoveCommand("minimize");

--- a/code/ui/ui_controls.c
+++ b/code/ui/ui_controls.c
@@ -326,7 +326,7 @@ static bind_t g_bindings[] = {
 	{"toggle g_synchronousClients", "Sync Clients:", ID_SYNCCLIENTS, ANIM_IDLE, 'p', -1, -1, -1},
 	{"vote yes", "Vote Yes:", ID_VOTEYES, ANIM_IDLE, K_F1, K_KP_PLUS, -1, -1},
 	{"vote no", "Vote No:", ID_VOTENO, ANIM_IDLE, K_F2, K_KP_MINUS, -1, -1},
-	{"screenshotJPEG", "Screenshot:", ID_SCREENSHOT, ANIM_IDLE, K_F12, -1, -1, -1},
+	{"screenshot", "Screenshot:", ID_SCREENSHOT, ANIM_IDLE, K_F12, -1, -1, -1},
 
 	{(char *)NULL, (char *)NULL, 0, 0, -1, -1, -1, -1},
 };

--- a/code/ui/ui_qmenu.c
+++ b/code/ui/ui_qmenu.c
@@ -1818,7 +1818,7 @@ sfxHandle_t Menu_DefaultKey(menuframework_s *m, int key) {
 		break;
 
 	case K_F12:
-		trap_Cmd_ExecuteText(EXEC_APPEND, "screenshotJPEG\n");
+		trap_Cmd_ExecuteText(EXEC_APPEND, "screenshot\n");
 		break;
 #endif
 	case K_KP_UPARROW:

--- a/wop/default.cfg
+++ b/wop/default.cfg
@@ -92,7 +92,7 @@ bind    F1          "vote yes"
 bind    KP_PLUS     "vote yes"
 bind    F2          "vote no"
 bind    KP_MINUS    "vote no"
-bind 	F12			screenshotJPEG
+bind 	F12			screenshot
 
 //
 // NOT IN MENU


### PR DESCRIPTION
It would be good to give the user control via the menu in which format a screenshot should be saved, as there are several to chose from. We should offer here a drop down option in Setup to select the desired screenshot format (PNG, JPG, TGA). This could be enhanced by a screenshot quality slider if JPEG format is selected.

Task to perform
- [x] Add an option to select screenshot format PNG, JPG or TGA to Setup/Display menu
- [x] Introduce a new CVAR 'r_screenshotFormat': 0=TGA; 1=JPG; 2=PNG (2 is default)
- [x] Remove 'screenshotJPEG' and 'screenshotPNG' commands, keep only 'screenshot' command
- [x] Add a slider beneath to select jpeg quality (60%-100%) and show as active if jpeg is the selected format
- [x] Check if changing those cvars force a vid_restart; if yes, show an accept button