### PR TITLE
Fix crash in levelshot command

### DIFF
--- a/code/renderergl1/tr_init.c
+++ b/code/renderergl1/tr_init.c
@@ -483,7 +483,7 @@ sampled down from full screen distorted images
 */
 static void R_LevelShot(screenshotType_e type, const char *ext) {
 	char fileName[MAX_OSPATH];
-	byte *source;
+	byte *source, *allsource;
 	byte *resample, *resamplestart;
 	size_t offset = 0, memcount;
 	int spadlen, rpadlen;
@@ -511,7 +511,8 @@ static void R_LevelShot(screenshotType_e type, const char *ext) {
 
 	Com_sprintf(fileName, sizeof(fileName), "levelshots/%s%s", tr.world->baseName, ext);
 
-	source = RB_ReadPixels(0, 0, glConfig.vidWidth, glConfig.vidHeight, &offset, &spadlen);
+	allsource = RB_ReadPixels(0, 0, glConfig.vidWidth, glConfig.vidHeight, &offset, &spadlen);
+	source = allsource + offset;
 
 	linelen = width * 3;
 	padwidth = spadlen + linelen;
@@ -560,7 +561,7 @@ static void R_LevelShot(screenshotType_e type, const char *ext) {
 		RE_SavePNG(fileName, width, height, resample + offset, rpadlen);
 
 	ri.Hunk_FreeTempMemory(resample);
-	ri.Hunk_FreeTempMemory(source);
+	ri.Hunk_FreeTempMemory(allsource);
 
 	ri.Printf(PRINT_ALL, "Wrote %s\n", fileName);
 }

--- a/code/renderergl1/tr_init.c
+++ b/code/renderergl1/tr_init.c
@@ -488,7 +488,7 @@ static void R_LevelShot(screenshotType_e type, const char *ext) {
 	size_t offset = 0, memcount;
 	int spadlen, rpadlen;
 	int padwidth, linelen;
-	GLint packAlign = 0;
+	GLint packAlign = 1;
 	byte *src, *dst;
 	int x, y;
 	int r, g, b;

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -572,7 +572,7 @@ the menu system, sampled down from full screen distorted images
 */
 static void R_LevelShot(screenshotType_e type, const char *ext) {
 	char fileName[MAX_OSPATH];
-	byte *source;
+	byte *source, *allsource;
 	byte *resample, *resamplestart;
 	size_t offset = 0, memcount;
 	int spadlen, rpadlen;
@@ -600,7 +600,8 @@ static void R_LevelShot(screenshotType_e type, const char *ext) {
 
 	Com_sprintf(fileName, sizeof(fileName), "levelshots/%s%s", tr.world->baseName, ext);
 
-	source = RB_ReadPixels(0, 0, glConfig.vidWidth, glConfig.vidHeight, &offset, &spadlen);
+	allsource = RB_ReadPixels(0, 0, glConfig.vidWidth, glConfig.vidHeight, &offset, &spadlen);
+	source = allsource + offset;
 
 	linelen = width * 3;
 	padwidth = spadlen + linelen;
@@ -650,7 +651,7 @@ static void R_LevelShot(screenshotType_e type, const char *ext) {
 		RE_SavePNG(fileName, width, height, resample + offset, rpadlen);
 
 	ri.Hunk_FreeTempMemory(resample);
-	ri.Hunk_FreeTempMemory(source);
+	ri.Hunk_FreeTempMemory(allsource);
 
 	ri.Printf(PRINT_ALL, "Wrote %s\n", fileName);
 }

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -577,7 +577,7 @@ static void R_LevelShot(screenshotType_e type, const char *ext) {
 	size_t offset = 0, memcount;
 	int spadlen, rpadlen;
 	int padwidth, linelen;
-	GLint packAlign = 0;
+	GLint packAlign = 1;
 	byte *src, *dst;
 	int x, y;
 	int r, g, b;

--- a/code/renderergl2/tr_init.c
+++ b/code/renderergl2/tr_init.c
@@ -573,11 +573,10 @@ the menu system, sampled down from full screen distorted images
 static void R_LevelShot(screenshotType_e type, const char *ext) {
 	char fileName[MAX_OSPATH];
 	byte *source, *allsource;
-	byte *resample, *resamplestart;
+	byte *resample;
 	size_t offset = 0, memcount;
-	int spadlen, rpadlen;
-	int padwidth, linelen;
-	GLint packAlign = 1;
+	int spadlen;
+	int linelen;
 	byte *src, *dst;
 	int x, y;
 	int r, g, b;
@@ -604,15 +603,9 @@ static void R_LevelShot(screenshotType_e type, const char *ext) {
 	source = allsource + offset;
 
 	linelen = width * 3;
-	padwidth = spadlen + linelen;
+	memcount = linelen * height;
 
-	// Allocate a few more bytes so that we can choose an alignment we like
-	resample = ri.Hunk_AllocateTempMemory(padwidth * height + offset + packAlign - 1);
-
-	resamplestart = PADP((intptr_t) resample + offset, packAlign);
-
-	offset = resamplestart - resample;
-	rpadlen = padwidth - linelen;
+	resample = ri.Hunk_AllocateTempMemory(memcount);
 
 	// resample from source
 	xScale = glConfig.vidWidth / (float)(width * 4.0f);
@@ -636,19 +629,17 @@ static void R_LevelShot(screenshotType_e type, const char *ext) {
 		}
 	}
 
-	memcount = (width * 3 + rpadlen) * height;
-
 	// gamma correction
 	if (glConfig.deviceSupportsGamma) {
-		R_GammaCorrect(resample + offset, memcount);
+		R_GammaCorrect(resample, memcount);
 	}
 
 	if (type == ST_TGA)
-		RE_SaveTGA(fileName, width, height, resample + offset, rpadlen);
+		RE_SaveTGA(fileName, width, height, resample, 0);
 	else if (type == ST_JPEG)
-		RE_SaveJPG(fileName, r_screenshotJpegQuality->integer, width, height, resample + offset, rpadlen);
+		RE_SaveJPG(fileName, r_screenshotJpegQuality->integer, width, height, resample, 0);
 	else if (type == ST_PNG)
-		RE_SavePNG(fileName, width, height, resample + offset, rpadlen);
+		RE_SavePNG(fileName, width, height, resample, 0);
 
 	ri.Hunk_FreeTempMemory(resample);
 	ri.Hunk_FreeTempMemory(allsource);


### PR DESCRIPTION
This fixes the game crashing in opengl1 and OpenGL2 renderers when running the `levelshot` command. It also fixes incorrect usage of memory alignment handling for source and resample buffers from [my ioq3 PR](https://github.com/ioquake/ioq3/pull/262) this is based on.

Fixes #256.