### PR TITLE
Increase default `cl_maxpackets` to 125

### DIFF
--- a/code/client/cl_main.c
+++ b/code/client/cl_main.c
@@ -3311,7 +3311,7 @@ void CL_Init(void) {
 	cl_pitchspeed = Cvar_Get("cl_pitchspeed", "140", CVAR_ARCHIVE);
 	cl_anglespeedkey = Cvar_Get("cl_anglespeedkey", "1.5", 0);
 
-	cl_maxpackets = Cvar_Get("cl_maxpackets", "30", CVAR_ARCHIVE);
+	cl_maxpackets = Cvar_Get("cl_maxpackets", "125", CVAR_ARCHIVE);
 	cl_packetdup = Cvar_Get("cl_packetdup", "1", CVAR_ARCHIVE);
 
 	cl_run = Cvar_Get("cl_run", "1", CVAR_ARCHIVE);


### PR DESCRIPTION
This decreases latency if FPS is greater than or equal to 30 (since the previous default for `cl_maxpackets` was `30`), and allows for more consistent input handling.

`com_maxfps` already defaults to 125, so it's a 1:1 match if your PC can render 125 FPS.

I've been using this configuration for years now and it works just fine, even on an average ADSL connection (before I had fiber).

- See also https://github.com/ec-/Quake3e/pull/299.
