### PR TITLE
ACCURACY: Adds an accuracy counter to the scoreboard

### DIFF
--- a/code/cgame/cg_local.h
+++ b/code/cgame/cg_local.h
@@ -952,6 +952,7 @@ typedef struct {
 	qhandle_t scoreboardScore;
 	qhandle_t scoreboardTime;
 	qhandle_t scoreboardMedals;
+	qhandle_t scoreboardAccuracy;
 
 	qhandle_t voiceIcon;
 

--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -910,6 +910,7 @@ static void CG_RegisterGraphics(void) {
 	cgs.media.scoreboardScore = trap_R_RegisterShaderNoMip("menu/headers/score");
 	cgs.media.scoreboardTime = trap_R_RegisterShaderNoMip("menu/headers/time");
 	cgs.media.scoreboardMedals = trap_R_RegisterShaderNoMip("menu/headers/medals");
+	cgs.media.scoreboardAccuracy = trap_R_RegisterShaderNoMip("menu/headers/accuracy");
 	cgs.media.voiceIcon = trap_R_RegisterShaderNoMip("icons/hint_voicechat");
 
 	if (cgs.gametype == GT_FREEZETAG) {

--- a/code/cgame/cg_scoreboard.c
+++ b/code/cgame/cg_scoreboard.c
@@ -124,7 +124,8 @@ static void CG_DrawClientScore(int y, const score_t *score, const vec4_t color, 
 	// neutral lolly icon indicating player has the neutral lolly in 1lctl
 	} else if (ci->powerups & (1 << PW_NEUTRALFLAG)) {
 		CG_DrawFlagModel(iconx, icony, iconsize, iconsize, TEAM_FREE);
-	// draw the handicap or bot skill marker unless player has lolly, killerduck, or is frozen)
+	// draw the handicap or bot skill marker unless player has
+	// lolly, cartridge, killer duck, or is frozen)
 	} else {
 		if (ci->botSkill > 0 && ci->botSkill <= 5) {
 			CG_DrawPic(iconx, icony, iconsize, iconsize, cgs.media.botSkillShaders[ci->botSkill - 1]);
@@ -624,6 +625,11 @@ qboolean CG_DrawOldScoreboard(void) {
 	}
 
 	CG_DrawMedals(64.0f, 313.0f, score);
+
+	// draw accuracy rate
+	CG_DrawPic(342.0f, 313.0f, 96.0f, 24.0f, cgs.media.scoreboardAccuracy);
+	Com_sprintf(buf, sizeof(buf), "%i%%", score->accuracy);
+	CG_DrawStringExt(440, 316, buf, colorWhite, qfalse, qtrue, BIGCHAR_WIDTH / 2 , BIGCHAR_HEIGHT, 0);
 
 	// load any models that have been deferred
 	if (++cg.deferredPlayerLoading > 10) {

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -1076,8 +1076,8 @@ void ClientBegin(int clientNum) {
 	CalculateRanks();
 }
 
-void G_LogHit(gentity_t *ent) {
-	gclient_t *client = ent->client;
+void G_LogHit(gentity_t *attacker) {
+	gclient_t *client = attacker->client;
 
 	Com_DPrintf("hit for %s\n", client->pers.netname);
 	client->accuracy_hits++;

--- a/code/game/g_client.c
+++ b/code/game/g_client.c
@@ -1076,6 +1076,13 @@ void ClientBegin(int clientNum) {
 	CalculateRanks();
 }
 
+void G_LogHit(gentity_t *ent) {
+	gclient_t *client = ent->client;
+
+	Com_DPrintf("hit for %s\n", client->pers.netname);
+	client->accuracy_hits++;
+}
+
 /*
 ===========
 ClientSpawn

--- a/code/game/g_combat.c
+++ b/code/game/g_combat.c
@@ -280,7 +280,7 @@ static void CheckAlmostLollyCapture(gentity_t *self, gentity_t *attacker) {
 	char *classname;
 
 	// if this player was carrying a lolly (flag)
-	if (self->client->ps.powerups[PW_REDFLAG] || self->client->ps.powerups[PW_BLUEFLAG] || 
+	if (self->client->ps.powerups[PW_REDFLAG] || self->client->ps.powerups[PW_BLUEFLAG] ||
 		self->client->ps.powerups[PW_NEUTRALFLAG]) {
 		// get the goal flag this player should have been going for
 		if (self->client->sess.sessionTeam == TEAM_BLUE) {

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -697,6 +697,7 @@ void G_Respawn(gentity_t *ent);
 void BeginIntermission(void);
 void InitBodyQue(void);
 void ClientSpawn(gentity_t *ent);
+void G_LogHit(gentity_t *ent);
 void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, int mod);
 void AddScore(gentity_t *ent, const vec3_t origin, int score, const char *reason);
 void CalculateRanks(void);

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -697,7 +697,7 @@ void G_Respawn(gentity_t *ent);
 void BeginIntermission(void);
 void InitBodyQue(void);
 void ClientSpawn(gentity_t *ent);
-void G_LogHit(gentity_t *ent);
+void G_LogHit(gentity_t *attacker);
 void player_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, int mod);
 void AddScore(gentity_t *ent, const vec3_t origin, int score, const char *reason);
 void CalculateRanks(void);

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -708,8 +708,12 @@ void G_RunExplosion(gentity_t *ent) {
 	if (level.time >= ent->pain_debounce_time) {
 		// do damage
 		ent->pain_debounce_time += 100;
-		G_RadiusDamage(ent->r.currentOrigin, ent->parent, 400, frac * ent->splashRadius, NULL,
-					   ent->splashMethodOfDeath);
+		if (G_RadiusDamage(ent->r.currentOrigin, ent->parent, 400, frac * ent->splashRadius, NULL,
+					   ent->splashMethodOfDeath)) {
+			if (ent->parent->client) {
+				G_LogHit(ent->parent);
+			}
+		}
 	}
 }
 

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -95,8 +95,7 @@ static void G_ExplodeMissile(gentity_t *ent) {
 	// splash damage
 	if (ent->splashDamage) {
 		if (G_RadiusDamage(ent->r.currentOrigin, ent->parent, ent->splashDamage, ent->splashRadius, ent,
-						   ent->splashMethodOfDeath) &&
-			ent->parent && ent->parent->client) {
+						   ent->splashMethodOfDeath) && ent->parent && ent->parent->client) {
 			ent->parent->client->accuracy_hits++;
 		}
 	}

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -109,9 +109,8 @@ G_MissileImpact
 ================
 */
 static void G_MissileImpact(gentity_t *ent, trace_t *trace) {
-	gentity_t *other;
 	qboolean hitClient = qfalse;
-	other = &g_entities[trace->entityNum];
+	gentity_t *other = &g_entities[trace->entityNum];
 
 	// check for bounce
 	if (!other->takedamage && (ent->s.eFlags & (EF_BOUNCE | EF_BOUNCE_HALF))) {
@@ -947,6 +946,7 @@ gentity_t *fire_killerducks(gentity_t *self, vec3_t start, vec3_t dir) {
 	bolt->s.eType = ET_MISSILE;
 	bolt->r.svFlags = SVF_USE_CURRENT_ORIGIN;
 	bolt->s.weapon = WP_KILLERDUCKS;
+	// TODO: this looks wrong - it should be self->s.number, as bolt - g_entities is the index of the killerduck missile.
 	bolt->r.ownerNum = bolt - g_entities; // self->s.number;
 	bolt->parent = self;
 	bolt->r.mins[0] = -10.0f;
@@ -964,7 +964,7 @@ gentity_t *fire_killerducks(gentity_t *self, vec3_t start, vec3_t dir) {
 		bolt->takedamage = qfalse;
 	}
 	bolt->die = duck_die;
-	// dmg-vars vielleicht noch missbrauchen ;)
+	// dmg-vars maybe misuse them ;)
 	bolt->damage = DAMAGE_KILLERDUCKS_IMPACT;
 	bolt->splashDamage = SPLASHDMG_KILLERDUCKS;
 	bolt->splashRadius = SPLASHRAD_KILLERDUCKS;
@@ -977,7 +977,7 @@ gentity_t *fire_killerducks(gentity_t *self, vec3_t start, vec3_t dir) {
 	bolt->s.pos.trTime = level.time; // - MISSILE_PRESTEP_TIME;		// move a bit on the very first frame
 									 //	VectorCopy( start, bolt->s.pos.trBase );
 
-	// missbrauch ;)
+	// misuse ;)
 	tr.endpos[0] = start[0] + dir[0] * 32.0f;
 	tr.endpos[1] = start[1] + dir[1] * 32.0f;
 	tr.endpos[2] = start[2] + dir[2] * 32.0f;

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -96,7 +96,7 @@ static void G_ExplodeMissile(gentity_t *ent) {
 	if (ent->splashDamage) {
 		if (G_RadiusDamage(ent->r.currentOrigin, ent->parent, ent->splashDamage, ent->splashRadius, ent,
 						   ent->splashMethodOfDeath) && ent->parent && ent->parent->client) {
-			ent->parent->client->accuracy_hits++;
+			G_LogHit(ent->parent);
 		}
 	}
 
@@ -125,7 +125,7 @@ static void G_MissileImpact(gentity_t *ent, trace_t *trace) {
 			vec3_t velocity;
 
 			if (LogAccuracyHit(other, &g_entities[ent->r.ownerNum])) {
-				g_entities[ent->r.ownerNum].client->accuracy_hits++;
+				G_LogHit(&g_entities[ent->r.ownerNum]);
 				hitClient = qtrue;
 			}
 			BG_EvaluateTrajectoryDelta(&ent->s.pos, level.time, velocity);
@@ -227,7 +227,7 @@ static void G_MissileImpact(gentity_t *ent, trace_t *trace) {
 		if (G_RadiusDamage(trace->endpos, ent->parent, ent->splashDamage, ent->splashRadius, other,
 						   ent->splashMethodOfDeath)) {
 			if (!hitClient) {
-				g_entities[ent->r.ownerNum].client->accuracy_hits++;
+				G_LogHit(&g_entities[ent->r.ownerNum]);
 			}
 		}
 	}

--- a/code/game/g_missile.c
+++ b/code/game/g_missile.c
@@ -624,6 +624,9 @@ void G_RunMissile(gentity_t *ent) {
 			if (other->takedamage && ent->damage) {
 				vec3_t delta;
 				BG_EvaluateTrajectoryDelta(&ent->s.pos, level.time, delta);
+				if (LogAccuracyHit(other, attacker)) {
+					G_LogHit(attacker);
+				}
 				G_Damage(other, ent, attacker, delta, tr.endpos, ent->damage, 0, ent->methodOfDeath);
 
 				if (other->client) {

--- a/code/game/g_weapon.c
+++ b/code/game/g_weapon.c
@@ -143,7 +143,7 @@ static void Weapon_PumperFire(gentity_t *ent) {
 		traceEnt = &g_entities[trace.entityNum];
 		if (traceEnt->takedamage) {
 			if (LogAccuracyHit(traceEnt, ent)) {
-				ent->client->accuracy_hits++;
+				G_LogHit(ent);
 			}
 			damage *= 1.0f - (trace.fraction * 0.5f);
 			G_Damage(traceEnt, ent, ent, forward, trace.endpos, damage, 0, MOD_PUMPER);

--- a/code/game/g_weapon.c
+++ b/code/game/g_weapon.c
@@ -125,7 +125,6 @@ static void Weapon_PumperFire(gentity_t *ent) {
 	gentity_t *tent;
 	gentity_t *traceEnt;
 	int damage;
-	int hits;
 	int passent;
 	vec3_t minPumper = {-4.0f, -4.0f, -4.0f};
 	vec3_t maxPumper = {4.0f, 4.0f, 4.0f};
@@ -135,7 +134,6 @@ static void Weapon_PumperFire(gentity_t *ent) {
 	VectorMA(muzzle, RANGE_PUMPER, forward, end);
 
 	// trace only against the solids, so the railgun will go through people
-	hits = 0;
 	traceEnt = NULL;
 	passent = ent->s.number;
 	trap_Trace(&trace, muzzle, minPumper, maxPumper, end, passent, MASK_SHOT);
@@ -145,7 +143,7 @@ static void Weapon_PumperFire(gentity_t *ent) {
 		traceEnt = &g_entities[trace.entityNum];
 		if (traceEnt->takedamage) {
 			if (LogAccuracyHit(traceEnt, ent)) {
-				hits++;
+				ent->client->accuracy_hits++;
 			}
 			damage *= 1.0f - (trace.fraction * 0.5f);
 			G_Damage(traceEnt, ent, ent, forward, trace.endpos, damage, 0, MOD_PUMPER);

--- a/code/game/g_weapon.c
+++ b/code/game/g_weapon.c
@@ -500,8 +500,10 @@ void G_FireWeapon(gentity_t *ent) {
 		s_quadFactor = 1;
 	}
 
-	// track shots taken for accuracy tracking.  Grapple is not a weapon and gauntet is just not tracked
-	if (ent->s.weapon != WP_GRAPPLING_HOOK && ent->s.weapon != WP_PUNCHY) {
+	// track shots taken for accuracy tracking.
+	// Grapple is not a weapon. Punchy and Spraypistol is just not tracked
+	if (ent->s.weapon != WP_GRAPPLING_HOOK && ent->s.weapon != WP_PUNCHY
+		&& ent->s.weapon != WP_SPRAYPISTOL) {
 		ent->client->accuracy_shots++;
 	}
 

--- a/wop/menu.pk3dir/menu/headers/accuracy.png
+++ b/wop/menu.pk3dir/menu/headers/accuracy.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d62925288f70cd9ad983b7270321b718f08db06acaeeb70a8a1585e27dfb700
+size 8146


### PR DESCRIPTION
The goal is to add an accuracy counter to the scoreboard, as it has been requested by the community. Instead of showing the counter to all players by adding it to the scores, I think it is good enough to only show it locally to the client itself to avoid too much bashing of new and not so experienced players.

- [x] need a header texture: Accuracy
- [x] needs to show score->accuracy as a percentage, so add a %.
- [x] do not track shots and hits for Punchy, Spraypistol and Grapplehook

Weapons where the accuracy count seems to work as expected:
- [x] NiPPER: works fine, the count is correct
- [x] BALLONY: looks good, direct and indirect hits are taken into account
- [x] BETTY: looks good, direct and indirect hits are taken into account
- [x] BUBBLE G: works fine, the count is correct
- [x] SPLASHER: works fine, the count is correct
- [x] iNjECTOR: works fine, the count is correct
- [x] PUMPER: count should be correct after changes
- [x] BOASTER: count should be correct after changes
- [x] iMPERiUS: count should be correct after changes
