### PR TITLE
JANITORIAL: Remove team arena flag handles and animation code

### DIFF
--- a/code/cgame/cg_ents.c
+++ b/code/cgame/cg_ents.c
@@ -913,7 +913,6 @@ static void CG_InterpolateEntityPosition(centity_t *cent) {
 /*
 ===============
 CG_CalcEntityLerpPositions
-
 ===============
 */
 static void CG_CalcEntityLerpPositions(centity_t *cent) {
@@ -949,32 +948,6 @@ static void CG_CalcEntityLerpPositions(centity_t *cent) {
 	if (cent != &cg.predictedPlayerEntity) {
 		CG_AdjustPositionForMover(cent->lerpOrigin, cent->currentState.groundEntityNum, cg.snap->serverTime, cg.time,
 								  cent->lerpOrigin, cent->lerpAngles, cent->lerpAngles);
-	}
-}
-
-/*
-===============
-CG_TeamBase
-===============
-*/
-static void CG_TeamBase(centity_t *cent) {
-	refEntity_t model;
-
-	if (cgs.gametype == GT_CTF) {
-		// show the flag base
-		memset(&model, 0, sizeof(model));
-		model.reType = RT_MODEL;
-		VectorCopy(cent->lerpOrigin, model.lightingOrigin);
-		VectorCopy(cent->lerpOrigin, model.origin);
-		AnglesToAxis(cent->currentState.angles, model.axis);
-		if (cent->currentState.modelindex == TEAM_RED) {
-			model.hModel = cgs.media.redFlagBaseModel;
-		} else if (cent->currentState.modelindex == TEAM_BLUE) {
-			model.hModel = cgs.media.blueFlagBaseModel;
-		} else {
-			model.hModel = cgs.media.neutralFlagBaseModel;
-		}
-		trap_R_AddRefEntityToScene(&model);
 	}
 }
 
@@ -1262,7 +1235,6 @@ static void CG_DrawBoomies(centity_t *cent) {
 /*
 ===============
 CG_AddCEntity
-
 ===============
 */
 static void CG_AddCEntity(centity_t *cent) {
@@ -1315,9 +1287,6 @@ static void CG_AddCEntity(centity_t *cent) {
 		break;
 	case ET_GRAPPLE:
 		CG_Grapple(cent);
-		break;
-	case ET_TEAM:
-		CG_TeamBase(cent);
 		break;
 	case ET_BALLOON:
 		CG_Balloon(cent);

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -361,7 +361,6 @@ typedef struct {
 	//	char			blueTeam[MAX_TEAMNAME];
 	qboolean deferred;
 
-	qboolean newAnims;	 // true if using the new mission pack animations
 	qboolean fixedlegs;	 // true if legs yaw is always the same as torso yaw
 	qboolean fixedtorso; // true if torso never changes yaw
 
@@ -713,18 +712,6 @@ typedef struct {
 	qhandle_t neutralFlagModel;
 	qhandle_t redFlagShader[3];
 	qhandle_t blueFlagShader[3];
-	qhandle_t flagShader[4];
-
-	qhandle_t flagPoleModel;
-	qhandle_t flagFlapModel;
-
-	qhandle_t redFlagFlapSkin;
-	qhandle_t blueFlagFlapSkin;
-	qhandle_t neutralFlagFlapSkin;
-
-	qhandle_t redFlagBaseModel;
-	qhandle_t blueFlagBaseModel;
-	qhandle_t neutralFlagBaseModel;
 
 	qhandle_t armorModel;
 	qhandle_t armorIcon;

--- a/code/cgame/cg_misc.c
+++ b/code/cgame/cg_misc.c
@@ -190,7 +190,6 @@ static void CG_ColorByEntityType(int eType, byte colors[4]) {
 		break;
 
 		// ET_GRAPPLE
-		// ET_TEAM
 		// ET_EXPLOSION
 		// ET_BALLOON
 		// ET_BAMBAM

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -783,7 +783,6 @@ typedef enum {
 	ET_TELEPORT_TRIGGER,
 	ET_INVISIBLE,
 	ET_GRAPPLE, // grapple hooked on wall
-	ET_TEAM,
 
 	ET_EXPLOSION,
 	ET_BALLOON,


### PR DESCRIPTION
WoP does not use it as far as I can see and always adds the lollies as trail items. Also the player models do not provide a tag for the flag and the handles for flag, base and pole models etc. are not used in WoP.