### PR TITLE
Increase default `r_conscale` to 2

### DIFF
--- a/code/client/cl_console.c
+++ b/code/client/cl_console.c
@@ -366,7 +366,7 @@ void Con_Init(void) {
 	con_notifytime = Cvar_Get("con_notifytime", "-4", 0);
 	con_conspeed = Cvar_Get("scr_conspeed", "3", 0);
 	con_autoclear = Cvar_Get("con_autoclear", "1", CVAR_ARCHIVE);
-	con_scale = Cvar_Get("con_scale", "1", CVAR_ARCHIVE);
+	con_scale = Cvar_Get("con_scale", "2", CVAR_ARCHIVE);
 	Cvar_CheckRange(con_scale, 1, 4, qfalse);
 
 	fontSize.w = SMALLCHAR_WIDTH * con_scale->value;


### PR DESCRIPTION
This makes console text more readable out of the box, especially on displays above 1080p.

- This closes https://github.com/PadWorld-Entertainment/worldofpadman/issues/296.

## Preview (on 4K display)

### Before

![image](https://github.com/user-attachments/assets/f2254a09-8178-4bd8-9042-e5ea4c5cf2ee)

### After

![image](https://github.com/user-attachments/assets/dce23adc-2e38-4ee7-8b78-b05b768cc1d5)