### PR TITLE
Support Linux PowerPC64 LE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ option(USE_CURL_DLOPEN "" ON)
 option(USE_VOIP "" ON)
 option(USE_MUMBLE "" ON)
 
+if (UNIX)
+	add_compile_definitions(ARCH_STRING="${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
 if (MSVC)
 	set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -34,8 +34,12 @@ set(QCOMMON_VM_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/qcommon/vm.c
 	${CMAKE_CURRENT_SOURCE_DIR}/qcommon/vm_interpreted.c
 	${CMAKE_CURRENT_SOURCE_DIR}/qcommon/vm_local.h
-	${CMAKE_CURRENT_SOURCE_DIR}/qcommon/vm_x86.c
 )
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^x86")
+	list(APPEND QCOMMON_VM_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/qcommon/vm_x86.c)
+else()
+	list(APPEND QCOMMON_VM_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/qcommon/vm_none.c)
+endif()
 
 find_program(GDB_EXECUTABLE gdb)
 find_program(LLDB_EXECUTABLE lldb)
@@ -84,6 +88,9 @@ function(wop_add_library)
 	endif()
 	if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
 		set(ARCH "arm64")
+	endif()
+	if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+		set(ARCH "ppc64le")
 	endif()
 
 	set(OUTPUTNAME "${_LIB_TARGET}_${ARCH}")
@@ -151,6 +158,9 @@ function(wop_add_executable)
 	endif()
 	if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm64|aarch64)$")
 		set(ARCH "arm64")
+	endif()
+	if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
+		set(ARCH "ppc64le")
 	endif()
 
 	set(OUTPUTNAME "${_EXE_TARGET}.${ARCH}")
@@ -349,6 +359,7 @@ function(add_asm TARGET)
 		endforeach()
 		target_sources(${TARGET} PRIVATE ${ASM_SRCS})
 	elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "arm64")
+	elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
 	else()
 		target_sources(${TARGET} PRIVATE ${CODE_DIR}/asm/snapvector.c ${CODE_DIR}/asm/ftola.c)
 		set_source_files_properties(${CODE_DIR}/asm/snapvector.c PROPERTIES COMPILE_FLAGS -march=k8)

--- a/code/client/CMakeLists.txt
+++ b/code/client/CMakeLists.txt
@@ -47,7 +47,6 @@ set(SRCS
 	../qcommon/puff.c
 	../qcommon/vm.c
 	../qcommon/vm_interpreted.c
-	../qcommon/vm_x86.c
 	../server/sv_bot.c
 	../server/sv_ccmds.c
 	../server/sv_client.c
@@ -64,6 +63,12 @@ set(SRCS
 	../sys/con_log.c
 	../sys/sys_main.c
 )
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^x86")
+	list(APPEND SRCS ../qcommon/vm_x86.c)
+else()
+	list(APPEND SRCS ../qcommon/vm_none.c)
+endif()
 
 if (WIN32)
 	list(APPEND SRCS ../sys/sys_win32.c)

--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -189,13 +189,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define PATH_SEP '/'
 
 #if !defined(ARCH_STRING)
-#if INTPTR_MAX == INT64_MAX
-#define ARCH_STRING "x86_64"
-#elif INTPTR_MAX == INT32_MAX
-#define ARCH_STRING "x86"
-#else
 #error ARCH_STRING should be defined by the Makefile
-#endif
 #endif
 
 #if defined __x86_64__
@@ -207,6 +201,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define Q3_BIG_ENDIAN
 #else
 #define Q3_LITTLE_ENDIAN
+#endif
+
+#if defined(__powerpc64__)
+#ifndef NO_VM_COMPILED
+#define NO_VM_COMPILED
+#endif
 #endif
 
 #define DLL_EXT ".so"


### PR DESCRIPTION
![Screenshot From 2025-03-25 01-40-11](https://github.com/user-attachments/assets/6067580e-2e84-4427-a484-ccdaa80e460a)

## Changes

* Use interpreter if the architecture does not support JIT VM
* Allow linux-ppc64le as compilation target

## Notes

No JIT VM so the performance will surely suffers a bit, on avg 40fps
