### PR TITLE
Enable aarch64 vm support on macOS

### DIFF
--- a/code/qcommon/q_platform.h
+++ b/code/qcommon/q_platform.h
@@ -159,9 +159,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #elif defined __aarch64__
 #define ARCH_STRING "arm64"
 #define Q3_LITTLE_ENDIAN
-#ifndef NO_VM_COMPILED
-#define NO_VM_COMPILED
-#endif
 #endif
 
 #define DLL_EXT ".dylib"


### PR DESCRIPTION
Remove ``#define NO_VM_COMPILED`` for macOS to support aarch64