### PR TITLE
Rename LCC constexpr function to constantexpr

### DIFF
--- a/code/tools/lcc/src/c.h
+++ b/code/tools/lcc/src/c.h
@@ -529,7 +529,7 @@ extern int process(char *);
 extern int findfunc(char *, char *);
 extern int findcount(char *, int, int);
 
-extern Tree constexpr(int);
+extern Tree constantexpr(int);
 extern int intexpr(int, int);
 extern Tree simplify(int, Type, Tree, Tree);
 extern int ispow2(unsigned long u);

--- a/code/tools/lcc/src/init.c
+++ b/code/tools/lcc/src/init.c
@@ -190,7 +190,7 @@ static int initstruct(int len, Type ty, int lev) {
 	return n;
 }
 
-/* initializer - constexpr | { constexpr ( , constexpr )* [ , ] } */
+/* initializer - constantexpr | { constantexpr ( , constantexpr )* [ , ] } */
 Type initializer(Type ty, int lev) {
 	int n = 0;
 	Tree e;

--- a/code/tools/lcc/src/simp.c
+++ b/code/tools/lcc/src/simp.c
@@ -167,7 +167,7 @@ static int subi(long x, long y, long min, long max, int needconst) {
 static int subd(double x, double y, double min, double max, int needconst) {
 	return addd(x, -y, min, max, needconst);
 }
-Tree constexpr(int tok) {
+Tree constantexpr(int tok) {
 	Tree p;
 
 	needconst++;
@@ -177,7 +177,7 @@ Tree constexpr(int tok) {
 }
 
 int intexpr(int tok, int n) {
-	Tree p = constexpr(tok);
+	Tree p = constantexpr(tok);
 
 	needconst++;
 	if (p->op == CNST + I || p->op == CNST + U)

--- a/code/tools/lcc/src/stmt.c
+++ b/code/tools/lcc/src/stmt.c
@@ -128,7 +128,7 @@ void statement(int loop, Swtch swp, int lev) {
 			static char stop[] = {IF, ID, 0};
 			Tree p;
 			t = gettok();
-			p = constexpr(0);
+			p = constantexpr(0);
 			if (generic(p->op) == CNST && isint(p->type)) {
 				if (swp) {
 					needconst++;


### PR DESCRIPTION
To avoid C23 keyword conflict which is now the default std in GCC15 that cause error:

```
/home/tle/Work/worldofpadman/code/tools/lcc/src/c.h:532:1: error: ‘constexpr’ used with ‘extern’
  532 | extern Tree constexpr(int);
      | ^~~~~~
/home/tle/Work/worldofpadman/code/tools/lcc/src/c.h:532:23: error: expected identifier or ‘(’ before ‘int’
  532 | extern Tree constexpr(int);
```
