### PR TITLE
Improve third-person mode usability

### DIFF
--- a/code/cgame/cg_draw.c
+++ b/code/cgame/cg_draw.c
@@ -1671,10 +1671,6 @@ static void CG_DrawCrosshair(void) {
 		return;
 	}
 
-	if (cg.renderingThirdPerson) {
-		return;
-	}
-
 	if (cg.wantSelectLogo) {
 		return;
 	}

--- a/code/cgame/cg_view.c
+++ b/code/cgame/cg_view.c
@@ -237,9 +237,6 @@ static void CG_OffsetThirdPersonView(void) {
 		cg.refdefViewAngles[YAW] = cg.predictedPlayerState.stats[STAT_DEAD_YAW];
 	}
 
-	if (focusAngles[PITCH] > 45) {
-		focusAngles[PITCH] = 45; // don't go too far overhead
-	}
 	AngleVectors(focusAngles, forward, NULL, NULL);
 
 	VectorMA(cg.refdef.vieworg, FOCUS_DISTANCE, forward, focusPoint);
@@ -247,8 +244,6 @@ static void CG_OffsetThirdPersonView(void) {
 	VectorCopy(cg.refdef.vieworg, view);
 
 	view[2] += 8;
-
-	cg.refdefViewAngles[PITCH] *= 0.5;
 
 	AngleVectors(cg.refdefViewAngles, forward, right, up);
 


### PR DESCRIPTION
- Don't clamp and divide pitch angle. This was vanilla Quake 3 behavior that other games rarely ever replicate.
- Draw crosshair while in third person mode.

This makes third-person mode much closer to games like Xonotic in terms of implementation.

If we want to improve usability further (so you have more chances to actually see what you're aiming at when aiming straight ahead), we can also increase the vertical offset which is defined here:

https://github.com/PadWorld-Entertainment/worldofpadman/blob/72de7efba80b8277141315b7b574f81d000fcffd/code/cgame/cg_view.c#L249

and here:

https://github.com/PadWorld-Entertainment/worldofpadman/blob/72de7efba80b8277141315b7b574f81d000fcffd/code/cgame/cg_view.c#L277

I use a value of 16 in Xonotic and it works quite well, although games like Serious Sam are closer to something between 24 and 32.

- This closes https://github.com/PadWorld-Entertainment/worldofpadman/issues/9.

cc @simse15

## Preview

https://github.com/user-attachments/assets/6c704ed5-0529-4194-a30b-bbc12fe02977