### PR TITLE
Load external entities from disk

### DIFF
--- a/code/game/CMakeLists.txt
+++ b/code/game/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRCS
 	ai_main.c
 	ai_team.c
 	ai_vcmd.c
+	be_alloc.c
 	bg_misc.c
 	bg_pmove.c
 	bg_slidemove.c

--- a/code/game/be_alloc.c
+++ b/code/game/be_alloc.c
@@ -1,0 +1,162 @@
+/*
+===========================================================================
+Copyright (C) 2010, 2011, 2012 the-brain
+
+This program is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+This program is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.	If not, see <http://gnu.org/licenses/>.
+===========================================================================
+*/
+
+#include "g_local.h"
+
+/* Any unlikely to be used value */
+#define FREEMEMCOOKIE ((int)0xDEADBE3F)
+
+typedef struct freeMemNode_s {
+	/* Size of ROUNDBITS */
+	/* Size includes node (obviously) */
+	int cookie, size;
+	struct freeMemNode_s *prev, *next;
+} freeMemNode_t;
+
+/* 512K ought to be enough for anybody */
+#define POOL_SIZE (2048 * 1024)
+static char memory_pool[POOL_SIZE];
+#undef POOL_SIZE
+static freeMemNode_t *freeHead;
+static int freeMem;
+
+/*
+	Find a free block and allocate.
+	Does two passes, attempts to fill same-sized free slot first.
+*/
+
+/* Round to 32 bytes */
+#define ROUNDBITS 31u
+
+void *BE_Alloc(unsigned int size) {
+	freeMemNode_t *fmn, *prev, *next, *smallest;
+	unsigned int allocSize, smallestSize;
+	char *endptr;
+	int *ptr;
+
+	/* Round to 32-byte boundary */
+	allocSize = ((size + sizeof(int) + ROUNDBITS) & ~ROUNDBITS);
+	ptr = NULL;
+
+	smallest = NULL;
+	/* Guaranteed not to miss any slots :) */
+	smallestSize = (sizeof(memory_pool) + 1);
+	for (fmn = freeHead; fmn; fmn = fmn->next) {
+		if (fmn->cookie != FREEMEMCOOKIE) {
+			G_Error("BE_Alloc: Memory corruption detected!\n");
+		}
+
+		if (fmn->size >= allocSize) {
+			/* We've got a block */
+			if (fmn->size == allocSize) {
+				/* Same size, just remove */
+				prev = fmn->prev;
+				next = fmn->next;
+				if (prev) {
+					prev->next = next;
+				}
+				if (next) {
+					next->prev = prev;
+				}
+				if (fmn == freeHead) {
+					freeHead = next;
+				}
+				ptr = (int *)fmn;
+				/* Stop the loop, this is fine */
+				break;
+			} else {
+				/* Keep track of the smallest free slot */
+				if (fmn->size < smallestSize) {
+					smallest = fmn;
+					smallestSize = fmn->size;
+				}
+			}
+		}
+	}
+
+	if (!ptr && smallest) {
+		/* We found a slot big enough */
+		smallest->size -= allocSize;
+		endptr = ((char *)smallest + smallest->size);
+		ptr = (int *)endptr;
+	}
+
+	if (ptr) {
+		freeMem -= allocSize;
+		/* TODO: Move this into BE_CAlloc()? */
+		memset(ptr, 0, allocSize);
+		/* Store a copy of size for deallocation */
+		*ptr++ = allocSize;
+		return (void *)ptr;
+	}
+
+	G_Error("BE_Alloc: failed on allocation of %i bytes\n", size);
+	return NULL;
+}
+
+#undef ROUNDBITS
+
+/*
+	Release allocated memory, add it to the free list.
+*/
+void BE_Free(void *ptr) {
+	freeMemNode_t *fmn;
+	char *freeend;
+	int *freeptr;
+
+	G_assert(ptr != NULL);
+	G_assert(freeHead != NULL);
+
+	freeptr = ptr;
+	freeptr--;
+
+	freeMem += *freeptr;
+
+	for (fmn = freeHead; fmn; fmn = fmn->next) {
+		freeend = (((char *)fmn) + fmn->size);
+		if (freeend == (char *)freeptr) {
+			/* Released block can be merged to an existing node */
+			/* Add size of node */
+			fmn->size += *freeptr;
+			return;
+		}
+	}
+
+	/* No merging, add to head of list */
+	fmn = (freeMemNode_t *)freeptr;
+	/* Set this first to avoid corrupting *freeptr */
+	fmn->size = *freeptr;
+	fmn->cookie = FREEMEMCOOKIE;
+	fmn->prev = NULL;
+	fmn->next = freeHead;
+	freeHead->prev = fmn;
+	freeHead = fmn;
+}
+
+/*
+	Set up the initial node
+*/
+void BE_InitMemory(void) {
+	freeHead = (freeMemNode_t *)memory_pool;
+	freeHead->cookie = FREEMEMCOOKIE;
+	freeHead->size = sizeof(memory_pool);
+	freeHead->next = NULL;
+	freeHead->prev = NULL;
+	freeMem = sizeof(memory_pool);
+}

--- a/code/game/be_alloc.h
+++ b/code/game/be_alloc.h
@@ -1,0 +1,22 @@
+/*
+===========================================================================
+Copyright (C) 2010, 2011, 2012 the-brain
+
+This program is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+This program is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://gnu.org/licenses/>.
+===========================================================================
+*/
+
+void *BE_Alloc(unsigned int size);
+void BE_InitMemory(void);
+void BE_Free(void *ptr);

--- a/code/game/g_local.h
+++ b/code/game/g_local.h
@@ -944,6 +944,7 @@ extern vmCvar_t pmove_msec;
 extern vmCvar_t g_enableBreath;
 
 extern vmCvar_t g_q3Items;
+extern vmCvar_t g_externalEntities;
 extern vmCvar_t g_sky;
 extern vmCvar_t g_skyLensflare;
 extern vmCvar_t g_LPS_startlives;
@@ -1180,3 +1181,7 @@ void trap_SnapVector(float *v);
 int trap_AAS_BestReachableArea(const vec3_t origin, const vec3_t mins, const vec3_t maxs, vec3_t goalorigin);
 
 qboolean IsPlayerAtBalloon(int clientNum, const gentity_t *balloon);
+
+qboolean BE_GetEntityToken(char *buffer, int bufferSize);
+void BE_PreSpawnEntities(void);
+void BE_PostSpawnEntities(void);

--- a/code/game/g_main.c
+++ b/code/game/g_main.c
@@ -83,6 +83,7 @@ vmCvar_t g_listEntity;
 vmCvar_t g_enableBreath;
 
 vmCvar_t g_q3Items;
+vmCvar_t g_externalEntities;
 vmCvar_t g_sky;
 vmCvar_t g_skyLensflare;
 vmCvar_t g_LPS_startlives;
@@ -181,6 +182,7 @@ static cvarTable_t gameCvarTable[] = {
 	{&g_KillerduckHealth, "g_KillerduckHealth", "-1", CVAR_ARCHIVE, 0, qfalse},
 
 	{&g_q3Items, "g_q3Items", "0", CVAR_ARCHIVE | CVAR_LATCH, 0, qfalse},
+	{&g_externalEntities, "g_externalEntities", "0", CVAR_ARCHIVE, 0, qtrue},
 	{&g_sky, "g_sky", "", (CVAR_SYSTEMINFO | CVAR_ROM), 0, qfalse},
 	{&g_skyLensflare, "g_skyLensflare", "", (CVAR_SYSTEMINFO | CVAR_ROM), 0, qfalse},
 	{&g_LPS_startlives, "g_LPS_startlives", "10", CVAR_SERVERINFO | CVAR_ARCHIVE | CVAR_LATCH, 0, qfalse},


### PR DESCRIPTION
This feature aims to bring a useful server-side function from The Brain's Beryllium mod to World of PADMAN: loading entities from an external file. This feature is helpful for supporting non-WoP custom maps that lack some of the entities from World of PADMAN. Enabling "g_q3Items" only allows you to replace certain q3 entities with their WoP counterparts. However, enabling "g_externalEntities" should allow server admins to alter maps by adding missing entities, such as Health Stations.