### PR TITLE
GENDER: Enable the user to select the gender

### DIFF
--- a/code/cgame/cg_event.c
+++ b/code/cgame/cg_event.c
@@ -156,40 +156,39 @@ static void CG_Obituary(entityState_t *ent) {
 		gender = ci->gender;
 		switch (mod) {
 		case MOD_BALLOONY_SPLASH:
-			if (gender == GENDER_FEMALE)
+			if (gender == GENDER_MALE)
+				message = "tripped on his own water bomb";
+			else if (gender == GENDER_FEMALE)
 				message = "tripped on her own water bomb";
 			else if (gender == GENDER_NEUTER)
 				message = "tripped on its own water bomb";
 			else
-				message = "tripped on his own water bomb";
+				message = "tripped on their own water bomb";
 			break;
 		case MOD_BETTY_SPLASH:
-			if (gender == GENDER_FEMALE)
+			if (gender == GENDER_MALE)
+				message = "blew himself up";
+			else if (gender == GENDER_FEMALE)
 				message = "blew herself up";
 			else if (gender == GENDER_NEUTER)
 				message = "blew itself up";
 			else
-				message = "blew himself up";
+				message = "blew themselves up";
 			break;
 		case MOD_BUBBLEG_SPLASH:
-			if (gender == GENDER_FEMALE)
+			if (gender == GENDER_MALE)
+				message = "melted himself";
+			else if (gender == GENDER_FEMALE)
 				message = "melted herself";
 			else if (gender == GENDER_NEUTER)
 				message = "melted itself";
 			else
-				message = "melted himself";
+				message = "melted themselves";
 			break;
 		case MOD_IMPERIUS_SPLASH:
 			message = "should have used a smaller gun";
 			break;
-		default: /*
-			 if ( gender == GENDER_FEMALE )
-				 message = "killed herself";
-			 else if ( gender == GENDER_NEUTER )
-				 message = "killed itself";
-			 else
-				 message = "killed himself";
-			 break;*/
+		default:
 			message = "did the lemming thing";
 			break;
 		}
@@ -206,19 +205,19 @@ static void CG_Obituary(entityState_t *ent) {
 
 		if (cgs.gametype < GT_TEAM) {
 			if (cgs.gametype == GT_LPS) {
-				const char *gender_strings[] = {"he", "she", "it", 0};
+				const char *gender_strings[] = {"they have", "he has", "she has", "it has", NULL};
 				CASSERT(ARRAY_LEN(gender_strings) == GENDER_MAX + 1);
 
 				gender = ci->gender;
-				if (gender > 2 || gender < 0)
-					gender = 2;
+				if (gender >= GENDER_MAX || gender < GENDER_NONE)
+					gender = GENDER_NONE;
 
 				if (ent->generic1 == 0)
-					s = va("You fragged %s\n%s has no lives left.", targetName, gender_strings[gender]);
+					s = va("You fragged %s,\n%s no lives left.", targetName, gender_strings[gender]);
 				else if (ent->generic1 == 1)
-					s = va("You fragged %s\n%s has 1 live left.", targetName, gender_strings[gender]);
+					s = va("You fragged %s,\n%s 1 life left.", targetName, gender_strings[gender]);
 				else
-					s = va("You fragged %s\n%s has %i lives left.", targetName, gender_strings[gender], ent->generic1);
+					s = va("You fragged %s,\n%s %i lives left.", targetName, gender_strings[gender], ent->generic1);
 			} else
 				s = va("You fragged %s\n%s place with %i", targetName,
 					   CG_PlaceString(cg.snap->ps.persistant[PERS_RANK] + 1), cg.snap->ps.persistant[PERS_SCORE]);
@@ -282,7 +281,7 @@ static void CG_Obituary(entityState_t *ent) {
 			break;
 		case MOD_SPLASHER:
 			message = "was splashed by";
-			message2 = "'s splasher";
+			message2 = "'s Splasher";
 			break;
 		case MOD_BOASTER:
 			message = "was showered by";
@@ -294,7 +293,7 @@ static void CG_Obituary(entityState_t *ent) {
 			break;
 		case MOD_KILLERDUCKS:
 			message = "was hunted & bitten to death by";
-			message2 = "'s KillerDuck";
+			message2 = "'s Killerduck";
 			break;
 		case MOD_TELEFRAG:
 			message = "tried to invade";

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -369,7 +369,8 @@ typedef struct {
 	float headScale;
 
 	footstep_t footsteps;
-	gender_t gender; // from model
+	gender_t gender;	  // user settings (can also be from model)
+	gender_t genderModel; // cached value from model (animation.cfg)
 
 	qhandle_t legsModel;
 	qhandle_t legsSkin;

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -3394,7 +3394,7 @@ void CL_Init(void) {
 	Cvar_Get("team_model", "padman", CVAR_USERINFO | CVAR_ARCHIVE);
 	Cvar_Get("team_headmodel", "padman", CVAR_USERINFO | CVAR_ARCHIVE);
 	Cvar_Get("handicap", "100", CVAR_USERINFO | CVAR_ARCHIVE);
-	Cvar_Get("sex", "male", CVAR_USERINFO | CVAR_ARCHIVE);
+	Cvar_Get("sex", "model", CVAR_USERINFO | CVAR_ARCHIVE);
 	Cvar_Get("cl_anonymous", "0", CVAR_USERINFO | CVAR_ARCHIVE);
 
 	Cvar_Get("password", "", CVAR_USERINFO);

--- a/code/game/bg_public.h
+++ b/code/game/bg_public.h
@@ -160,7 +160,7 @@ typedef enum {
 
 int convertGTStringToGTNumber(const char *argStr);
 
-typedef enum { GENDER_MALE, GENDER_FEMALE, GENDER_NEUTER, GENDER_MAX } gender_t;
+typedef enum { GENDER_NONE, GENDER_MALE, GENDER_FEMALE, GENDER_NEUTER, GENDER_MAX } gender_t;
 
 /*
 ===================================================================================

--- a/code/game/g_bot.c
+++ b/code/game/g_bot.c
@@ -576,7 +576,7 @@ static void G_AddBot(const char *name, float skill, const char *team, int delay,
 	// have the server allocate a client slot
 	clientNum = trap_BotAllocateClient();
 	if (clientNum == -1) {
-		G_Printf(S_COLOR_RED "Unable to add bot.  All player slots are in use.\n");
+		G_Printf(S_COLOR_RED "Unable to add bot. All player slots are in use.\n");
 		G_Printf(S_COLOR_RED "Start server with more 'open' slots (or check setting of sv_maxclients cvar).\n");
 		return;
 	}


### PR DESCRIPTION
Inspired by https://github.com/PadWorld-Entertainment/worldofpadman-fork/pull/41

- [x] add "none" as a new gender which will force "they/them" to be used instead of "male" with "he/him"
- [x] add "model" as the new default gender which will force always to apply the gender of the selected player model (to keep old behavior)
- [x] also "none" is the fallback for a model if a gender is undefined in animations.cfg
- [x] add gender neutral event messages
- [x] fix minor typos in event messages
- [x] add gender selection option (model/male/female/neuter/none) in player settings menu; if "model" the gender is normally set by the player model via animations.cfg, else taken from user info "sex"
- [x] add a tool tip for gender selection option