### PR TITLE
OpenGL2: Fix sun shadows and parsing q3gl2_sun

### DIFF
--- a/code/renderergl2/tr_shader.c
+++ b/code/renderergl2/tr_shader.c
@@ -1584,12 +1584,17 @@ static qboolean ParseShader(const char **text) {
 				tr.sunShadowScale = atof(token);
 
 				// parse twice, since older shaders may include mapLightScale before sunShadowScale
-				token = COM_ParseExt(text, qfalse);
-				if (token[0])
-					tr.sunShadowScale = atof(token);
+				if (token[0]) {
+					token = COM_ParseExt(text, qfalse);
+					if (token[0]) {
+						tr.sunShadowScale = atof(token);
+					}
+				}
 			}
 
-			SkipRestOfLine(text);
+			if (token[0]) {
+				SkipRestOfLine(text);
+			}
 			continue;
 		}
 		// tonemap parms

--- a/code/renderergl2/tr_shader.c
+++ b/code/renderergl2/tr_shader.c
@@ -2228,7 +2228,8 @@ static int CollapseStagesToGLSL(void) {
 		numStages++;
 	}
 
-	// convert any remaining lightmap stages with blendfunc filter to a lighting pass with a white texture
+	// convert any remaining lightmap stages with no blending or blendfunc filter
+	// to a lighting pass with a white texture
 	// only do this with r_sunlightMode non-zero, as it's only for correct shadows.
 	if (r_sunlightMode->integer && shader.numDeforms == 0) {
 		for (i = 0; i < MAX_SHADER_STAGES; i++) {
@@ -2246,7 +2247,8 @@ static int CollapseStagesToGLSL(void) {
 
 			blendBits = pStage->stateBits & (GLS_DSTBLEND_BITS | GLS_SRCBLEND_BITS);
 
-			if (blendBits != (GLS_DSTBLEND_SRC_COLOR | GLS_SRCBLEND_ZERO) &&
+			if (blendBits != 0 &&
+				blendBits != (GLS_DSTBLEND_SRC_COLOR | GLS_SRCBLEND_ZERO) &&
 				blendBits != (GLS_DSTBLEND_ZERO | GLS_SRCBLEND_DST_COLOR)) {
 				continue;
 			}

--- a/wop/padpack.pk3dir/scripts/wop_padpack-skyboxes.mtr
+++ b/wop/padpack.pk3dir/scripts/wop_padpack-skyboxes.mtr
@@ -10,7 +10,7 @@ textures/pad_shop/nottingham
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	q3map_lightimage textures/pad_shop/brown
-	q3gl2_sun 0.266383 0.274632 0.358662 100 225 50
+	q3gl2_sun 0.266383 0.274632 0.358662 100 225 50 0.5
 	q3map_surfacelight 250
 
 		skyparms env/nottingham1024 - -
@@ -26,7 +26,7 @@ textures/pad_petesky/night-life
 	surfaceparm noimpact
 	surfaceparm nolightmap
 	q3map_lightimage textures/pad_petesky/white02
-	q3gl2_sun 0.47451 0.576471 1.000000 60 350 45
+	q3gl2_sun 0.47451 0.576471 1.000000 60 350 45 0.5
 	q3map_surfacelight 200
 
 		skyparms env/pc-night-life1024 - -

--- a/wop/scripts.pk3dir/scripts/pad_skyboxes.mtr
+++ b/wop/scripts.pk3dir/scripts/pad_skyboxes.mtr
@@ -10,8 +10,7 @@ textures/pad_trash/trash_skybox_night
     surfaceparm noimpact
     surfaceparm nolightmap
     surfaceparm sky
-    q3gl2_sun 0.47451 0.576471 1 55 210 60
-    q3map_surfacelight 0
+    q3gl2_sun 0.47451 0.576471 1 55 210 60 0.5
     skyParms env/pc-friday-13th-512 128 -
 }
 
@@ -22,7 +21,7 @@ textures/pad_trash/trash_skybox_day
     surfaceparm noimpact
     surfaceparm nolightmap
     surfaceparm sky
-    q3gl2_sun 1 1 0.9 100 210 68
+    q3gl2_sun 1 1 0.9 100 210 68 0.5
     q3map_surfacelight 300
     skyParms env/padcity512 128 -
 }

--- a/wop/scripts.pk3dir/scripts/pad_skyboxes.shader
+++ b/wop/scripts.pk3dir/scripts/pad_skyboxes.shader
@@ -11,7 +11,6 @@ textures/pad_trash/trash_skybox_night
     surfaceparm nolightmap
     surfaceparm sky
     q3map_sun 0.47451 0.576471 1 55 210 60
-    q3map_surfacelight 0
     skyParms env/pc-friday-13th-512 128 -
 }
 


### PR DESCRIPTION
Fixes sun shadows not applying to some surfaces (issue introduced in "OpenGL2: Fix q3map2 lightstyles effects" commit d7db0b50d9a648c15b7c981b9e3d3327509e9eef (https://github.com/PadWorld-Entertainment/worldofpadman/pull/243)) and parsing q3gl2_sun.