### PR TITLE
OPENGL2: my nvidia driver 525.147.05 return GL_NO_ERROR here

### DIFF
--- a/code/renderergl2/tr_fbo.c
+++ b/code/renderergl2/tr_fbo.c
@@ -33,7 +33,7 @@ R_CheckFBO
 static qboolean R_CheckFBO(const FBO_t *fbo) {
 	GLenum code = qglCheckNamedFramebufferStatusEXT(fbo->frameBuffer, GL_FRAMEBUFFER);
 
-	if (code == GL_FRAMEBUFFER_COMPLETE)
+	if (code == GL_FRAMEBUFFER_COMPLETE || code == GL_NO_ERROR)
 		return qtrue;
 
 	// an error occurred


### PR DESCRIPTION
according to the docs this is not expected: https://docs.gl/gl3/glCheckFramebufferStatus