### PR TITLE
AUTOSWITCH:  Extends weapon auto switch with more options

### DIFF
--- a/code/cgame/cg_event.c
+++ b/code/cgame/cg_event.c
@@ -392,21 +392,20 @@ CG_WeaponHigher
 ================
 */
 static qboolean CG_WeaponHigher(int currentWeapon, int newWeapon) {
-    char *currentScore = NULL;
-    char *newScore = NULL;
-    char weapon[5];
-    Com_sprintf(weapon,5,"/%i/",currentWeapon);
-    currentScore = strstr(cg_weaponOrder.string,weapon);
-    Com_sprintf(weapon,5,"/%i/",newWeapon);
-    newScore = strstr(cg_weaponOrder.string,weapon);
-    if(!newScore || !currentScore)
-        return qfalse;
-    if(newScore>currentScore)
-        return qtrue;
-    else
-        return qfalse;
+	const char *currentScore = NULL;
+	const char *newScore = NULL;
+	char weapon[5];
+	Com_sprintf(weapon, sizeof(weapon), "/%i/", currentWeapon);
+	currentScore = strstr(cg_weaponOrder.string, weapon);
+	Com_sprintf(weapon, sizeof(weapon), "/%i/", newWeapon);
+	newScore = strstr(cg_weaponOrder.string, weapon);
+	if (!newScore || !currentScore)
+		return qfalse;
+	if (newScore > currentScore)
+		return qtrue;
+	else
+		return qfalse;
 }
-
 
 /*
 ================
@@ -433,7 +432,7 @@ static void CG_ItemPickup(int itemNum) {
 			if (cg.weaponSelect == WP_SPRAYPISTOL)
 				return;
 		}
-		
+
 		// if always
 		if (cg_autoswitch.integer == 1 && bg_itemlist[itemNum].giTag != WP_NIPPER) {
 			cg.weaponSelectTime = cg.time;
@@ -441,24 +440,23 @@ static void CG_ItemPickup(int itemNum) {
 		}
 
 		// if new
-		if (cg_autoswitch.integer == 2 && 0 == (cg.snap->ps.stats[ STAT_WEAPONS ] & (1 << bg_itemlist[itemNum].giTag))) {
-            cg.weaponSelectTime = cg.time;
+		if (cg_autoswitch.integer == 2 && 0 == (cg.snap->ps.stats[STAT_WEAPONS] & (1 << bg_itemlist[itemNum].giTag))) {
+			cg.weaponSelectTime = cg.time;
 			cg.weaponSelect = bg_itemlist[itemNum].giTag;
-        }
+		}
 
 		// if better
-        if (cg_autoswitch.integer == 3 && CG_WeaponHigher(cg.weaponSelect,bg_itemlist[itemNum].giTag)) {
-        	cg.weaponSelectTime = cg.time;
+		if (cg_autoswitch.integer == 3 && CG_WeaponHigher(cg.weaponSelect, bg_itemlist[itemNum].giTag)) {
+			cg.weaponSelectTime = cg.time;
 			cg.weaponSelect = bg_itemlist[itemNum].giTag;
-        }
+		}
 
-        // if new and better
-        if (cg_autoswitch.integer == 4 && 0 == (cg.snap->ps.stats[ STAT_WEAPONS ] & (1 << bg_itemlist[itemNum].giTag)) 
-				&& CG_WeaponHigher(cg.weaponSelect,bg_itemlist[itemNum].giTag)) {
-            cg.weaponSelectTime = cg.time;
+		// if new and better
+		if (cg_autoswitch.integer == 4 && 0 == (cg.snap->ps.stats[STAT_WEAPONS] & (1 << bg_itemlist[itemNum].giTag)) &&
+			CG_WeaponHigher(cg.weaponSelect, bg_itemlist[itemNum].giTag)) {
+			cg.weaponSelectTime = cg.time;
 			cg.weaponSelect = bg_itemlist[itemNum].giTag;
-    	}
-
+		}
 	}
 
 	if (bg_itemlist[itemNum].giType == IT_POWERUP && bg_itemlist[itemNum].giTag == PW_BERSERKER) {

--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -1263,6 +1263,7 @@ extern vmCvar_t cg_tracerChance;
 extern vmCvar_t cg_tracerWidth;
 extern vmCvar_t cg_tracerLength;
 extern vmCvar_t cg_autoswitch;
+extern vmCvar_t cg_weaponOrder;
 extern vmCvar_t cg_ignore;
 extern vmCvar_t cg_simpleItems;
 extern vmCvar_t cg_fov;

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -125,6 +125,7 @@ vmCvar_t cg_tracerChance;
 vmCvar_t cg_tracerWidth;
 vmCvar_t cg_tracerLength;
 vmCvar_t cg_autoswitch;
+vmCvar_t cg_weaponOrder;
 vmCvar_t cg_ignore;
 vmCvar_t cg_simpleItems;
 vmCvar_t cg_fov;
@@ -217,7 +218,8 @@ typedef struct {
 
 static cvarTable_t cvarTable[] = {	   // bk001129
 	{&cg_ignore, "cg_ignore", "0", 0}, // used for debugging
-	{&cg_autoswitch, "cg_autoswitch", "1", CVAR_ARCHIVE},
+	{&cg_autoswitch, "cg_autoswitch", "4", CVAR_ARCHIVE},
+	{&cg_weaponOrder,"cg_weaponOrder", "/1/2/4/6/3/7/8/9/5/", CVAR_ARCHIVE},
 	{&cg_drawGun, "cg_drawGun", "1", CVAR_ARCHIVE},
 	{&cg_zoomFov, "cg_zoomfov", "22.5", CVAR_ARCHIVE},
 	{&cg_fov, "cg_fov", "90", CVAR_ARCHIVE},

--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -3343,7 +3343,7 @@ void CL_Init(void) {
 
 	// init autoswitch so the ui will have it correctly even
 	// if the cgame hasn't been started
-	Cvar_Get("cg_autoswitch", "1", CVAR_ARCHIVE);
+	Cvar_Get("cg_autoswitch", "4", CVAR_ARCHIVE);
 
 	m_pitch = Cvar_Get("m_pitch", "0.022", CVAR_ARCHIVE);
 	m_yaw = Cvar_Get("m_yaw", "0.022", CVAR_ARCHIVE);

--- a/code/ui/ui_controls.c
+++ b/code/ui/ui_controls.c
@@ -140,14 +140,13 @@ typedef struct {
 #define ID_FREELOOK 60
 #define ID_INVERTMOUSE 61
 #define ID_ALWAYSRUN 62
-#define ID_AUTOSWITCH 63
-#define ID_MOUSESPEED 64
-#define ID_JOYENABLE 65
-#define ID_JOYTHRESHOLD 66
-#define ID_SMOOTHMOUSE 67
-#define ID_MOUSEACCELFACTOR 68
-#define ID_MOUSEACCELSTYLE 69
-#define ID_MOUSEACCELOFFSET 70
+#define ID_MOUSESPEED 63
+#define ID_JOYENABLE 64
+#define ID_JOYTHRESHOLD 65
+#define ID_SMOOTHMOUSE 66
+#define ID_MOUSEACCELFACTOR 67
+#define ID_MOUSEACCELSTYLE 68
+#define ID_MOUSEACCELOFFSET 69
 
 #define ANIM_IDLE 0
 #define ANIM_RUN 1
@@ -218,7 +217,6 @@ typedef struct {
 	menuaction_s zoom;
 	menuaction_s nextweapon;
 	menuaction_s prevweapon;
-	menuradiobutton_s autoswitch;
 	menuaction_s chainsaw;
 	menuaction_s machinegun;
 	menuaction_s shotgun;
@@ -335,7 +333,6 @@ static configcvar_t g_configcvars[] =
 {
 	{"cl_run", 0, 0},
 	{"m_pitch",	0, 0},
-	{"cg_autoswitch", 0, 0},
 	{"sensitivity", 0, 0},
 	{"cl_mouseAccel", 0, 0},
 	{"cl_mouseAccelStyle", 0, 0},
@@ -369,7 +366,6 @@ static menucommon_s *g_weapons_controls[] = {
 	(menucommon_s *)&s_controls.zoom,
 	(menucommon_s *)&s_controls.nextweapon,
 	(menucommon_s *)&s_controls.prevweapon,
-	(menucommon_s *)&s_controls.autoswitch,
 	(menucommon_s *)&s_controls.chainsaw,
 	(menucommon_s *)&s_controls.machinegun,
 	(menucommon_s *)&s_controls.shotgun,
@@ -877,7 +873,6 @@ static void Controls_GetConfig(void) {
 	s_controls.invertmouse.curvalue = Controls_GetCvarValue("m_pitch") < 0;
 	s_controls.smoothmouse.curvalue = UI_ClampCvar(0, 1, Controls_GetCvarValue("m_filter"));
 	s_controls.alwaysrun.curvalue = UI_ClampCvar(0, 1, Controls_GetCvarValue("cl_run"));
-	s_controls.autoswitch.curvalue = UI_ClampCvar(0, 1, Controls_GetCvarValue("cg_autoswitch"));
 	s_controls.sensitivity.curvalue = UI_ClampCvar(2, 30, Controls_GetCvarValue("sensitivity"));
 	s_controls.maccelfactor.curvalue = UI_ClampCvar(0, 10, Controls_GetCvarValue("cl_mouseAccel"));
 	s_controls.maccelstyle.curvalue = UI_ClampCvar(0, 1, Controls_GetCvarValue("cl_mouseAccelStyle"));
@@ -919,7 +914,6 @@ static void Controls_SetConfig(void) {
 
 	trap_Cvar_SetValue("m_filter", s_controls.smoothmouse.curvalue);
 	trap_Cvar_SetValue("cl_run", s_controls.alwaysrun.curvalue);
-	trap_Cvar_SetValue("cg_autoswitch", s_controls.autoswitch.curvalue);
 	trap_Cvar_SetValue("sensitivity", s_controls.sensitivity.curvalue);
 	trap_Cvar_SetValue("cl_mouseAccel", s_controls.maccelfactor.curvalue);
 	trap_Cvar_SetValue("cl_mouseAccelStyle", s_controls.maccelstyle.curvalue);
@@ -983,7 +977,6 @@ static void Controls_SetDefaults(void) {
 	s_controls.invertmouse.curvalue = Controls_GetCvarDefault("m_pitch") < 0;
 	s_controls.alwaysrun.curvalue = Controls_GetCvarDefault("cl_run");
 	s_controls.smoothmouse.curvalue = Controls_GetCvarDefault("m_filter");
-	s_controls.autoswitch.curvalue = Controls_GetCvarDefault("cg_autoswitch");
 	s_controls.sensitivity.curvalue = Controls_GetCvarDefault("sensitivity");
 	s_controls.maccelfactor.curvalue = Controls_GetCvarDefault("cl_mouseAccel");
 	s_controls.maccelstyle.curvalue = Controls_GetCvarDefault("cl_mouseAccelStyle");
@@ -1216,7 +1209,6 @@ static void Controls_MenuEvent(void *ptr, int event) {
 	case ID_INVERTMOUSE:
 	case ID_SMOOTHMOUSE:
 	case ID_ALWAYSRUN:
-	case ID_AUTOSWITCH:
 	case ID_JOYENABLE:
 		if (event == QM_ACTIVATED) {
 			s_controls.changesmade = qtrue;
@@ -1558,16 +1550,6 @@ static void Controls_MenuInit(void) {
 	s_controls.prevweapon.generic.ownerdraw = Controls_DrawKeyBinding;
 	s_controls.prevweapon.generic.id = ID_WEAPPREV;
 
-	s_controls.autoswitch.generic.type = MTYPE_RADIOBUTTON;
-	s_controls.autoswitch.generic.flags = QMF_SMALLFONT;
-	s_controls.autoswitch.generic.x = SCREEN_WIDTH / 2;
-	s_controls.autoswitch.generic.name = "Autoswitch Weapon:";
-	s_controls.autoswitch.generic.id = ID_AUTOSWITCH;
-	s_controls.autoswitch.generic.callback = Controls_MenuEvent;
-	s_controls.autoswitch.generic.statusbar = Controls_StatusBar;
-	s_controls.autoswitch.generic.toolTip =
-		"If enabled, your character will automatically switch to the weapon that you run into to pick up.";
-
 	s_controls.chainsaw.generic.type = MTYPE_ACTION;
 	s_controls.chainsaw.generic.flags = QMF_LEFT_JUSTIFY | QMF_GRAYED | QMF_HIDDEN;
 	s_controls.chainsaw.generic.callback = Controls_ActionEvent;
@@ -1797,7 +1779,6 @@ static void Controls_MenuInit(void) {
 	Menu_AddItem(&s_controls.menu, &s_controls.zoom);
 	Menu_AddItem(&s_controls.menu, &s_controls.nextweapon);
 	Menu_AddItem(&s_controls.menu, &s_controls.prevweapon);
-	Menu_AddItem(&s_controls.menu, &s_controls.autoswitch);
 	Menu_AddItem(&s_controls.menu, &s_controls.chainsaw);
 	Menu_AddItem(&s_controls.menu, &s_controls.machinegun);
 	Menu_AddItem(&s_controls.menu, &s_controls.shotgun);

--- a/code/ui/ui_preferences.c
+++ b/code/ui/ui_preferences.c
@@ -67,16 +67,17 @@ PREFERENCES MENU
 #define ID_FPS 20
 #define ID_UPS 21
 
-#define ID_SIMPLEITEMS 30
-#define ID_WALLMARKS 31
-#define ID_DYNAMICLIGHTS 32
-#define ID_FLARES 33
-#define ID_HIGHQUALITYSKY 34
-#define ID_LENSFLARE 35
-#define ID_INGAMEVIDEO 36
-#define ID_SYNCEVERYFRAME 37
-#define ID_FORCEMODEL 38
-#define ID_GLOWMODEL 39
+#define ID_AUTOSWITCH 30
+#define ID_SIMPLEITEMS 31
+#define ID_WALLMARKS 32
+#define ID_DYNAMICLIGHTS 33
+#define ID_FLARES 34
+#define ID_HIGHQUALITYSKY 35
+#define ID_LENSFLARE 36
+#define ID_INGAMEVIDEO 37
+#define ID_SYNCEVERYFRAME 38
+#define ID_FORCEMODEL 39
+#define ID_GLOWMODEL 40
 
 #define ID_CONNOTIFY 50
 #define ID_CHATHEIGHT 51
@@ -123,6 +124,7 @@ typedef struct {
 	menuradiobutton_s fps;
 	menuradiobutton_s ups;
 
+	menulist_s autoswitch;
 	menuradiobutton_s simpleitems;
 	menuradiobutton_s wallmarks;
 	menuradiobutton_s dynamiclights;
@@ -180,6 +182,7 @@ static menucommon_s *g_hud_options[] = {
 };
 
 static menucommon_s *g_game_options[] = {
+	(menucommon_s *)&s_preferences.autoswitch,
 	(menucommon_s *)&s_preferences.simpleitems,
 	(menucommon_s *)&s_preferences.wallmarks,
 	(menucommon_s *)&s_preferences.dynamiclights,
@@ -229,6 +232,8 @@ static menucommon_s **g_options[] = {
 static const char *ffahudtheme_items[] = {"Black", "Red", "Blue", "Green", "Chrome", "Whitemetal",
 									 "Rust", "Flower", "Wood", "Airforce", NULL};
 
+static const char *autoswitch_items[] = {"Never", "Always", "New", "Better", "New+Better", NULL};
+
 static const char *connotify_items[] = {"Short", "Default", "Long", "Maximum", NULL};
 
 static const char *glowmodel_items[] = {S_COLOR_YELLOW "None", S_COLOR_BLACK "Black", S_COLOR_RED "Red",
@@ -263,6 +268,7 @@ static void UI_Preferences_SetMenuItems(void) {
 	s_preferences.fps.curvalue = Com_Clamp(0, 1, trap_Cvar_VariableValue("cg_drawFPS"));
 	s_preferences.ups.curvalue = Com_Clamp(0, 1, trap_Cvar_VariableValue("cg_drawups"));
 
+	s_preferences.autoswitch.curvalue = Com_Clamp(0, 4, trap_Cvar_VariableValue("cg_autoswitch"));
 	s_preferences.simpleitems.curvalue = trap_Cvar_VariableValue("cg_simpleItems") != 0;
 	s_preferences.wallmarks.curvalue = trap_Cvar_VariableValue("cg_marks") != 0;
 	s_preferences.dynamiclights.curvalue = trap_Cvar_VariableValue("r_dynamiclight") != 0;
@@ -476,6 +482,10 @@ static void UI_Preferences_Event(void *ptr, int notification) {
 
 	case ID_UPS:
 		trap_Cvar_SetValue("cg_drawUPS", s_preferences.ups.curvalue);
+		break;
+
+	case ID_AUTOSWITCH:
+		trap_Cvar_SetValue("cg_autoswitch", s_preferences.autoswitch.curvalue);
 		break;
 
 	case ID_SIMPLEITEMS:
@@ -904,6 +914,21 @@ static void UI_Preferences_MenuInit(void) {
 
 	// game options
 	y = YPOSITION;
+	s_preferences.autoswitch.generic.type = MTYPE_SPINCONTROL;
+	s_preferences.autoswitch.generic.name = "Autoswitch Weapon:";
+	s_preferences.autoswitch.generic.flags = QMF_SMALLFONT | QMF_HIDDEN;
+	s_preferences.autoswitch.generic.callback = UI_Preferences_Event;
+	s_preferences.autoswitch.generic.id = ID_AUTOSWITCH;
+	s_preferences.autoswitch.generic.x = XPOSITION;
+	s_preferences.autoswitch.generic.y = y;
+	s_preferences.autoswitch.itemnames = autoswitch_items;
+	s_preferences.autoswitch.generic.toolTip =
+		"If you run into a weapon to pick it up, your character will 'never' auto-switch to that weapon, "
+		"'always' auto-switch to that weapon, only auto-switch to that weapon when 'new', only auto-switch "
+		"to that weapon when 'better', only auto-switch to that weapon when 'new and better'. Default is "
+		"'new and better'.";
+
+	y += (BIGCHAR_HEIGHT + 2);
 	s_preferences.simpleitems.generic.type = MTYPE_RADIOBUTTON;
 	s_preferences.simpleitems.generic.name = "Simple Items:";
 	s_preferences.simpleitems.generic.flags = QMF_SMALLFONT | QMF_HIDDEN;
@@ -1277,6 +1302,7 @@ static void UI_Preferences_MenuInit(void) {
 	Menu_AddItem(&s_preferences.menu, &s_preferences.fps);
 	Menu_AddItem(&s_preferences.menu, &s_preferences.ups);
 
+	Menu_AddItem(&s_preferences.menu, &s_preferences.autoswitch);
 	Menu_AddItem(&s_preferences.menu, &s_preferences.simpleitems);
 	Menu_AddItem(&s_preferences.menu, &s_preferences.wallmarks);
 	Menu_AddItem(&s_preferences.menu, &s_preferences.dynamiclights);


### PR DESCRIPTION
cg_autoswitch now works as follows:
0 = Never: as before, simply switched off.
1 = Always: switches the weapon every time one is picked up
2 = New: switches to a picked up weapon if it is new and was not in the inventory before
3 = Better: changes to a picked up weapon if it is better than the currently selected weapon
4 = New+Better: switches to a picked up weapon if it is new and was not in the inventory before and if it is better than the currently selected weapon.

The new default value for cg_autoswitch is 4 (New+Better). This is a better value for beginners. Experienced players will want to set cg_autochange to 0 anyway.

The weapon order is determined by the cvar cg_weaponOrder. The current default is "/1/2/4/6/3/7/8/9/5/" and can be customized.

The Autoswitch Weapon menu entry has been removed from the Controls menu and is now located in the Options menu on the Game page.

Thanks to Open Arena for giving the idea and the code to build up on. https://github.com/OpenArena/gamecode/commit/32fa9c763bcbd2b3e84e4beb19b0a1f790e7e318