### PR TITLE
CGAME: Make lensflare aspect correct in widescreen

### DIFF
--- a/code/cgame/cg_advanced2d.c
+++ b/code/cgame/cg_advanced2d.c
@@ -39,8 +39,8 @@ static void CG_Initrefdef2D(void) {
 	memset(&refdef2D, 0, sizeof(refdef2D));
 	refdef2D.rdflags = RDF_NOWORLDMODEL;
 	// orig (0/0/0)
-	refdef2D.vieworg[0] = SCREEN_WIDTH / 2.0f;
-	refdef2D.vieworg[1] = SCREEN_HEIGHT / 2.0f;
+	refdef2D.vieworg[0] = cgs.glconfig.vidWidth / 2.0f;
+	refdef2D.vieworg[1] = cgs.glconfig.vidHeight / 2.0f;
 	refdef2D.vieworg[2] = 1000.0f;
 	refdef2D.viewaxis[0][0] = 0;
 	refdef2D.viewaxis[0][1] = 0;
@@ -155,6 +155,9 @@ void CG_DrawLine(float x1, float y1, float x2, float y2, float size, vec4_t colo
 	poly.numVerts = 4;
 	poly.hShader = cgs.media.whiteShader;
 
+	CG_AdjustFrom640(&x1, &y1, NULL, NULL);
+	CG_AdjustFrom640(&x2, &y2, NULL, NULL);
+
 	verts[0].modulate[0] = verts[1].modulate[0] = verts[2].modulate[0] = verts[3].modulate[0] = 255 * color[0];
 
 	verts[0].modulate[1] = verts[1].modulate[1] = verts[2].modulate[1] = verts[3].modulate[1] = 255 * color[1];
@@ -214,6 +217,8 @@ void CG_DrawPic2Color(float x, float y, float w, float h, float s1, float t1, fl
 	poly.numVerts = 4;
 	poly.hShader = shader;
 
+	CG_AdjustFrom640(&x, &y, &w, &h);
+
 	verts[0].modulate[0] = verts[3].modulate[0] = 255 * color1[0];
 	verts[1].modulate[0] = verts[2].modulate[0] = 255 * color2[0];
 
@@ -269,6 +274,11 @@ void CG_Draw4VertsPic(float x1, float y1, float x2, float y2, float x3, float y3
 	poly.numVerts = 4;
 	poly.hShader = shader;
 
+	CG_AdjustFrom640(&x1, &y1, NULL, NULL);
+	CG_AdjustFrom640(&x2, &y2, NULL, NULL);
+	CG_AdjustFrom640(&x3, &y3, NULL, NULL);
+	CG_AdjustFrom640(&x4, &y4, NULL, NULL);
+
 	//	Com_Printf("x1=%3.2f, y1=%3.2f, x2=%3.2f, y2=%3.2f\nx3=%3.2f, y3=%3.2f, x4=%3.2f, y4=%3.2f\n", x1, y1, x2, y2,
 	// x3, y3, x4, y4);
 
@@ -323,6 +333,9 @@ static void CG_AddCharToScene(float x, float y, int ch, vec4_t color, vec2_t vec
 	poly.verts = verts;
 	poly.numVerts = 4;
 	poly.hShader = cgs.media.charsetShader;
+
+	CG_AdjustFrom640(&x, &y, &vec_w[0], &vec_h[0]);
+	CG_AdjustFrom640(NULL, NULL, &vec_w[1], &vec_h[1]);
 
 	verts[0].modulate[0] = verts[1].modulate[0] = verts[2].modulate[0] = verts[3].modulate[0] = (byte)(255.0f * color[0]);
 	verts[0].modulate[1] = verts[1].modulate[1] = verts[2].modulate[1] = verts[3].modulate[1] = (byte)(255.0f * color[1]);

--- a/code/cgame/cg_drawtools.c
+++ b/code/cgame/cg_drawtools.c
@@ -85,20 +85,28 @@ See CG_NativeResTo640()
 */
 void CG_AdjustFrom640(float *x, float *y, float *w, float *h) {
 	// scale for screen sizes (aspect correct)
-	*x *= cgs.screenXScale;
-	*w *= cgs.screenXScale;
-	if (cg_horizontalPlacement == PLACE_CENTER) {
-		*x += cgs.screenXBias;
-	} else if (cg_horizontalPlacement == PLACE_RIGHT) {
-		*x += cgs.screenXBias*2;
+	if (x) {
+		*x *= cgs.screenXScale;
+		if (cg_horizontalPlacement == PLACE_CENTER) {
+			*x += cgs.screenXBias;
+		} else if (cg_horizontalPlacement == PLACE_RIGHT) {
+			*x += cgs.screenXBias*2;
+		}
+	}
+	if (w) {
+		*w *= cgs.screenXScale;
 	}
 
-	*y *= cgs.screenYScale;
-	*h *= cgs.screenYScale;
-	if (cg_verticalPlacement == PLACE_CENTER) {
-		*y += cgs.screenYBias;
-	} else if (cg_verticalPlacement == PLACE_BOTTOM) {
-		*y += cgs.screenYBias*2;
+	if (y) {
+		*y *= cgs.screenYScale;
+		if (cg_verticalPlacement == PLACE_CENTER) {
+			*y += cgs.screenYBias;
+		} else if (cg_verticalPlacement == PLACE_BOTTOM) {
+			*y += cgs.screenYBias*2;
+		}
+	}
+	if (h) {
+		*h *= cgs.screenYScale;
 	}
 }
 

--- a/code/cgame/cg_lensflare.c
+++ b/code/cgame/cg_lensflare.c
@@ -564,14 +564,12 @@ static float CG_2DdirOf3D(vec3_t point, vec3_t dir, vec2_t v2, float *distanceSq
 	trace_t tr;
 
 	// x,y of the center ... Width, Height ... all convertet to the 640x480-screen
-	xywh[0] = (float)SCREEN_WIDTH * (float)(cg.refdef.x + cg.refdef.width * 0.5f) / (float)cgs.glconfig.vidWidth;
-	xywh[1] = (float)SCREEN_HEIGHT * (float)(cg.refdef.y + cg.refdef.height * 0.5f) / (float)cgs.glconfig.vidHeight;
-	xywh[2] = (float)SCREEN_WIDTH * (float)cg.refdef.width / (float)cgs.glconfig.vidWidth;
-	xywh[3] = (float)SCREEN_HEIGHT * (float)cg.refdef.height / (float)cgs.glconfig.vidHeight;
+	xywh[0] = cg.refdef.x + cg.refdef.width * 0.5f;
+	xywh[1] = cg.refdef.y + cg.refdef.height * 0.5f;
+	xywh[2] = cg.refdef.width;
+	xywh[3] = cg.refdef.height;
 
-	CG_SetScreenPlacement(PLACE_CENTER, PLACE_CENTER);
 	CG_NativeResTo640(&xywh[0], &xywh[1], &xywh[2], &xywh[3]);
-	CG_PopScreenPlacement();
 
 	// a small hack to mark only dirs (origins have to be between 65535 and -65535)
 	if (point[0] != CG_LENS_DIR_MARKER) {
@@ -894,6 +892,8 @@ void CG_AddLFsToScreen(void) {
 		return;
 	}
 
+	CG_SetScreenPlacement(PLACE_CENTER, PLACE_CENTER);
+
 	if (cg.skylensflare[0] != '\0') {
 		vec3_t tmpv3 = {CG_LENS_DIR_MARKER, 0, 0};
 		vec3_t tmpv32;
@@ -919,7 +919,6 @@ void CG_AddLFsToScreen(void) {
 	}
 
 	// Draw (with 3DTo2D-calc)
-	CG_SetScreenPlacement(PLACE_CENTER, PLACE_CENTER);
 	for (i = 0; i < IFDA_firstempty; i++) {
 		float distanceSquared = 0.0f;
 		vec4_t xywh = {0.0f, 0.0f, 0.0f, 0.0f};
@@ -931,7 +930,6 @@ void CG_AddLFsToScreen(void) {
 		// usually 480 ... except the screen was made smaller
 		CG_DrawLensflare(IFD_Array[i].lensflare, v2, lfalpha, distanceSquared, xywh, qfalse);
 	}
-	CG_PopScreenPlacement();
 
 	// del list
 	memset(IFD_Array, 0, sizeof(IFD_Array));


### PR DESCRIPTION
refdef2D.vieworg was causing CG_DrawPoly() to be 640x480 stretched to screen size and xywh in CG_2DdirOf3D() was scaled to fit it.

Also fix other CG_DrawPoly() usage to call CG_AdjustFrom640() and clean up CG_SetScreenPlacement().

Fixes #239.

The recent work on this made it easier to fix.