### PR TITLE
MMPLAYER: Simple music player accessible from the main menu

### DIFF
--- a/code/tests/CMakeLists.txt
+++ b/code/tests/CMakeLists.txt
@@ -90,6 +90,7 @@ set(SRCS_UI
 	${CODE_DIR}/ui/ui_menu.c
 	${CODE_DIR}/ui/ui_mfield.c
 	${CODE_DIR}/ui/ui_mods.c
+	${CODE_DIR}/ui/ui_music.c
 	${CODE_DIR}/ui/ui_musicbox.c
 	${CODE_DIR}/ui/ui_network.c
 	${CODE_DIR}/ui/ui_password.c

--- a/code/ui/CMakeLists.txt
+++ b/code/ui/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRCS
 	ui_menu.c
 	ui_mfield.c
 	ui_mods.c
+	ui_music.c
 	ui_musicbox.c
 	ui_network.c
 	ui_password.c

--- a/code/ui/ui_local.h
+++ b/code/ui/ui_local.h
@@ -434,6 +434,12 @@ extern void UI_Controls_Cache(void);
 extern void UI_SetDefaultBinds_onUnusedKeys(void);
 
 //
+// ui_music.c
+//
+extern void UI_MusicMenu(void);
+extern void UI_Music_Cache(void);
+
+//
 // ui_demos.c
 //
 extern void UI_DemosMenu(void);

--- a/code/ui/ui_menu.c
+++ b/code/ui/ui_menu.c
@@ -109,6 +109,7 @@ static void Main_MenuEvent(void *ptr, int event) {
 		break;
 
 	case ID_MUSIC:
+		UI_MusicMenu();
 		break;
 
 	case ID_DEMOS:
@@ -304,7 +305,7 @@ void UI_MainMenu(void) {
 
 	s_main.Music.generic.type = MTYPE_BITMAP;
 	s_main.Music.generic.name = MUSIC0;
-	s_main.Music.generic.flags = QMF_LEFT_JUSTIFY | QMF_INACTIVE; //QMF_HIGHLIGHT_IF_FOCUS;
+	s_main.Music.generic.flags = QMF_LEFT_JUSTIFY | QMF_HIGHLIGHT_IF_FOCUS;
 	s_main.Music.generic.x = 710;
 	s_main.Music.generic.y = 248;
 	s_main.Music.generic.id = ID_MUSIC;

--- a/code/ui/ui_music.c
+++ b/code/ui/ui_music.c
@@ -1,0 +1,349 @@
+/*
+===========================================================================
+Copyright (C) 1999-2005 Id Software, Inc.
+
+This file is part of Quake III Arena source code.
+
+Quake III Arena source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+Quake III Arena source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Quake III Arena source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+//
+#include "ui_local.h"
+
+/*
+=======================================================================
+
+MUSIC PLAYER MENU
+
+=======================================================================
+*/
+
+#define MUSICBG "menu/bg/music"
+#define PLAY0 "menu/buttons/mp_play0"
+#define PLAY1 "menu/buttons/mp_play1"
+#define STOP0 "menu/buttons/mp_stop0"
+#define STOP1 "menu/buttons/mp_stop1"
+#define PREVSONG0 "menu/buttons/mp_prevs0"
+#define PREVSONG1 "menu/buttons/mp_prevs1"
+#define NEXTSONG0 "menu/buttons/mp_nexts0"
+#define NEXTSONG1 "menu/buttons/mp_nexts1"
+#define PREVALBUM0 "menu/buttons/mp_preva0"
+#define PREVALBUM1 "menu/buttons/mp_preva1"
+#define NEXTALBUM0 "menu/buttons/mp_nexta0"
+#define NEXTALBUM1 "menu/buttons/mp_nexta1"
+#define EXIT0 "menu/buttons/mp_exit0"
+#define EXIT1 "menu/buttons/mp_exit1"
+
+#define ID_PLAY 10
+#define ID_STOP 11
+#define ID_NEXTSONG 12
+#define ID_PREVSONG 13
+#define ID_NEXTALBUM 14
+#define ID_PREVALBUM 15
+#define ID_EXIT 16
+
+#define MAX_TRACKS 15
+#define MAX_ALBUMS 10
+#define MAX_TRACKNAME 64
+#define MAX_ALBUMNAME 32
+
+typedef struct {
+	menuframework_s menu;
+
+	menubitmap_s musicbg;
+	menubitmap_s play;
+	menubitmap_s stop;
+	menubitmap_s nextsong;
+	menubitmap_s prevsong;
+	menubitmap_s nextalbum;
+	menubitmap_s prevalbum;
+	menubitmap_s exit;
+
+} music_t;
+
+static music_t s_music;
+
+/*
+=================
+UI_Music_UpdateMenuItems
+=================
+*/
+static void UI_Music_UpdateMenuItems(void) {
+/*	if (UI_GetCvarInt("r_fullscreen") == 0) {
+		s_graphicsoptions.colordepth.generic.flags |= QMF_GRAYED;
+	} else {
+		s_graphicsoptions.colordepth.generic.flags &= ~QMF_GRAYED;
+	}
+
+	if (Q_stricmp(UI_Cvar_VariableString("cl_renderer"), "opengl2") ||
+		(s_graphicsoptions.renderer.curvalue != 1)) {
+		s_graphicsoptions.effects.generic.flags |= QMF_GRAYED;
+	} else {
+		s_graphicsoptions.effects.generic.flags &= ~QMF_GRAYED;
+	}
+
+	s_graphicsoptions.apply.generic.flags |= QMF_HIDDEN | QMF_INACTIVE;
+	if (s_ivo.mode != s_graphicsoptions.mode.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.renderer != s_graphicsoptions.renderer.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.colordepth != s_graphicsoptions.colordepth.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.lighting != s_graphicsoptions.lighting.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.mdetail != s_graphicsoptions.mdetail.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.cdetail != s_graphicsoptions.cdetail.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.tdetail != s_graphicsoptions.tdetail.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.tquality != s_graphicsoptions.tquality.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.tfilter != s_graphicsoptions.tfilter.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.ct != s_graphicsoptions.ct.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	} else if (s_ivo.aa != s_graphicsoptions.aa.curvalue) {
+		s_graphicsoptions.apply.generic.flags &= ~(QMF_HIDDEN | QMF_INACTIVE);
+	}*/
+
+}
+
+/*
+=================
+UI_Music_MenuEvent
+=================
+*/
+static void UI_Music_MenuEvent(void *ptr, int event) {
+	if (event != QM_ACTIVATED) {
+		return;
+	}
+
+	switch (((menucommon_s *)ptr)->id) {
+	case ID_PLAY:
+		break;
+
+	case ID_STOP:
+		break;
+
+	case ID_NEXTSONG:
+		break;
+
+	case ID_PREVSONG:
+		break;
+
+	case ID_NEXTALBUM:
+		break;
+
+	case ID_PREVALBUM:
+		break;
+
+	case ID_EXIT:
+		UI_StartMusic();
+		UI_PopMenu();
+		break;
+	}
+}
+
+/*
+================
+UI_Music_Key
+================
+*/
+static sfxHandle_t UI_Music_Key(int key) {
+	switch (key) {
+	case K_ESCAPE:
+		UI_Music_MenuEvent(&s_music.exit, QM_ACTIVATED);
+		break;
+	}
+
+	return Menu_DefaultKey(&s_music.menu, key);
+}
+
+/*
+================
+UI_Music_InitAlbums
+================
+*/
+void UI_Music_InitAlbums(void) {
+
+
+
+}
+
+/*
+================
+UI_Music_DrawAlbums
+================
+*/
+static void UI_Music_DrawAlbums(void) {
+
+	// if (musicInfo.albums[musicMenu.currentAlbum].background) {
+	// 	UI_DrawHandlePic((202), 60, 374, 340, musicInfo.albums[musicMenu.currentAlbum].background);
+	//}
+}
+
+/*
+================
+UI_Music_MenuInit
+================
+*/
+void UI_Music_MenuInit(void) {
+	memset(&s_music, 0, sizeof(music_t));
+
+	// zero set all our globals
+	UI_Music_Cache();
+	UI_Music_InitAlbums();
+
+	s_music.menu.wrapAround = qtrue;
+	s_music.menu.fullscreen = qtrue;
+	s_music.menu.key = UI_Music_Key;
+	
+	UI_Music_DrawAlbums();
+
+	s_music.musicbg.generic.type = MTYPE_BITMAP;
+	s_music.musicbg.generic.name = MUSICBG;
+	s_music.musicbg.generic.x = 0;
+	s_music.musicbg.generic.y = 0;
+	s_music.musicbg.width = SCREEN_WIDTH;
+	s_music.musicbg.height = SCREEN_HEIGHT;
+
+	s_music.play.generic.type = MTYPE_BITMAP;
+	s_music.play.generic.name = PLAY0;
+	s_music.play.generic.flags = QMF_LEFT_JUSTIFY | QMF_HIGHLIGHT_IF_FOCUS;
+	s_music.play.generic.callback = UI_Music_MenuEvent;
+	s_music.play.generic.id = ID_PLAY;
+	s_music.play.generic.x = 433;
+	s_music.play.generic.y = 323;
+	s_music.play.width = 44;
+	s_music.play.height = 44;
+	s_music.play.focuspic = PLAY1;
+	s_music.play.focuspicinstead = qtrue;
+
+	s_music.stop.generic.type = MTYPE_BITMAP;
+	s_music.stop.generic.name = STOP0;
+	s_music.stop.generic.flags = QMF_LEFT_JUSTIFY | QMF_HIGHLIGHT_IF_FOCUS;
+	s_music.stop.generic.callback = UI_Music_MenuEvent;
+	s_music.stop.generic.id = ID_STOP;
+	s_music.stop.generic.x = 387;
+	s_music.stop.generic.y = 323;
+	s_music.stop.width = 44;
+	s_music.stop.height = 44;
+	s_music.stop.focuspic = STOP1;
+	s_music.stop.focuspicinstead = qtrue;
+
+	s_music.nextsong.generic.type = MTYPE_BITMAP;
+	s_music.nextsong.generic.name = NEXTSONG0;
+	s_music.nextsong.generic.flags = QMF_LEFT_JUSTIFY | QMF_HIGHLIGHT_IF_FOCUS;
+	s_music.nextsong.generic.callback = UI_Music_MenuEvent;
+	s_music.nextsong.generic.id = ID_NEXTSONG;
+	s_music.nextsong.generic.x = 479;
+	s_music.nextsong.generic.y = 323;
+	s_music.nextsong.width = 50;
+	s_music.nextsong.height = 44;
+	s_music.nextsong.focuspic = NEXTSONG1;
+	s_music.nextsong.focuspicinstead = qtrue;
+
+	s_music.prevsong.generic.type = MTYPE_BITMAP;
+	s_music.prevsong.generic.name = PREVSONG0;
+	s_music.prevsong.generic.flags = QMF_LEFT_JUSTIFY | QMF_HIGHLIGHT_IF_FOCUS;
+	s_music.prevsong.generic.callback = UI_Music_MenuEvent;
+	s_music.prevsong.generic.id = ID_PREVSONG;
+	s_music.prevsong.generic.x = 335;
+	s_music.prevsong.generic.y = 323;
+	s_music.prevsong.width = 50;
+	s_music.prevsong.height = 44;
+	s_music.prevsong.focuspic = PREVSONG1;
+	s_music.prevsong.focuspicinstead = qtrue;
+
+	s_music.nextalbum.generic.type = MTYPE_BITMAP;
+	s_music.nextalbum.generic.name = NEXTALBUM0;
+	s_music.nextalbum.generic.flags = QMF_LEFT_JUSTIFY | QMF_HIGHLIGHT_IF_FOCUS;
+	s_music.nextalbum.generic.callback = UI_Music_MenuEvent;
+	s_music.nextalbum.generic.id = ID_NEXTALBUM;
+	s_music.nextalbum.generic.x = 531;
+	s_music.nextalbum.generic.y = 323;
+	s_music.nextalbum.width = 50;
+	s_music.nextalbum.height = 44;
+	s_music.nextalbum.focuspic = NEXTALBUM1;
+	s_music.nextalbum.focuspicinstead = qtrue;
+
+	s_music.prevalbum.generic.type = MTYPE_BITMAP;
+	s_music.prevalbum.generic.name = PREVALBUM0;
+	s_music.prevalbum.generic.flags = QMF_LEFT_JUSTIFY | QMF_HIGHLIGHT_IF_FOCUS;
+	s_music.prevalbum.generic.callback = UI_Music_MenuEvent;
+	s_music.prevalbum.generic.id = ID_PREVALBUM;
+	s_music.prevalbum.generic.x = 283;
+	s_music.prevalbum.generic.y = 323;
+	s_music.prevalbum.width = 50;
+	s_music.prevalbum.height = 44;
+	s_music.prevalbum.focuspic = PREVALBUM1;
+	s_music.prevalbum.focuspicinstead = qtrue;
+
+	s_music.exit.generic.type = MTYPE_BITMAP;
+	s_music.exit.generic.name = EXIT0;
+	s_music.exit.generic.flags = QMF_LEFT_JUSTIFY | QMF_HIGHLIGHT_IF_FOCUS;
+	s_music.exit.generic.callback = UI_Music_MenuEvent;
+	s_music.exit.generic.id = ID_EXIT;
+	s_music.exit.generic.x = 750;
+	s_music.exit.generic.y = 192;
+	s_music.exit.width = 28;
+	s_music.exit.height = 28;
+	s_music.exit.focuspic = EXIT1;
+	s_music.exit.focuspicinstead = qtrue;
+
+	Menu_AddItem(&s_music.menu, &s_music.musicbg);
+	Menu_AddItem(&s_music.menu, &s_music.play);
+	Menu_AddItem(&s_music.menu, &s_music.stop);
+	Menu_AddItem(&s_music.menu, &s_music.nextsong);
+	Menu_AddItem(&s_music.menu, &s_music.prevsong);
+	Menu_AddItem(&s_music.menu, &s_music.nextalbum);
+	Menu_AddItem(&s_music.menu, &s_music.prevalbum);
+	Menu_AddItem(&s_music.menu, &s_music.exit);
+}
+
+/*
+=================
+UI_Music_Cache
+=================
+*/
+void UI_Music_Cache(void) {
+	trap_R_RegisterShaderNoMip(MUSICBG);
+	trap_R_RegisterShaderNoMip(PLAY0);
+	trap_R_RegisterShaderNoMip(PLAY1);
+	trap_R_RegisterShaderNoMip(STOP0);
+	trap_R_RegisterShaderNoMip(STOP1);
+	trap_R_RegisterShaderNoMip(NEXTSONG0);
+	trap_R_RegisterShaderNoMip(NEXTSONG1);
+	trap_R_RegisterShaderNoMip(PREVSONG0);
+	trap_R_RegisterShaderNoMip(PREVSONG1);
+	trap_R_RegisterShaderNoMip(NEXTALBUM0);
+	trap_R_RegisterShaderNoMip(NEXTALBUM1);
+	trap_R_RegisterShaderNoMip(PREVALBUM0);
+	trap_R_RegisterShaderNoMip(PREVALBUM1);
+	trap_R_RegisterShaderNoMip(EXIT0);
+	trap_R_RegisterShaderNoMip(EXIT1);
+}
+
+/*
+=================
+UI_MusicMenu
+=================
+*/
+void UI_MusicMenu(void) {
+	trap_S_StopBackgroundTrack();
+	UI_Music_MenuInit();
+	UI_PushMenu(&s_music.menu);
+}

--- a/code/ui/ui_music.c
+++ b/code/ui/ui_music.c
@@ -62,7 +62,6 @@ MUSIC PLAYER MENU
 typedef struct {
 	menuframework_s menu;
 
-	menubitmap_s musicbg;
 	menubitmap_s play;
 	menubitmap_s stop;
 	menubitmap_s nextsong;
@@ -71,9 +70,33 @@ typedef struct {
 	menubitmap_s prevalbum;
 	menubitmap_s exit;
 
+	int currentAlbum;
 } music_t;
 
 static music_t s_music;
+
+typedef struct {
+	char title[MAX_TRACKNAME];
+	char file[MAX_QPATH];
+} trackInfo_t;
+
+typedef struct {
+	trackInfo_t tracks[MAX_TRACKS];
+	qhandle_t albumCover;
+	char name[MAX_ALBUMNAME];
+	int numTracks;
+} albumInfo_t;
+
+typedef struct {
+	albumInfo_t albums[MAX_ALBUMS];
+
+//	playOrder_t *playOrder;
+//	playOrder_t *lastplayOrderItem;
+	int numAlbums;
+//	int songStarted;
+} musicInfo_t;
+
+static musicInfo_t s_musicInfo;
 
 /*
 =================
@@ -190,9 +213,26 @@ UI_Music_DrawAlbums
 */
 static void UI_Music_DrawAlbums(void) {
 
-	// if (musicInfo.albums[musicMenu.currentAlbum].background) {
-	// 	UI_DrawHandlePic((202), 60, 374, 340, musicInfo.albums[musicMenu.currentAlbum].background);
-	//}
+	if (s_musicInfo.albums[s_music.currentAlbum - 1].albumCover) {
+		UI_DrawHandlePic(110, 32, 130, 120, s_musicInfo.albums[s_music.currentAlbum - 1].albumCover);
+	} else {
+		UI_FillRect(110, 32, 130, 120, colorDkGrey);
+	}
+
+	if (s_musicInfo.albums[s_music.currentAlbum].albumCover) {
+		UI_DrawHandlePic(298, 32, 248, 230, s_musicInfo.albums[s_music.currentAlbum].albumCover);
+	} else {
+		UI_FillRect(298, 32, 248, 230, colorDkGrey);
+	}
+
+	if (s_musicInfo.albums[s_music.currentAlbum + 1].albumCover) {
+		UI_DrawHandlePic(614, 32, 130, 120, s_musicInfo.albums[s_music.currentAlbum + 1].albumCover);
+	} else {
+		UI_FillRect(614, 32, 130, 120, colorDkGrey);
+	}
+
+	UI_DrawNamedPic(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, MUSICBG);
+	Menu_Draw(&s_music.menu);
 }
 
 /*
@@ -210,15 +250,7 @@ void UI_Music_MenuInit(void) {
 	s_music.menu.wrapAround = qtrue;
 	s_music.menu.fullscreen = qtrue;
 	s_music.menu.key = UI_Music_Key;
-	
-	UI_Music_DrawAlbums();
-
-	s_music.musicbg.generic.type = MTYPE_BITMAP;
-	s_music.musicbg.generic.name = MUSICBG;
-	s_music.musicbg.generic.x = 0;
-	s_music.musicbg.generic.y = 0;
-	s_music.musicbg.width = SCREEN_WIDTH;
-	s_music.musicbg.height = SCREEN_HEIGHT;
+	s_music.menu.draw = UI_Music_DrawAlbums;
 
 	s_music.play.generic.type = MTYPE_BITMAP;
 	s_music.play.generic.name = PLAY0;
@@ -304,7 +336,6 @@ void UI_Music_MenuInit(void) {
 	s_music.exit.focuspic = EXIT1;
 	s_music.exit.focuspicinstead = qtrue;
 
-	Menu_AddItem(&s_music.menu, &s_music.musicbg);
 	Menu_AddItem(&s_music.menu, &s_music.play);
 	Menu_AddItem(&s_music.menu, &s_music.stop);
 	Menu_AddItem(&s_music.menu, &s_music.nextsong);

--- a/wop/menu.pk3dir/menu/bg/music.png
+++ b/wop/menu.pk3dir/menu/bg/music.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3dc17010db39e2580869da7700e085b9bd7b86b01e0aca9206940916b65865e0
+size 1209267

--- a/wop/menu.pk3dir/menu/buttons/mp_exit0.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_exit0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50e5204d674b5127f031835b09cff0c666800a8011197e475f3936f4722a1c9e
+size 26215

--- a/wop/menu.pk3dir/menu/buttons/mp_exit1.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_exit1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f347cd0fd42824973da5aab2f074d269d71497e95db989c6891ed2386c970582
+size 26864

--- a/wop/menu.pk3dir/menu/buttons/mp_nexta0.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_nexta0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:af126472b2be5c4372ea4f2e11df48be3e22534eb4cc5c38c698c799b7882fa0
+size 32761

--- a/wop/menu.pk3dir/menu/buttons/mp_nexta1.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_nexta1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:73109e59b6f8eb4564b8893599ef1384a886901e86327dfe327bf7421136a064
+size 34578

--- a/wop/menu.pk3dir/menu/buttons/mp_nexts0.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_nexts0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4eaded6497698f3131cbf8b4555be0c3d94d38c9ce12b671d0d0f415a7e1ef79
+size 26032

--- a/wop/menu.pk3dir/menu/buttons/mp_nexts1.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_nexts1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d9116cdf54e495239ecf406752cb19fb3596f9ef22f3973b8b845e205f17a70
+size 27509

--- a/wop/menu.pk3dir/menu/buttons/mp_play0.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_play0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c094f259918192bb852f849a0461fa58334f8ec433b82dea9a2f72a3d22ab68
+size 28348

--- a/wop/menu.pk3dir/menu/buttons/mp_play1.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_play1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80d445691a7cfae2ed29962f8452ea3fbb22da7fc8b03981b76a660e336eb448
+size 30193

--- a/wop/menu.pk3dir/menu/buttons/mp_preva0.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_preva0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b78ba2e227cc2a5848df0fc1fb725b0360ece3c63b43d2c396c1c8748979c552
+size 33007

--- a/wop/menu.pk3dir/menu/buttons/mp_preva1.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_preva1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20b20d20fc6eba99ec389a4ccd36f13bd0d60828b4c7d5f9f1a9a58d4e582061
+size 35053

--- a/wop/menu.pk3dir/menu/buttons/mp_prevs0.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_prevs0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77811308665152d54f671b5c68264a2bfbf9ea3781e56af88cc491434fe30e7
+size 26680

--- a/wop/menu.pk3dir/menu/buttons/mp_prevs1.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_prevs1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:806329b608ea5a48a85c5a3f06fee001c30c99eee3d494e7a53a91de08e6220e
+size 28312

--- a/wop/menu.pk3dir/menu/buttons/mp_stop0.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_stop0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e9c5a5c3df6ce4e66f1113347e94742221d5af0e552001ecb18a901484937c5
+size 20284

--- a/wop/menu.pk3dir/menu/buttons/mp_stop1.png
+++ b/wop/menu.pk3dir/menu/buttons/mp_stop1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f0698e53ebc3ecb1d3fe9f85835cc615e53edae3ab70c7be66b124d7bed4d96
+size 21745


### PR DESCRIPTION
This should add a basic music player to the main menu to enable the user to play the WoP soundtrack directly from the main menu without actually starting a match. It should imitate an old-school disk player where you need to change disks.

- User should be able to cycle through albums back and forth (prev and next album buttons)
- User should be able to cycle through all tracks of an album (prev and next track button)
- User should be able to play the selected track (play button)
- User should be able to stop the playback (stop button)
- User should be able to exit the player (exit button)
- Player should show current album cover and should indicate prev and next album by cover on screen
- Player should show only tracks of the current selected album to scroll through
- Player should play the currently selected track, if the track finishes, it should start the next track
- Player should stop with the last track of the album
- Player should not interfere with the in-game music box player
- Player should not use or edit the playlist of the in-game music box player