### PR TITLE
Holololly

### DIFF
--- a/code/cgame/cg_main.c
+++ b/code/cgame/cg_main.c
@@ -1033,8 +1033,6 @@ static void CG_RegisterGraphics(void) {
 		if (cgs.gametype == GT_CTF || cgs.gametype == GT_1FCTF || cg_buildScript.integer) {
 			cgs.media.hud_CTL_bg_red = trap_R_RegisterShaderNoMip("hud/CTL_red");
 			cgs.media.hud_CTL_bg_blue = trap_R_RegisterShaderNoMip("hud/CTL_blue");
-			cgs.media.redFlagModel = trap_R_RegisterModel("models/ctl/lollipop_red");
-			cgs.media.blueFlagModel = trap_R_RegisterModel("models/ctl/lollipop_blue");
 			cgs.media.redFlagShader[0] = trap_R_RegisterShaderNoMip("icons/hud_lolly_red1");
 			cgs.media.blueFlagShader[0] = trap_R_RegisterShaderNoMip("icons/hud_lolly_blue1");
 			// BamBam assets
@@ -1052,6 +1050,8 @@ static void CG_RegisterGraphics(void) {
 		}
 
 		if (cgs.gametype == GT_CTF || cg_buildScript.integer) {
+			cgs.media.redFlagModel = trap_R_RegisterModel("models/ctl/lollipop_red");
+			cgs.media.blueFlagModel = trap_R_RegisterModel("models/ctl/lollipop_blue");
 			cgs.media.redFlagShader[1] = trap_R_RegisterShaderNoMip("icons/hud_lolly_red2");
 			cgs.media.redFlagShader[2] = trap_R_RegisterShaderNoMip("icons/hud_lolly_red3");
 			cgs.media.blueFlagShader[1] = trap_R_RegisterShaderNoMip("icons/hud_lolly_blue2");
@@ -1059,6 +1059,8 @@ static void CG_RegisterGraphics(void) {
 		}
 
 		if (cgs.gametype == GT_1FCTF || cg_buildScript.integer) {
+			cgs.media.redFlagModel = trap_R_RegisterModel("models/ctl/lollipop_red_holo");
+			cgs.media.blueFlagModel = trap_R_RegisterModel("models/ctl/lollipop_blue_holo");
 			cgs.media.neutralFlagModel = trap_R_RegisterModel("models/ctl/lollipop_neutral");
 			cgs.media.neutralflagShader[0] = trap_R_RegisterShaderNoMip("icons/hud_lolly_neutral1");
 			cgs.media.neutralflagShader[1] = trap_R_RegisterShaderNoMip("icons/hud_lolly_neutral2");

--- a/code/cgame/cg_weapons.c
+++ b/code/cgame/cg_weapons.c
@@ -625,6 +625,7 @@ The server says this item is used on this level
 void CG_RegisterItemVisuals(int itemNum) {
 	itemInfo_t *itemInfo;
 	const gitem_t *item;
+	const char *model;
 
 	if (itemNum < 0 || itemNum >= bg_numItems) {
 		CG_Error("CG_RegisterItemVisuals: itemNum %d out of range [0-%d]", itemNum, bg_numItems - 1);
@@ -640,7 +641,15 @@ void CG_RegisterItemVisuals(int itemNum) {
 	memset(itemInfo, 0, sizeof(*itemInfo));
 	itemInfo->registered = qtrue;
 
-	itemInfo->models[0] = trap_R_RegisterModel(item->world_model[0]);
+	model = item->world_model[0];
+	if (cgs.gametype == GT_1FCTF && item->giType == IT_TEAM) {
+		if (item->giTag == PW_REDFLAG) {
+			model = "models/ctl/lollipop_red_holo";
+		} else if (item->giTag == PW_BLUEFLAG) {
+			model = "models/ctl/lollipop_blue_holo";
+		}
+	}
+	itemInfo->models[0] = trap_R_RegisterModel(model);
 
 	itemInfo->icon = trap_R_RegisterShader(item->icon);
 

--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -689,18 +689,6 @@ void FinishSpawningItem(gentity_t *ent) {
 
 	ent->s.eType = ET_ITEM;
 	ent->s.modelindex = ent->item - bg_itemlist; // store item number in modelindex
-
-	// we use modified lolly assets in 1LC
-	if (g_gametype.integer == GT_1FCTF) {
-		if (ent->item->giType == IT_TEAM) {
-			if (ent->item->giTag == PW_REDFLAG) {
-				ent->s.modelindex = G_ModelIndex("models/ctl/lollipop_red_holo");
-			} else if (ent->item->giTag == PW_BLUEFLAG) {
-				ent->s.modelindex = G_ModelIndex("models/ctl/lollipop_blue_holo");
-			}
-		}
-	}
-
 	ent->s.modelindex2 = 0;						 // zero indicates this isn't a dropped item
 	ent->r.contents = CONTENTS_TRIGGER;
 	ent->touch = Touch_Item;

--- a/code/game/g_items.c
+++ b/code/game/g_items.c
@@ -689,8 +689,19 @@ void FinishSpawningItem(gentity_t *ent) {
 
 	ent->s.eType = ET_ITEM;
 	ent->s.modelindex = ent->item - bg_itemlist; // store item number in modelindex
-	ent->s.modelindex2 = 0;						 // zero indicates this isn't a dropped item
 
+	// we use modified lolly assets in 1LC
+	if (g_gametype.integer == GT_1FCTF) {
+		if (ent->item->giType == IT_TEAM) {
+			if (ent->item->giTag == PW_REDFLAG) {
+				ent->s.modelindex = G_ModelIndex("models/ctl/lollipop_red_holo");
+			} else if (ent->item->giTag == PW_BLUEFLAG) {
+				ent->s.modelindex = G_ModelIndex("models/ctl/lollipop_blue_holo");
+			}
+		}
+	}
+
+	ent->s.modelindex2 = 0;						 // zero indicates this isn't a dropped item
 	ent->r.contents = CONTENTS_TRIGGER;
 	ent->touch = Touch_Item;
 	// using an item causes it to respawn

--- a/wop/models.pk3dir/models/ctl/b_holo_glow.png
+++ b/wop/models.pk3dir/models/ctl/b_holo_glow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b712ccade598e9ee9de558451a018b146d89254a5d7b88e285c32d1ed48d4163
+size 3065

--- a/wop/models.pk3dir/models/ctl/b_holo_lollipop.png
+++ b/wop/models.pk3dir/models/ctl/b_holo_lollipop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94bde241403afd73a0e5d4bfc0778722ecf74450422453a8d16b4e73c25b64f2
+size 59804

--- a/wop/models.pk3dir/models/ctl/holo_interlace.png
+++ b/wop/models.pk3dir/models/ctl/holo_interlace.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b48cdd8a3c16196d53633e27b932a09010e77e91f8cdb5afa69b1131e4532511
+size 3361

--- a/wop/models.pk3dir/models/ctl/lollipop_blue_holo.md3
+++ b/wop/models.pk3dir/models/ctl/lollipop_blue_holo.md3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46d8087cad50ad98756c18a97ab14e6b3f2668b88cfe2ce24a2bec98133a1a3c
+size 8844

--- a/wop/models.pk3dir/models/ctl/lollipop_red_holo.md3
+++ b/wop/models.pk3dir/models/ctl/lollipop_red_holo.md3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f562b4aaaa16951dca367e3387f7d86030a7e6d0a6e2f3be8e6a1ae8c4e507ef
+size 8844

--- a/wop/models.pk3dir/models/ctl/r_holo_glow.png
+++ b/wop/models.pk3dir/models/ctl/r_holo_glow.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1c77827b2b63c3c7adabea50f20c379a34e5d0ead373c2266d72fa8142a34d4
+size 3061

--- a/wop/models.pk3dir/models/ctl/r_holo_lollipop.png
+++ b/wop/models.pk3dir/models/ctl/r_holo_lollipop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea2809841b1d517695580e1f65a1bd11c5308bc697b32ef0049008b531030556
+size 58590

--- a/wop/scripts.pk3dir/scripts/wop_gamemodels.shader
+++ b/wop/scripts.pk3dir/scripts/wop_gamemodels.shader
@@ -134,10 +134,9 @@ station/ring
 
 
 // =================
-// LOLLYPOP
+// LOLLIPOP
 // =================
 
-//shaders by doomdragon for WoP capture the lollipop gamemode
 models/ctl/foil
 {
 	cull disable
@@ -256,7 +255,147 @@ models/ctl/n_sticker_ribbon
 }
 
 // =================
-// BiGBALLOON
+// LOLLIPOP HOLO
+// =================
+
+models/ctl/r_lollipop_holo
+{
+	{
+		map models/ctl/holo_interlace.png
+		blendFunc GL_ZERO GL_ONE
+		alphaFunc GE128
+		tcgen vector ( 0 0.04 0 ) ( 0 0 -.04 0)
+		tcMod scroll 0 -0.2
+		depthWrite
+	}
+	{
+		map models/ctl/r_holo_lollipop.png
+		blendfunc add
+		rgbGen identity
+		depthFunc equal
+	}
+	{
+		map models/ctl/r_holo_glow.png
+		blendFunc add
+		tcgen vector ( 0 0.01 0 ) ( 0 0 -.01 0)
+		tcMod scroll 0 -0.4
+		depthFunc equal
+	}
+}
+
+models/ctl/r_ribbon_holo
+{
+	cull none
+	{
+		map models/ctl/holo_interlace.png
+		blendFunc GL_ZERO GL_ONE
+		alphaFunc GE128
+		tcgen vector ( 0 0.04 0 ) ( 0 0 -.04 0)
+		tcMod scroll 0 -0.2
+		depthWrite
+	}
+	{
+		map models/ctl/r_holo_lollipop.png
+		blendfunc add
+		rgbGen identity
+		depthFunc equal
+	}
+	{
+		map models/ctl/r_holo_glow.png
+		blendFunc add
+		tcgen vector ( 0 0.01 0 ) ( 0 0 -.01 0)
+		tcMod scroll 0 -0.4
+		depthFunc equal
+	}
+}
+
+models/ctl/r_label_holo
+{
+	{
+		map models/ctl/holo_interlace.png
+		blendFunc GL_ZERO GL_ONE
+		alphaFunc GE128
+		tcgen vector ( 0 0.04 0 ) ( 0 0 -.04 0)
+		tcMod scroll 0 -0.2
+		depthWrite
+	}
+	{
+		map models/ctl/r_holo_lollipop.png
+		blendfunc add
+		depthFunc equal
+	}
+}
+
+models/ctl/b_lollipop_holo
+{
+	{
+		map models/ctl/holo_interlace.png
+		blendFunc GL_ZERO GL_ONE
+		alphaFunc GE128
+		tcgen vector ( 0 0.04 0 ) ( 0 0 -.04 0)
+		tcMod scroll 0 -0.2
+		depthWrite
+	}
+	{
+		map models/ctl/b_holo_lollipop.png
+		blendfunc add
+		rgbGen identity
+		depthFunc equal
+	}
+	{
+		map models/ctl/b_holo_glow.png
+		blendFunc add
+		tcgen vector ( 0 0.01 0 ) ( 0 0 -.01 0)
+		tcMod scroll 0 -0.4
+		depthFunc equal
+	}
+}
+
+models/ctl/b_ribbon_holo
+{
+	cull none
+	{
+		map models/ctl/holo_interlace.png
+		blendFunc GL_ZERO GL_ONE
+		alphaFunc GE128
+		tcgen vector ( 0 0.04 0 ) ( 0 0 -.04 0)
+		tcMod scroll 0 -0.2
+		depthWrite
+	}
+	{
+		map models/ctl/b_holo_lollipop.png
+		blendfunc add
+		rgbGen identity
+		depthFunc equal
+	}
+	{
+		map models/ctl/b_holo_glow.png
+		blendFunc add
+		tcgen vector ( 0 0.01 0 ) ( 0 0 -.01 0)
+		tcMod scroll 0 -0.4
+		depthFunc equal
+	}
+}
+
+models/ctl/b_label_holo
+{
+	{
+		map models/ctl/holo_interlace.png
+		blendFunc GL_ZERO GL_ONE
+		alphaFunc GE128
+		tcgen vector ( 0 0.04 0 ) ( 0 0 -.04 0)
+		tcMod scroll 0 -0.2
+		depthWrite
+	}
+	{
+		map models/ctl/b_holo_lollipop.png
+		blendfunc add
+		depthFunc equal
+	}
+}
+
+// =================
+// BiG BALLOON
 // =================
 
 models/special/ballon


### PR DESCRIPTION
Usually in CTL, the goal is to capture the enemy lolly and bring it back to your base. In 1LC, the concept changes to capture a neutral lolly in the center of the map and bring it to the enemy base, where the enemy lolly is usually located. In 1LC, the lolly models at the bases cannot be captured. They just mark the position where you have to bring the neutral lolly to score points. To avoid confusion and to distinguish the 1LC game type from CTL, we want to change the appearance of the red and blue lollipops in 1LC. They should appear as non-material holographic lollipops to indicate that they cannot be picked up by the player. So the goal is to replace the default red or blue lollipop models with the new red or blue holo models.

Corresponding item models are defined in bg_itemlist in bg_misc.c. The goal is to change the default model path only in 1LC from

- models/ctl/lollipop_red --> models/ctl/lollipop_red_holo
- models/ctl/lollipop_blue --> models/ctl/lollipop_blue_holo

So the idea is to change the model path on item spawn. As far as I can see, game and cgame get the model path from the item list, so there is no need to load the holo lolly assets in cg_main.c, but I could be wrong. Also, the model paths should remain untouched in CTL game mode.

Useful commands:
- sv_pure 0
- developer 1
- g_gametype 9
- devmap wop_westernsetCTL
- setviewpos -380 729 514 8 6 --> to see the red lolly
- setviewpos -1175 -4963 547 18 -177 --> to see the blue lolly
